### PR TITLE
MGMT-18446: Correct hostname max length validation

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	MaxHostnameLength = 64
+	MaxHostnameLength = 63
 	HostnamePattern   = "^[a-z0-9][a-z0-9-]{0,62}(?:[.][a-z0-9-]{1,63})*$"
 )
 
@@ -76,7 +76,7 @@ func GetEventSeverityFromHostStatus(status string) string {
 
 func ValidateHostname(hostname string) error {
 	if len(hostname) > MaxHostnameLength {
-		return common.NewApiError(http.StatusBadRequest, errors.New("hostname is too long"))
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("hostname is too long, must be 63 characters or less. Hostname: %s has %d characters", hostname, len(hostname)))
 	}
 	b, err := regexp.MatchString(HostnamePattern, hostname)
 	if err != nil {

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -99,10 +99,11 @@ var _ = Describe("Validation", func() {
 		}
 	})
 
-	It("Should not allow hostnames longer than 64 characters", func() {
+	It("Should not allow hostnames longer than 63 characters", func() {
 		for _, hostName := range []string{
 			"foobar.local.arbitrary.hostname.longer.than.64-characters.inthis.name",
 			"foobar1234-foobar1234-foobar1234-foobar1234-foobar1234-foobar1234-foobar1234",
+			"this-host.name-iss.exactly-64.characters.long.so.itt-should.fail",
 		} {
 			err := ValidateHostname(hostName)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-18446
Discovered that Kubelet fails when a hostname is longer than 63 characters (rather than 64 originally). Updates the validation to only allow hostnames with 63 characters or less.
More details https://access.redhat.com/solutions/7068042

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


/cc @adriengentil 
