### PR TITLE
MGMT-18448: Allow local cluster import to be disabled.

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -156,7 +156,8 @@ const (
 	ConditionReconcileCompleted conditionsv1.ConditionType = "ReconcileCompleted"
 	// ConditionDeploymentsHealthy reports whether deployments are healthy.
 	ConditionDeploymentsHealthy conditionsv1.ConditionType = "DeploymentsHealthy"
-
+	// ReasonLocalClusterImportNotEnabled when the import of local cluster is not enabled.
+	ReasonLocalClusterImportNotEnabled string = "Local cluster import is not enabled"
 	// ReasonLocalClusterEntitiesCreated when the local cluster is managed.
 	ReasonLocalClusterManaged string = "Local cluster is managed."
 	// ReasonLocalClusterEntitiesRemoved when the local cluster is not managed.

--- a/internal/controller/controllers/local_cluster_import_controller.go
+++ b/internal/controller/controllers/local_cluster_import_controller.go
@@ -35,6 +35,7 @@ const (
 	hubKubeConfigName                                 = "node-kubeconfigs"
 	hubPullSecretNamespace                            = "openshift-config" // #nosec G101
 	hubPullSecretName                                 = "pull-secret"      // #nosec G101
+	importLocalClusterEnabledAnnotation               = "agent-install.openshift.io/enable-local-cluster-import"
 )
 
 type LocalClusterImportReconciler struct {
@@ -123,6 +124,16 @@ func (r *LocalClusterImportReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		// Stop reconciliation as the item is being deleted
 		r.log.Infof("Finalizer removed by local cluster import controller (local cluster CRs are cleared)")
+		return ctrl.Result{}, nil
+	}
+
+	// Enable local cluster import if annotation allows this.
+	_, importLocalClusterEnabled := instance.GetAnnotations()[importLocalClusterEnabledAnnotation]
+	if !importLocalClusterEnabled {
+		err := r.setReconciliationStatus(ctx, false, aiv1beta1.ReasonLocalClusterImportNotEnabled, "Local cluster import is not enabled")
+		if err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "Unable to set reconciliation status of LocalClusterImport on AgentServiceConfig")
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
@@ -156,7 +156,8 @@ const (
 	ConditionReconcileCompleted conditionsv1.ConditionType = "ReconcileCompleted"
 	// ConditionDeploymentsHealthy reports whether deployments are healthy.
 	ConditionDeploymentsHealthy conditionsv1.ConditionType = "DeploymentsHealthy"
-
+	// ReasonLocalClusterImportNotEnabled when the import of local cluster is not enabled.
+	ReasonLocalClusterImportNotEnabled string = "Local cluster import is not enabled"
 	// ReasonLocalClusterEntitiesCreated when the local cluster is managed.
 	ReasonLocalClusterManaged string = "Local cluster is managed."
 	// ReasonLocalClusterEntitiesRemoved when the local cluster is not managed.


### PR DESCRIPTION
We need to make sure that the local cluster import may be disabled.
The import should be switched off by default and only overridden with an annotation.

This PR implements this functionality.

If the local cluster import functionality is disabled then all local cluster entities controlled
by assisted will be left intact, we will simply skip the reconcile loop.

Customers who need to enable the feature may do so by placing an annotation on the AgentServiceConfig.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
