### PR TITLE
MGMT-17560: Workaround missing DNS on iSCSI

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1632,6 +1632,9 @@ func (m *Manager) GenerateAdditionalManifests(ctx context.Context, cluster *comm
 		return errors.Wrap(err, "failed to add disk encryption manifest")
 	}
 
+	if err := m.manifestsGeneratorAPI.AddNicReapply(ctx, log, cluster); err != nil {
+		return errors.Wrap(err, "failed to add nic reapply manifest")
+	}
 	return nil
 }
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2955,6 +2955,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		manifestsGenerator.EXPECT().AddDnsmasqForSingleNode(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+		manifestsGenerator.EXPECT().AddNicReapply(ctx, gomock.Any(), &c).Return(nil)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
 		err := capi.GenerateAdditionalManifests(ctx, &c)
@@ -2977,6 +2978,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		manifestsGenerator.EXPECT().IsSNODNSMasqEnabled().Return(false).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+		manifestsGenerator.EXPECT().AddNicReapply(ctx, gomock.Any(), &c).Return(nil)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
 		err := capi.GenerateAdditionalManifests(ctx, &c)
@@ -3001,6 +3003,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
 			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 			manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+			manifestsGenerator.EXPECT().AddNicReapply(ctx, gomock.Any(), &c).Return(nil)
 
 			err := capi.GenerateAdditionalManifests(ctx, &c)
 			Expect(err).To(Not(HaveOccurred()))

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -659,7 +659,7 @@ var _ = Describe("nic reaaply manifest", func() {
 
 	Context("CreateClusterManifest success", func() {
 		It("CreateClusterManifest success", func() {
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false),Times(2).Return(&models.Manifest{
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Times(2).Return(&models.Manifest{
 				FileName: "manifest.yaml",
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil)

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -731,7 +731,9 @@ var _ = Describe("nic reaaply manifest", func() {
 					InstallationDiskID: "install-id",
 				},
 			}
-			Expect(manifestsGeneratorApi.AddNicReapply(ctx, log, &cluster)).Should(HaveOccurred())
+			err := manifestsGeneratorApi.AddNicReapply(ctx, log, &cluster)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(Equal("Failed to create manifest 50-masters-iscsi-nic-reapply.yaml: Failed to create manifest"))
 		})
 	})
 })

--- a/internal/network/mock_manifests_generator.go
+++ b/internal/network/mock_manifests_generator.go
@@ -78,6 +78,20 @@ func (mr *MockManifestsGeneratorAPIMockRecorder) AddDnsmasqForSingleNode(ctx, lo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDnsmasqForSingleNode", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddDnsmasqForSingleNode), ctx, log, c)
 }
 
+// AddNicReapply mocks base method.
+func (m *MockManifestsGeneratorAPI) AddNicReapply(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddNicReapply", ctx, log, c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddNicReapply indicates an expected call of AddNicReapply.
+func (mr *MockManifestsGeneratorAPIMockRecorder) AddNicReapply(ctx, log, c interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNicReapply", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddNicReapply), ctx, log, c)
+}
+
 // AddSchedulableMastersManifest mocks base method.
 func (m *MockManifestsGeneratorAPI) AddSchedulableMastersManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When iSCSI boot is enabled, DNS configuration will be missing on first
boot, even though the information was advertised by DHCP:
https://issues.redhat.com/browse/OCPBUGS-26580.

The workaround consists at re-applying the network configuration on all
the network interfaces when we detect if `/sysroot` is mounted from an
iSCSI block volume.

PRs part of this story:
- Validate iSCSI volume eligibility on hosts: https://github.com/openshift/assisted-service/pull/6434
- Report iSCSI host ip address: https://github.com/openshift/assisted-installer-agent/pull/727
- Configure DHCP on iSCSI network interface: https://github.com/openshift/assisted-service/pull/6602
- Workaround DNS issue on first boot: https://github.com/openshift/assisted-service/pull/6603
- Filter out machine networks: TODO
