### PR TITLE
MGMT-16212: Allow Assisted-Installer to tolerate a slightly lower memory than required

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -47,6 +47,11 @@ const (
 	maxHostAheadOfServiceTimeDiff                    = 1 * time.Hour
 	maxHostTimingMetrics                             = 4
 	maxPingCommandExamples                           = 4
+
+	// How much we allow the user to deviate from our official
+	// minimum. Some setups (e.g. VMs) might give just a bit less
+	// than requested, so we shouldn't be too strict about it
+	HostMemoryRequirementToleranceMiB int64 = 100
 )
 
 const FailedToFindAction = "failed to find action for step"
@@ -347,7 +352,7 @@ func (v *validator) hasMinMemory(c *validationContext) (ValidationStatus, string
 	if c.inventory == nil {
 		return status, "Missing inventory"
 	}
-	status = boolValue(c.inventory.Memory.PhysicalBytes >= conversions.MibToBytes(c.minRAMMibRequirement))
+	status = boolValue(c.inventory.Memory.PhysicalBytes >= conversions.MibToBytes(c.minRAMMibRequirement-HostMemoryRequirementToleranceMiB))
 	if status == ValidationSuccess {
 		return status, "Sufficient minimum RAM"
 	}
@@ -530,7 +535,7 @@ func (v *validator) hasMemoryForRole(c *validationContext) (ValidationStatus, st
 		return ValidationPending, "Missing inventory or role"
 	}
 	requiredBytes := conversions.MibToBytes(c.clusterHostRequirements.Total.RAMMib)
-	if c.inventory.Memory.PhysicalBytes >= requiredBytes {
+	if c.inventory.Memory.PhysicalBytes >= requiredBytes-conversions.MibToBytes(HostMemoryRequirementToleranceMiB) {
 		return ValidationSuccess, fmt.Sprintf("Sufficient RAM for role %s", common.GetEffectiveRole(c.host))
 	}
 	return ValidationFailure, fmt.Sprintf("Require at least %s RAM for role %s, found only %s",


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

We want to allow hosts to have slightly less memory than in the official documentation because some setups (like VMs) might give slightly less than the required amount. This PR changes the host validator to tolerate a slightly lower memory amount.

Apart from automatic tests this was also tested in the following way:
1. deploy a k8s cluster with assisted installer with an image for assisted-service from this branch
2.  create a vm with 16284 mb (100 mb less than 16 gb)
3. try to install an sno and add the vm as a host
4. check that the ui shows that minimum memory requirement is 16 gb even though the host is valid
5. finish the installation to make sure everything is fine
6. try the same with a vm that has 16283 mb
7. check that the host is insufficient with the error message saying it does not have the minimum memory which is 16 gb 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
