### PR TITLE
MGMT-18505: Fix installation from a 4.17 hub with converged flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.2
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a
-	github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e
+	github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b
 	github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -1379,8 +1379,8 @@ github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b2
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f/go.mod h1:/CLsleDcQ6AFTGKJe9VL3Y4rB9DqX3fQwQv47q2/ZJc=
 github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a h1:E+XPJs/aVvYsrlJzo2ED38ZTR2RTNUlFMmOaFAAdMZg=
 github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a/go.mod h1:E1bgquRiwfugdArdecPbpYIrAdve5kTzMaJb0+8jMXI=
-github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e h1:x1j5gWm4PdTTXTmuX3S7VAmsnazbbMiefQyCLdyjH74=
-github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e/go.mod h1:rTvO75VGcFhEuE2HgQe10OijcR9HBDNC+CnKei8p1HE=
+github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b h1:SDdbzE3oW2qs7AJj4DT5gk8HDkZYR8DTT1ZfyBhECZ8=
+github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b/go.mod h1:G9yHOogitMOA0R5UWFmFup00E6nik8Sns/tCYYBU7jE=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
 github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b h1:BmunS/b02dKSwQ0H21+3EbXDfDr9t8UDlO54WxKkOts=

--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -120,11 +120,6 @@ func (r *bmoUtils) getICCConfig(ctx context.Context) (*ICCConfig, error) {
 		return nil, fmt.Errorf(configKeyNotFoundError, ironicBaseURLKey, secret.Name, secret.Namespace)
 	}
 
-	ironicInspectorBaseURL, ok := secret.Data[ironicInspectorBaseURLKey]
-	if !ok {
-		return nil, fmt.Errorf(configKeyNotFoundError, ironicInspectorBaseURLKey, secret.Name, secret.Namespace)
-	}
-
 	ironicAgentImage, ok := secret.Data[ironicAgentImageKey]
 	if !ok {
 		return nil, fmt.Errorf(configKeyNotFoundError, ironicAgentImageKey, secret.Name, secret.Namespace)
@@ -132,7 +127,7 @@ func (r *bmoUtils) getICCConfig(ctx context.Context) (*ICCConfig, error) {
 
 	return &ICCConfig{
 		IronicBaseURL:          string(ironicBaseURL),
-		IronicInspectorBaseUrl: string(ironicInspectorBaseURL),
+		IronicInspectorBaseUrl: string(secret.Data[ironicInspectorBaseURLKey]),
 		IronicAgentImage:       string(ironicAgentImage),
 	}, nil
 }

--- a/vendor/github.com/openshift/image-customization-controller/pkg/ignition/builder.go
+++ b/vendor/github.com/openshift/image-customization-controller/pkg/ignition/builder.go
@@ -37,9 +37,6 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicInspectorBaseU
 	if ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
 	}
-	if ironicInspectorBaseURL == "" {
-		ironicInspectorBaseURL = ironicBaseURL
-	}
 	if ironicAgentImage == "" {
 		return nil, errors.New("ironicAgentImage is required")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -824,8 +824,8 @@ github.com/openshift/hive/apis/hive/v1/openstack
 github.com/openshift/hive/apis/hive/v1/ovirt
 github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e
-## explicit; go 1.19
+# github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b
+## explicit; go 1.21
 github.com/openshift/image-customization-controller/pkg/ignition
 # github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b
 ## explicit; go 1.20


### PR DESCRIPTION
This allows ironic inspector URL to be missing in ICC config secret.

In 4.17 this is expected to be missing as the inspector service as been
removed.

If this URL is provided the agent will attempt to contact the inspector
service when it shouldn't causing the install to fail.

In earlier versions the secret will not be present so the controller
will continue to provide the inspector service URL as before.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-18505

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed a 4.17 hub cluster and installed a 4.17 SNO from assisted installed on it with this branch image.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
