### PR TITLE
MGMT-18121: Configure networking when using ISCSI over OCI

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -282,6 +282,10 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 	var err error
 	var hasStaticNetwork bool
 
+	if inventory == nil {
+		return "", fmt.Errorf("Missing inventory")
+	}
+
 	if host.InstallerArgs != "" {
 		err = json.Unmarshal([]byte(host.InstallerArgs), &installerArgs)
 		if err != nil {

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -338,14 +338,17 @@ func appendNetworkArgs(installerArgs []string, cluster *common.Cluster, host *mo
 		return installerArgs, nil
 	}
 
-	// set DHCP args only if no IP config override was specified (user override, LPAR and zVM nodes on s390x, iSCSI boot drive on OCI)
+	// set DHCP args only if no IP config override was specified (user
+	// override, LPAR and zVM nodes on s390x, iSCSI boot drive on OCI)
 	//
-	// The set of ip=<nic>:dhcp kernel arguments should be added only if there is no static
-	// network configured by the user. This is because this parameter will configure RHCOS to
-	// try to obtain IP address from the DHCP server even if we provide a static addressing.
-	// As in majority of cases it's not an issue because of the priorities set in the config
-	// of NetworkManager, in some specific scenarios (e.g. BZ-2106110) this causes machines to
-	// lose their connectivity because priorities get mixed.
+	// The set of ip=<nic>:dhcp kernel arguments should be added only if
+	// there is no static network configured by the user. This is because
+	// this parameter will configure RHCOS to try to obtain IP address from
+	// the DHCP server even if we provide a static addressing. As in
+	// majority of cases it's not an issue because of the priorities set in
+	// the config of NetworkManager, in some specific scenarios (e.g.
+	// BZ-2106110) this causes machines to lose their connectivity because
+	// priorities get mixed.
 	installerArgs, err := appendDHCPArgs(cluster, host, inventory, installerArgs, log)
 	if err != nil {
 		return nil, err

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -868,6 +868,45 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("Cannot find the interface belonging to iSCSI host IP 10.56.21.80"))
 	})
+	It("iSCSI installation disk - OCI - IPv4 address is left un-configured on machine networks interface", func() {
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "10.56.21.0/25"}}
+		cluster.Platform = &models.Platform{
+			Type: models.PlatformTypeExternal.Pointer(),
+			External: &models.PlatformExternal{
+				PlatformName:           swag.String(common.ExternalPlatformNameOci),
+				CloudControllerManager: swag.String(models.PlatformExternalCloudControllerManagerExternal),
+			},
+		}
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.80"
+					}
+				},
+				{
+					"id": "other-id",
+					"drive_type": "%s"
+				}
+			],
+			"interfaces":[
+				{
+					"name": "eth1",
+					"ipv4_addresses":["10.56.20.80/25"]
+				},
+				{
+					"name": "eth2",
+					"ipv4_addresses":["10.56.21.80/25"]
+				}
+			]
+		}`, models.DriveTypeISCSI, models.DriveTypeSSD)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp"]`))
+	})
 	It("ip=<nic>:dhcp6 added when machine CIDR is IPv6", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "2001:db8::/64"}}
 		host.Inventory = `{

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -22,7 +22,18 @@
     {
         "name": "multipathd.service",
         "enabled": true
-    }{{end}}{{if .StaticNetworkConfig}},
+    },
+    {
+        "name": "iscsistart.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "iscsistart.service" . | toString | toJson }}
+    },
+    {
+        "name": "iscsi-oci-configure-secondary-nic.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "iscsi-oci-configure-secondary-nic.service" . | toString | toJson }}
+    }
+    {{end}}{{if .StaticNetworkConfig}},
     {
         "name": "pre-network-manager-config.service",
         "enabled": true,
@@ -37,12 +48,8 @@
         "name": "systemd-journal-gatewayd.socket",
         "enabled": true,
         "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toString | toJson }}
-    }{{end}}{{if .OKDBinaries | not}},
-    {
-        "name": "iscsistart.service",
-        "enabled": true,
-        "contents": {{ executeTemplate "iscsistart.service" . | toString | toJson }}
-    }{{end}}{{if .AdditionalNtpSources}},
+    }
+    {{end}}{{if .AdditionalNtpSources}},
     {
         "name": "add-ntp-sources.service",
         "enabled": true,
@@ -78,7 +85,16 @@
           "name": "root"
       },
       "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ executeTemplate "multipath.conf" . | toBase64 }}" }
-    }{{end}},
+    },
+    {
+      "path": "/usr/local/bin/iscsi-oci-configure-secondary-nic.sh",
+      "mode": 493,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ executeTemplate "iscsi-oci-configure-secondary-nic.sh" . | toBase64 }}" }
+    }
+    {{end}},
     {
       "overwrite": true,
       "path": "/etc/NetworkManager/conf.d/01-ipv6.conf",

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Configure secondary NIC on OCI when using iSSCI boot drive
-After=network-online.target
+After=NetworkManager.service
 
 [Service]
-ExecStart=/usr/local/bin/oci-configure-secondary-nic.sh
+ExecStart=/usr/local/bin/iscsi-oci-configure-secondary-nic.sh
 Type=oneshot
 RemainAfterExit=yes
 Restart=on-failure

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
@@ -3,6 +3,8 @@ Description=Configure secondary NIC on OCI when using iSCSI boot drive
 After=NetworkManager.service
 
 [Service]
+StandardOutput=syslog
+StandardError=syslog
 ExecStart=/usr/local/bin/iscsi-oci-configure-secondary-nic.sh
 Type=oneshot
 RemainAfterExit=yes

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Configure secondary NIC on OCI when using iSSCI boot drive
+Description=Configure secondary NIC on OCI when using iSCSI boot drive
 After=NetworkManager.service
 
 [Service]

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Configure secondary NIC on OCI when using iSSCI boot drive
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/oci-configure-secondary-nic.sh
+Type=oneshot
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.sh
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.sh
@@ -23,6 +23,29 @@ function get_if_name_from_mac_address {
   ip -json link | jq --raw-output --arg mac_address "${mac_address}" '. | map(select(.address==($mac_address|ascii_downcase))) | .[].ifname'
 }
 
+# /opc/v2/vnics endpoint returns something that will look like the following
+# structure:
+# [
+#   {
+#     "macAddr": "00:10:e0:ec:72:fc",
+#     "nicIndex": 0,
+#     "privateIp": "10.0.29.201",
+#     "subnetCidrBlock": "10.0.16.0/20",
+#     "virtualRouterIp": "10.0.16.1",
+#     "vlanTag": 0,
+#     "vnicId": "ocid1.vnic.oc1.us-sanjose-1.abzwuljrppq34sbvgltddp7wujxwqw6xb7zjkwg54oaewx5mc4wr5cgtdzna"
+#   },
+#   {
+#     "macAddr": "00:10:e0:ec:72:fd",
+#     "nicIndex": 1,
+#     "privateIp": "10.0.32.210",
+#     "subnetCidrBlock": "10.0.32.0/20",
+#     "virtualRouterIp": "10.0.32.1",
+#     "vlanTag": 0,
+#     "vnicId": "ocid1.vnic.oc1.us-sanjose-1.abzwuljrsndaptsyq5mppfsoaqoun3gbvnpngcaspybo2nbpcmrozx25jenq"
+#   }
+# ]
+
 vnics=$(curl --silent -H "Authorization: Bearer Oracle" -L http://169.254.169.254/opc/v2/vnics/)
 secondary_if_mac_address=$(jq -r '.[1].macAddr' <<< "${vnics}")
 secondary_if_name=$(get_if_name_from_mac_address "${secondary_if_mac_address}")

--- a/internal/ignition/templates/iscsi-oci-configure-secondary-nic.sh
+++ b/internal/ignition/templates/iscsi-oci-configure-secondary-nic.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+chassis_asset_tag="$(dmidecode --string chassis-asset-tag)"
+if [ "${chassis_asset_tag}" != "OracleCloud.com" ]
+then
+  echo "Not running in Oracle Cloud Infrastructure. Skipping."
+  exit 0
+fi
+
+if [ ! -d "/sys/firmware/ibft" ]
+then
+  echo "No IBFT configuration found. Skipping."
+  exit 0
+fi
+
+MTU=9000
+
+function get_if_name_from_mac_address {
+  mac_address="${1}"
+  ip -json link | jq --raw-output --arg mac_address "${mac_address}" '. | map(select(.address==($mac_address|ascii_downcase))) | .[].ifname'
+}
+
+vnics=$(curl --silent -H "Authorization: Bearer Oracle" -L http://169.254.169.254/opc/v2/vnics/)
+secondary_if_mac_address=$(jq -r '.[1].macAddr' <<< "${vnics}")
+secondary_if_name=$(get_if_name_from_mac_address "${secondary_if_mac_address}")
+secondary_if_ip_address=$(jq -r '.[1].privateIp' <<< "${vnics}")
+secondary_if_default_gateway=$(jq -r '.[1].virtualRouterIp' <<< "${vnics}")
+secondary_if_subnet=$(jq -r '.[1].subnetCidrBlock' <<< "${vnics}")
+secondary_if_subnet_size=$(cut -f 2 -d '/' <<< "${secondary_if_subnet}")
+
+if [ ! -f "/etc/NetworkManager/system-connections/${secondary_if_name}.nmconnection" ]
+then
+  nmcli connection add con-name "${secondary_if_name}" ifname "${secondary_if_name}" type ethernet ip4 "${secondary_if_ip_address}/${secondary_if_subnet_size}" gw4 "${secondary_if_default_gateway}"
+  nmcli connection modify "${secondary_if_name}" ethernet.mtu ${MTU}
+  nmcli connection modify "${secondary_if_name}" ipv4.route-metric 0 # make this interface the default interface
+  nmcli connection modify "${secondary_if_name}" connection.autoconnect true
+
+  nmcli connection reload
+  nmcli connection up "${secondary_if_name}"
+fi


### PR DESCRIPTION
A secondary network interface is required in OCI in order to install clusters on iSCSI boot volumes. Extra interfaces in OCI must be statically set, this change adds a script that configures the secondary network interface on OCI during discovery. We ensure that we execute the script only for machines in OCI with an iBFT configuration.

Since the secondary interface is the one that will be part of the machine networks, we will prevent its configuration with DHCP though the kernel arguments.

Unfortunately, we cannot propagate the network configuration set during discovery to the installed system because `--copy-network` won't work with iSCSI boot volumes: https://github.com/coreos/coreos-installer/issues/1389. As an alternative, the user will need to pass extra custom manifests to configure the network on next boot.

For the moment, we'll keep this script to configure OCI networking in assisted-service, but in the future we may want Oracle to own this script and inject it at discovery time. This will be refined in a later stage.