### PR TITLE
MGMT-18456: Revert "MGMT-18127: User name and password in a proxy url should be url encoded"

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -138,20 +138,6 @@ func ValidateHTTPProxyFormat(proxyURL string) error {
 	if u.Scheme != "http" {
 		return errors.Errorf("The URL scheme must be http and specified in the URL: '%s'", proxyURL)
 	}
-
-	userName := u.User.Username()
-	encodedUserName := url.QueryEscape(userName)
-	if userName != encodedUserName {
-		return errors.Errorf("The URL '%s' user name '%s' has to be encoded: '%s'", proxyURL, userName, encodedUserName)
-	}
-
-	password, hasPassword := u.User.Password()
-	if hasPassword {
-		encodedPassword := url.QueryEscape(password)
-		if password != encodedPassword {
-			return errors.Errorf("The URL '%s' password '%s' has to be encoded: '%s'", proxyURL, password, encodedPassword)
-		}
-	}
 	return nil
 }
 

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -65,14 +65,6 @@ var _ = Describe("URL validations", func() {
 				"http://!@#$!@#$",
 				"Proxy URL format is not valid: 'http://!@#$!@#$'",
 			},
-			{
-				"http://user@name:pswd@proxy.com",
-				"The URL 'http://user@name:pswd@proxy.com' user name 'user@name' has to be encoded: 'user%40name'",
-			},
-			{
-				"http://username:ps$wd@proxy.com",
-				"The URL 'http://username:ps$wd@proxy.com' password 'ps$wd' has to be encoded: 'ps%24wd'",
-			},
 		}
 
 		It("validates proxy URL input", func() {


### PR DESCRIPTION
Reverts openshift/assisted-service#6467
The PR introduced a regression, it blocked any proxy URL with special characters, even if it was url encoded.