### PR TITLE
MGMT-18411: Add NTP sources to discovery environment

### DIFF
--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -242,6 +242,13 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		return "", err
 	}
 
+	// If the list of additional NTP sources is empty then we want to pass an empty list to the
+	// template, but the Split method returns a slice with one empty element in that case.
+	additionalNtpSources := strings.Split(infraEnv.AdditionalNtpSources, ",")
+	if len(additionalNtpSources) == 1 && additionalNtpSources[0] == "" {
+		additionalNtpSources = []string{}
+	}
+
 	var ignitionParams = map[string]interface{}{
 		"userSshKey":          userSshKey,
 		"AgentDockerImg":      cfg.AgentDockerImg,
@@ -264,6 +271,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"SELINUX_POLICY":       base64.StdEncoding.EncodeToString([]byte(selinuxPolicy)),
 		"EnableAgentService":   infraEnv.InternalIgnitionConfigOverride == "",
 		"ProfileProxyExports":  dataurl.EncodeBytes([]byte(GetProfileProxyEntries(httpProxy, httpsProxy, noProxy))),
+		"AdditionalNtpSources": additionalNtpSources,
 	}
 	if safeForLogs {
 		for _, key := range []string{"userSshKey", "PullSecretToken", "PULL_SECRET", "RH_ROOT_CA"} {

--- a/internal/ignition/templates/add-ntp-sources.service
+++ b/internal/ignition/templates/add-ntp-sources.service
@@ -1,0 +1,9 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/add-ntp-sources.sh
+
+[Unit]
+Before=chronyd.service
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/add-ntp-sources.sh
+++ b/internal/ignition/templates/add-ntp-sources.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >> /etc/chrony.conf <<.
+{{ range .AdditionalNtpSources }}
+server {{ . }} iburst
+{{ end }}
+.

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -42,7 +42,13 @@
         "name": "iscsistart.service",
         "enabled": true,
         "contents": {{ executeTemplate "iscsistart.service" . | toString | toJson }}
-    }{{end}}
+    }{{end}}{{if .AdditionalNtpSources}},
+    {
+        "name": "add-ntp-sources.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "add-ntp-sources.service" . | toString | toJson }}
+    }
+    {{end}}
     ]
   },
   "storage": {
@@ -196,6 +202,14 @@
         "name": "root"
       },
       "contents": { "source": "{{.ProfileProxyExports}}" }
+    }{{end}}{{if .AdditionalNtpSources}},
+    {
+      "path": "/usr/local/bin/add-ntp-sources.sh",
+      "mode": 493,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ executeTemplate "add-ntp-sources.sh" . | toBase64 }}" }
     }{{end}}]
   }
 }


### PR DESCRIPTION
Currently when the user provides additional NTP sources for the installation they are used by the installed cluster, but not by the discovery environment. That means that the system clock of the discovery environment may be wrong if the default NTP servers can't be reached, and as result it may fail to pull images because the system clock may be before the validity date of the certificates of the registry server. To avoid that this patch changes the ignition of the discovery environment so that it will also use the NTP sources provided by the user.

Related: https://issues.redhat.com/browse/MGMT-18411

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested creating a libvirt virtual machine that has the clock fixed in the past:

```bash
# date -d '01/01/2000' +"%s"
946681200
```

```xml
<clock offset='absolute' start='946681200'>
  ...
</clock>
```

The blocked access to all NTP servers, except one which is not in the default pool used by CoreOS:

```bash
# iptables --table filter --insert FORWARD 1 --protocol udp --dport 123 --jump REJECT
# iptables --table filter --insert FORWARD 1 --destination 162.159.200.123 --protocol udp --dport 123 --jump ACCEPT
```

Then verified that when the NTP sources aren't specified the discovery environment has the date incorrect, and when 162.159.200.123 is specified it is added to `/etc/chrony.conf` and the date is set correctly.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
