### PR TITLE
NO-ISSUE: Add missing kube api flag on kube api subsystem test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,8 +449,8 @@ test-kube-api:
 # Alias for test
 subsystem-test: test
 
-# Alias for test-kube-api
-subsystem-test-kube-api: test-kube-api
+subsystem-test-kube-api:
+	$(MAKE) test-kube-api ENABLE_KUBE_API=true
 
 _run_subsystem_test:
 	@if [ $(TARGET) == "kind" ]; then \


### PR DESCRIPTION
Fix subsystem kubeapi tests when `ENABLE_KUBE_API` is not exported.
As described in https://github.com/openshift/assisted-service/blob/master/docs/dev/running-test.md#running-the-tests - exporting `ENABLE_KUBE_API` should be transparent to whom running the tests

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

/cc @danmanor 