### PR TITLE
MGMT-18514: Calculate machine networks in external platform

### DIFF
--- a/internal/provider/external/base.go
+++ b/internal/provider/external/base.go
@@ -1,6 +1,8 @@
 package external
 
 import (
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -23,4 +25,17 @@ func (p *baseExternalProvider) IsHostSupported(_ *models.Host) (bool, error) {
 
 func (p *baseExternalProvider) AreHostsSupported(hosts []*models.Host) (bool, error) {
 	return true, nil
+}
+
+func (p *baseExternalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+	cfg.Platform = installcfg.Platform{
+		External: &installcfg.ExternalInstallConfigPlatform{
+			PlatformName:           *cluster.Platform.External.PlatformName,
+			CloudControllerManager: installcfg.CloudControllerManager(*cluster.Platform.External.CloudControllerManager),
+		},
+	}
+
+	provider.ConfigureUserManagedNetworkingInInstallConfig(p.Log, cluster, cfg)
+
+	return nil
 }

--- a/internal/provider/external/external.go
+++ b/internal/provider/external/external.go
@@ -1,10 +1,6 @@
 package external
 
 import (
-	"github.com/go-openapi/swag"
-	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/host/hostutil"
-	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -23,36 +19,6 @@ func NewExternalProvider(log logrus.FieldLogger) provider.Provider {
 	}
 	p.Provider = p
 	return p
-}
-
-func (p *externalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
-	cfg.Platform = installcfg.Platform{
-		External: &installcfg.ExternalInstallConfigPlatform{
-			PlatformName:           *cluster.Platform.External.PlatformName,
-			CloudControllerManager: installcfg.CloudControllerManager(*cluster.Platform.External.CloudControllerManager),
-		},
-	}
-
-	cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
-	if cluster.NetworkType != nil {
-		cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
-	}
-
-	if common.IsSingleNodeCluster(cluster) {
-
-		if cfg.Networking.NetworkType == "" {
-			cfg.Networking.NetworkType = models.ClusterNetworkTypeOVNKubernetes
-		}
-
-		bootstrap := common.GetBootstrapHost(cluster)
-		if bootstrap != nil {
-			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
-		}
-	} else {
-		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
-	}
-
-	return nil
 }
 
 func (p *externalProvider) IsProviderForPlatform(platform *models.Platform) bool {

--- a/internal/provider/external/external.go
+++ b/internal/provider/external/external.go
@@ -48,6 +48,8 @@ func (p *externalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerC
 		if bootstrap != nil {
 			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
 		}
+	} else {
+		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
 	}
 
 	return nil

--- a/internal/provider/external/oci.go
+++ b/internal/provider/external/oci.go
@@ -70,6 +70,8 @@ func (p *ociExternalProvider) AddPlatformToInstallConfig(cfg *installcfg.Install
 		if bootstrap != nil {
 			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
 		}
+	} else {
+		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
 	}
 
 	return nil

--- a/internal/provider/external/oci.go
+++ b/internal/provider/external/oci.go
@@ -3,10 +3,7 @@ package external
 import (
 	"fmt"
 
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/host/hostutil"
-	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -45,36 +42,6 @@ func (p *ociExternalProvider) AreHostsSupported(hosts []*models.Host) (bool, err
 		}
 	}
 	return true, nil
-}
-
-func (p *ociExternalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
-	cfg.Platform = installcfg.Platform{
-		External: &installcfg.ExternalInstallConfigPlatform{
-			PlatformName:           common.ExternalPlatformNameOci,
-			CloudControllerManager: installcfg.CloudControllerManagerTypeExternal,
-		},
-	}
-
-	cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
-	if cluster.NetworkType != nil {
-		cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
-	}
-
-	if common.IsSingleNodeCluster(cluster) {
-
-		if cfg.Networking.NetworkType == "" {
-			cfg.Networking.NetworkType = models.ClusterNetworkTypeOVNKubernetes
-		}
-
-		bootstrap := common.GetBootstrapHost(cluster)
-		if bootstrap != nil {
-			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
-		}
-	} else {
-		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
-	}
-
-	return nil
 }
 
 func (p *ociExternalProvider) IsProviderForPlatform(platform *models.Platform) bool {

--- a/internal/provider/none/installConfig.go
+++ b/internal/provider/none/installConfig.go
@@ -1,12 +1,9 @@
 package none
 
 import (
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider"
-	"github.com/openshift/assisted-service/models"
 )
 
 func (p noneProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
@@ -14,24 +11,7 @@ func (p noneProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfig
 		None: &installcfg.PlatformNone{},
 	}
 
-	cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
-	if cluster.NetworkType != nil {
-		cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
-	}
-
-	if common.IsSingleNodeCluster(cluster) {
-
-		if cfg.Networking.NetworkType == "" {
-			cfg.Networking.NetworkType = models.ClusterNetworkTypeOVNKubernetes
-		}
-
-		bootstrap := common.GetBootstrapHost(cluster)
-		if bootstrap != nil {
-			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
-		}
-	} else {
-		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
-	}
+	provider.ConfigureUserManagedNetworkingInInstallConfig(p.Log, cluster, cfg)
 
 	return nil
 }

--- a/internal/provider/none/installConfig.go
+++ b/internal/provider/none/installConfig.go
@@ -5,39 +5,9 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/installcfg"
-	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/models"
-	"github.com/samber/lo"
 )
-
-func (p noneProvider) replaceMachineNetworkIfNeeded(cluster *common.Cluster, cfg *installcfg.InstallerConfigBaremetal) {
-	bootstrapHost := common.GetBootstrapHost(cluster)
-	if bootstrapHost == nil {
-		p.Log.Warnf("GetBootstrapHost: failed to get bootstrap host for cluster %s", lo.FromPtr(cluster.ID))
-		return
-	}
-	nodeIpAllocations, err := network.GenerateNonePlatformAddressAllocation(cluster, p.Log)
-	if err != nil {
-		p.Log.WithError(err).Warnf("failed to get node ip allocations for cluster %s", lo.FromPtr(cluster.ID))
-		return
-	}
-	allocation, ok := nodeIpAllocations[lo.FromPtr(bootstrapHost.ID)]
-	if !ok {
-		p.Log.Warnf("node ip allocation for bootstrap host %s in cluster %s is missing", lo.FromPtr(bootstrapHost.ID), lo.FromPtr(cluster.ID))
-		return
-	}
-	isIpv4 := network.IsIPV4CIDR(allocation.Cidr)
-	for i := range cfg.Networking.MachineNetwork {
-		if network.IsIPV4CIDR(cfg.Networking.MachineNetwork[i].Cidr) == isIpv4 {
-			if cfg.Networking.MachineNetwork[i].Cidr != allocation.Cidr {
-				p.Log.Infof("Replacing machine network %s with %s", cfg.Networking.MachineNetwork[i].Cidr, allocation.Cidr)
-				cfg.Networking.MachineNetwork[i].Cidr = allocation.Cidr
-			}
-			break
-		}
-	}
-}
 
 func (p noneProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
 	cfg.Platform = installcfg.Platform{
@@ -60,7 +30,7 @@ func (p noneProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfig
 			cfg.BootstrapInPlace = &installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
 		}
 	} else {
-		p.replaceMachineNetworkIfNeeded(cluster, cfg)
+		provider.ReplaceMachineNetworkIfNeeded(p.Log, cluster, cfg)
 	}
 
 	return nil


### PR DESCRIPTION
Since external platform relies on user managed networking, we need the
feature introduced in
https://github.com/openshift/assisted-service/pull/6257 to determine the
machine networks.

This change is useful when using iSCSI boot drive on Oracle Cloud
Infrastructure, in order to select the machine network that doesn't
belong to the iSCSI subnet.
