### PR TITLE
NO-ISSUE: Add -L option to curl command to follow redirects

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -119,7 +119,7 @@ function mirror_file() {
 
   local url_path="$(echo ${remote_url} | cut -d / -f 4-)"
   mkdir -p "$(dirname ${httpd_path}/${url_path})"
-  curl --retry 5 --connect-timeout 30 "${remote_url}" -o "${httpd_path}/${url_path}"
+  curl -L --retry 5 --connect-timeout 30 "${remote_url}" -o "${httpd_path}/${url_path}"
 
   echo "${base_mirror_url}/${url_path}"
 }
@@ -138,7 +138,7 @@ function merge_authfiles() {
 }
 
 function install_opm() {
-  curl --retry 5 --connect-timeout 30 -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.7/opm-linux.tar.gz | tar xvz -C /usr/local/bin/
+  curl -L --retry 5 --connect-timeout 30 -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.7/opm-linux.tar.gz | tar xvz -C /usr/local/bin/
 }
 
 function ocp_mirror_release() {


### PR DESCRIPTION
Based on mirror.openshift.com being migrated to deliver bits from a different cloud provider
So add the -L option to the curl command to follow redirects.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed