### PR TITLE
OCPBUGS-27238: Use both the OCP cluster trusted certs and user certs

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -246,18 +246,18 @@ oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.opens
 
 A ConfigMap can be used to configure assisted service to create installations using mirrored content. The ConfigMap contains two keys:
 
-- *ca-bundle.crt* - This key contains the contents of the certificate for accessing the mirror registry, if necessary. It may be a certificate bundle and is defined as a single string.
-- *registries.conf* - This key contains the contents of the registries.conf file that configures mappings to the mirror registry.
+- `ca-bundle.crt` - This key contains the contents of the certificate for accessing the mirror registry, if necessary. It may be a certificate bundle and is defined as a single string.
+- `registries.conf` - This key contains the contents of the registries.conf file that configures mappings to the mirror registry.
 
-The mirror registry configuration changes the discovery image's ignition config, with *ca-bundle.crt* written out to */etc/pki/ca-trust/source/anchors/domain.crt* and with *registries.conf* written out to */etc/containers/registries.conf*. 
-
-The configuration also changes the *install-config.yaml* file used to install a new cluster, with the contents of *ca-bundle.crt* added to *additionalTrustBundle* and with the registries defined *registries.conf* added to *imageContentSources* as mirrors.
-The assisted service pod also converts the registries.conf into an imageContentSourcesPolicy file, and use it with the --icsp flag in a few oc adm commands run against the release image (executed from within the assisted service pod itself).
+Supplying this ConfigMap makes several changes to the installation flow and assisted-service deployment:
+- Changes the discovery image's ignition config such that `ca-bundle.crt` is written out to `/etc/pki/ca-trust/source/anchors/domain.crt` and `registries.conf` is written out to `/etc/containers/registries.conf`.
+- Changes the `install-config.yaml` file used to install a new cluster, with the contents of `ca-bundle.crt` added to `additionalTrustBundle` and with the registries defined `registries.conf` added to `imageContentSources` as mirrors.
+- The assisted-service pod converts the registries.conf into an imageContentSourcesPolicy file, and use it with the --icsp flag in a few `oc adm` commands run against the release image (executed from within the assisted-service pod itself).
+- The certificate bundle is added to the list of trusted certs provided by the cluster. A combined ConfigMap is created which includes the provided bundle. This is mounted into the assisted-service pod at path `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`
 
 The ca-bundle.crt and registries.conf keys can be added individually or together.
 
-
-1. To configure the mirror registry, first create and upload the ConfigMap containing the *ca-bundle.crt* and *registries.conf* keys.
+1. To configure the mirror registry, first create and upload the ConfigMap containing the `ca-bundle.crt` and `registries.conf` keys.
 
 ``` bash
 cat <<EOF | kubectl create -f -

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -44,7 +44,8 @@ import (
 )
 
 const (
-	mirrorRegistryRefCertKey         = "ca-bundle.crt"
+	caBundleKey                      = "ca-bundle.crt"
+	mirrorRegistryRefCertKey         = caBundleKey
 	mirrorRegistryRefRegistryConfKey = "registries.conf"
 	mirrorRegistryConfigVolume       = "mirror-registry-config"
 	WatchResourceLabel               = "agent-install.openshift.io/watch"


### PR DESCRIPTION
Previously when a user provided mirror registry certs the assisted-service pod would be deployed in such a way that those would be the _only_ certs trusted by most commands running on the pod.

This would cause issues when, for example, the spoke cluster release image is mirrored internally, but the hub cluster image is not.

This was the case in https://issues.redhat.com/browse/OCPBUGS-27238 where assisted-service failed to pull the hub cluster release image because it didn't trust a certificate it otherwise should have.

To address this the infrastructure-operator creates a configmap which is annotated such that the cluster network operator will inject the public CA bundle into it as described in [1]. This content is then merged with the user-provided content (if any is provided) into a third configmap which is mounted into the assisted-service container.

[1] https://docs.openshift.com/container-platform/4.16/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki

## List all the issues related to this PR

https://issues.redhat.com/browse/OCPBUGS-27238

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested manually in a dev-scripts environment to see that the cert configmaps were created correctly.
Relying on the CI disconnected job to test that case.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
