### PR TITLE
NO-ISSUE: Print subsystem environment variables before test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,15 @@ _run_subsystem_test:
 		db_port="$(shell $(call get_service_host_port,postgres) | sed 's/http:\/\///g' | cut -d ":" -f 2)"; \
 		ocm_host="$(shell $(call get_service_host_port,wiremock) | sed 's/http:\/\///g')"; \
 	fi; \
+	echo "INVENTORY=$$assisted_service_url\n"; \
+	echo "DB_HOST=$$db_host\n"; \
+	echo "DB_PORT=$$db_port\n"; \
+	echo "OCM_HOST=$$ocm_host\n"; \
+	echo "TEST_TOKEN=$(shell cat $(BUILD_FOLDER)/auth-tokenString)"; \
+	echo "TEST_TOKEN_2=$(shell cat $(BUILD_FOLDER)/auth-tokenString2)"; \
+	echo "TEST_TOKEN_ADMIN=$(shell cat $(BUILD_FOLDER)/auth-tokenAdminString)"; \
+	echo "TEST_TOKEN_UNALLOWED=$(shell cat $(BUILD_FOLDER)/auth-tokenUnallowedString)"; \
+	echo "TEST_TOKEN_EDITOR=$(shell cat $(BUILD_FOLDER)/auth-tokenClusterEditor)"; \
 	INVENTORY=$$assisted_service_url \
 	DB_HOST=$$db_host \
 	DB_PORT=$$db_port \


### PR DESCRIPTION
When we started using kind we stopped printing the test environment variables before running the test, this PR adds those back.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eliorerz 