### PR TITLE
MGMT-10006: Wait for host to deprovision in BMAC

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -64,6 +64,7 @@ import (
 
 const (
 	AgentFinalizerName                   = "agent." + aiv1beta1.Group + "/ai-deprovision"
+	AgentSpokeCleanupAnnotation          = "agent." + aiv1beta1.Group + "/clean-spoke-on-delete"
 	BaseLabelPrefix                      = aiv1beta1.Group + "/"
 	InventoryLabelPrefix                 = "inventory." + BaseLabelPrefix
 	AgentLabelHasNonrotationalDisk       = InventoryLabelPrefix + "storage-hasnonrotationaldisk"
@@ -398,16 +399,7 @@ func (r *AgentReconciler) handleAgentFinalizer(ctx context.Context, log logrus.F
 		}
 	} else { // agent is being deleted
 		if funk.ContainsString(agent.GetFinalizers(), AgentFinalizerName) {
-			if _, has_annotation := agent.GetAnnotations()[BMH_FINALIZER_NAME]; has_annotation && agent.Spec.ClusterDeploymentName != nil {
-				// wait for BMH to be deleted
-				if foundBMH, err := r.bmhExists(ctx, agent); err != nil || foundBMH {
-					if err != nil {
-						log.WithError(err).Warnf("failed to determine if BMH exists for agent")
-					}
-					log.Info("waiting for BMH to be deleted")
-					return &ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
-				}
-
+			if _, has_annotation := agent.GetAnnotations()[AgentSpokeCleanupAnnotation]; has_annotation && agent.Spec.ClusterDeploymentName != nil {
 				// only remove the spoke resources if the entire cluster isn't being deleted
 				clusterExists, err := r.clusterExists(ctx, agent)
 				if err != nil {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -3849,272 +3849,252 @@ var _ = Describe("handleAgentFinalizer", func() {
 			Expect(res).NotTo(BeNil())
 		})
 
-		Context("with the BMH annotation", func() {
+		Context("with the cleanup annotation", func() {
 			var (
-				bmhName         = "mybmh"
 				fakeSpokeClient spoke_k8s_client.SpokeK8sClient
 			)
+			expectAgentFinalizerRemoved := func() {
+				mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
+					func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
+						Expect(updatedAgent.GetFinalizers()).NotTo(ContainElement(AgentFinalizerName))
+						return nil
+					},
+				)
+			}
+
+			expectHostRemoved := func() {
+				hostID := strfmt.UUID(uuid.New().String())
+				infraEnvID := strfmt.UUID(uuid.New().String())
+				host := &common.Host{
+					Host: models.Host{
+						ID:         &hostID,
+						InfraEnvID: infraEnvID,
+					},
+				}
+				key := types.NamespacedName{Namespace: agent.Namespace, Name: agent.Name}
+				mockInstallerInternal.EXPECT().GetHostByKubeKey(key).Return(host, nil)
+				params := installer.V2DeregisterHostParams{InfraEnvID: infraEnvID, HostID: hostID}
+				mockInstallerInternal.EXPECT().V2DeregisterHostInternal(ctx, params, bminventory.NonInteractive).Return(nil)
+			}
+
+			mockSpokeClient := func() {
+				cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+				mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
+					func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
+						cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+							AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "clusterKubeConfig"},
+						}
+						return nil
+					},
+				).AnyTimes()
+
+				secretKey := types.NamespacedName{Name: "clusterKubeConfig", Namespace: testNamespace}
+				mockClient.EXPECT().Get(ctx, secretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(_ context.Context, key client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+						secret.ObjectMeta.Labels = map[string]string{
+							BackupLabel:        "true",
+							WatchResourceLabel: "true",
+						}
+						secret.Data = map[string][]byte{"kubeconfig": []byte("definitely_a_kubeconfig")}
+						return nil
+					},
+				).AnyTimes()
+
+				mockClientFactory.EXPECT().CreateFromSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(secret *corev1.Secret) (spoke_k8s_client.SpokeK8sClient, error) {
+						Expect(secret.Data["kubeconfig"]).To(Equal([]byte("definitely_a_kubeconfig")))
+						return fakeSpokeClient, nil
+					},
+				).AnyTimes()
+			}
 
 			BeforeEach(func() {
-				agent.ObjectMeta.Annotations = map[string]string{BMH_FINALIZER_NAME: "true"}
-				agent.ObjectMeta.Labels = map[string]string{AGENT_BMH_LABEL: bmhName}
+				agent.ObjectMeta.Annotations = map[string]string{AgentSpokeCleanupAnnotation: "true"}
 
 				schemes := GetKubeClientSchemes()
 				fakeClient := fakeclient.NewClientBuilder().WithScheme(schemes).Build()
 				fakeSpokeClient = fakeSpokeK8sClient{Client: fakeClient}
+				mockSpokeClient()
+				expectHostRemoved()
+				expectAgentFinalizerRemoved()
 			})
 
-			It("requeues if the BMH still exists", func() {
-				bmhKey := types.NamespacedName{Name: bmhName, Namespace: agent.Namespace}
-				mockClient.EXPECT().Get(ctx, bmhKey, gomock.AssignableToTypeOf(&bmh_v1alpha1.BareMetalHost{})).Return(nil)
+			It("doesn't fail when the agent is not bound", func() {
+				agent.Spec.ClusterDeploymentName = nil
+
 				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
 				Expect(err).To(BeNil())
 				Expect(res).NotTo(BeNil())
-				Expect(res.RequeueAfter).To(Equal(defaultRequeueAfterOnError))
 			})
 
-			Context("with a removed BMH", func() {
-				expectAgentFinalizerRemoved := func() {
-					mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
-						func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
-							Expect(updatedAgent.GetFinalizers()).NotTo(ContainElement(AgentFinalizerName))
-							return nil
-						},
-					)
+			It("removes a node with no machine", func() {
+				node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: agentHostname}}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a node with an invalid machine annotation", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": "namewithoutaslash"},
+					},
 				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
 
-				expectHostRemoved := func() {
-					hostID := strfmt.UUID(uuid.New().String())
-					infraEnvID := strfmt.UUID(uuid.New().String())
-					host := &common.Host{
-						Host: models.Host{
-							ID:         &hostID,
-							InfraEnvID: infraEnvID,
-						},
-					}
-					key := types.NamespacedName{Namespace: agent.Namespace, Name: agent.Name}
-					mockInstallerInternal.EXPECT().GetHostByKubeKey(key).Return(host, nil)
-					params := installer.V2DeregisterHostParams{InfraEnvID: infraEnvID, HostID: hostID}
-					mockInstallerInternal.EXPECT().V2DeregisterHostInternal(ctx, params, bminventory.NonInteractive).Return(nil)
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a node referencing a missing machine", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/machine0"},
+					},
 				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
 
-				mockSpokeClient := func() {
-					cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
-					mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
-						func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
-							cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
-								AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "clusterKubeConfig"},
-							}
-							return nil
-						},
-					).AnyTimes()
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
 
-					secretKey := types.NamespacedName{Name: "clusterKubeConfig", Namespace: testNamespace}
-					mockClient.EXPECT().Get(ctx, secretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-						func(_ context.Context, key client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-							secret.ObjectMeta.Labels = map[string]string{
-								BackupLabel:        "true",
-								WatchResourceLabel: "true",
-							}
-							secret.Data = map[string][]byte{"kubeconfig": []byte("definitely_a_kubeconfig")}
-							return nil
-						},
-					).AnyTimes()
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
 
-					mockClientFactory.EXPECT().CreateFromSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-						func(secret *corev1.Secret) (spoke_k8s_client.SpokeK8sClient, error) {
-							Expect(secret.Data["kubeconfig"]).To(Equal([]byte("definitely_a_kubeconfig")))
-							return fakeSpokeClient, nil
-						},
-					).AnyTimes()
+			It("removes a machine without a machineset label", func() {
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
 				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
 
-				BeforeEach(func() {
-					bmhKey := types.NamespacedName{Name: bmhName, Namespace: agent.Namespace}
-					notFoundError := k8serrors.NewNotFound(schema.GroupResource{Group: "v1alpha1", Resource: "BareMetalHost"}, bmhName)
-					mockClient.EXPECT().Get(ctx, bmhKey, gomock.AssignableToTypeOf(&bmh_v1alpha1.BareMetalHost{})).Return(notFoundError).AnyTimes()
-					mockSpokeClient()
-					expectHostRemoved()
-					expectAgentFinalizerRemoved()
-				})
-
-				It("doesn't fail when the agent is not bound", func() {
-					agent.Spec.ClusterDeploymentName = nil
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-				})
-
-				It("removes a node with no machine", func() {
-					node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: agentHostname}}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-
-					err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
-
-				It("removes a node with an invalid machine annotation", func() {
-					node := &corev1.Node{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        agentHostname,
-							Annotations: map[string]string{"machine.openshift.io/machine": "namewithoutaslash"},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-
-					err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
-
-				It("removes a node referencing a missing machine", func() {
-					node := &corev1.Node{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        agentHostname,
-							Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/machine0"},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-
-					err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
-
-				It("removes a machine without a machineset label", func() {
-					machineNSName := client.ObjectKey{
-						Name:      "machine0",
-						Namespace: "openshift-machine-api",
-					}
-					node := &corev1.Node{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        agentHostname,
-							Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					machine := &machinev1beta1.Machine{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      machineNSName.Name,
-							Namespace: machineNSName.Namespace,
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-
-					err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
-
-				It("removes a machine referencing a missing machineset", func() {
-					machineNSName := client.ObjectKey{
-						Name:      "machine0",
-						Namespace: "openshift-machine-api",
-					}
-					node := &corev1.Node{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        agentHostname,
-							Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					machine := &machinev1beta1.Machine{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      machineNSName.Name,
-							Namespace: machineNSName.Namespace,
-							Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "machineset0"},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
-
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
-
-					err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
-
-				It("annotates a machine and machineset for autoscaling and removes the BMH", func() {
-					bmhNSName := client.ObjectKey{
-						Name:      "host0",
-						Namespace: "openshift-machine-api",
-					}
-					bmh := &bmh_v1alpha1.BareMetalHost{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      bmhNSName.Name,
-							Namespace: bmhNSName.Namespace,
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, bmh)).To(Succeed())
-
-					machineNSName := client.ObjectKey{
-						Name:      "machine0",
-						Namespace: "openshift-machine-api",
-					}
-					node := &corev1.Node{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        agentHostname,
-							Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-					machineSetNSName := client.ObjectKey{
-						Name:      "machineset0",
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineNSName.Name,
 						Namespace: machineNSName.Namespace,
-					}
-					machine := &machinev1beta1.Machine{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        machineNSName.Name,
-							Namespace:   machineNSName.Namespace,
-							Labels:      map[string]string{"machine.openshift.io/cluster-api-machineset": machineSetNSName.Name},
-							Annotations: map[string]string{"metal3.io/BareMetalHost": bmhNSName.String()},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
 
-					machineSet := &machinev1beta1.MachineSet{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      machineSetNSName.Name,
-							Namespace: machineSetNSName.Namespace,
-						},
-						Spec: machinev1beta1.MachineSetSpec{
-							Selector: metav1.LabelSelector{MatchLabels: machine.Labels},
-						},
-					}
-					Expect(fakeSpokeClient.Create(ctx, machineSet)).To(Succeed())
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
 
-					res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-					Expect(err).To(BeNil())
-					Expect(res).NotTo(BeNil())
+				err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
 
-					Expect(fakeSpokeClient.Get(ctx, machineNSName, machine)).To(Succeed())
-					Expect(fakeSpokeClient.Get(ctx, machineSetNSName, machineSet)).To(Succeed())
+			It("removes a machine referencing a missing machineset", func() {
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
+				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
 
-					Expect(machine.Annotations).To(HaveKey("machine.openshift.io/delete-machine"))
-					Expect(machine.Annotations).To(HaveKey("machine.openshift.io/exclude-node-draining"))
-					Expect(machineSet.Annotations).To(HaveKey("metal3.io/autoscale-to-hosts"))
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineNSName.Name,
+						Namespace: machineNSName.Namespace,
+						Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "machineset0"},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
 
-					err = fakeSpokeClient.Get(ctx, bmhNSName, &bmh_v1alpha1.BareMetalHost{})
-					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				})
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("annotates a machine and machineset for autoscaling and removes the BMH", func() {
+				bmhNSName := client.ObjectKey{
+					Name:      "host0",
+					Namespace: "openshift-machine-api",
+				}
+				bmh := &bmh_v1alpha1.BareMetalHost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      bmhNSName.Name,
+						Namespace: bmhNSName.Namespace,
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, bmh)).To(Succeed())
+
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
+				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				machineSetNSName := client.ObjectKey{
+					Name:      "machineset0",
+					Namespace: machineNSName.Namespace,
+				}
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        machineNSName.Name,
+						Namespace:   machineNSName.Namespace,
+						Labels:      map[string]string{"machine.openshift.io/cluster-api-machineset": machineSetNSName.Name},
+						Annotations: map[string]string{"metal3.io/BareMetalHost": bmhNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+
+				machineSet := &machinev1beta1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineSetNSName.Name,
+						Namespace: machineSetNSName.Namespace,
+					},
+					Spec: machinev1beta1.MachineSetSpec{
+						Selector: metav1.LabelSelector{MatchLabels: machine.Labels},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machineSet)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				Expect(fakeSpokeClient.Get(ctx, machineNSName, machine)).To(Succeed())
+				Expect(fakeSpokeClient.Get(ctx, machineSetNSName, machineSet)).To(Succeed())
+
+				Expect(machine.Annotations).To(HaveKey("machine.openshift.io/delete-machine"))
+				Expect(machine.Annotations).To(HaveKey("machine.openshift.io/exclude-node-draining"))
+				Expect(machineSet.Annotations).To(HaveKey("metal3.io/autoscale-to-hosts"))
+
+				err = fakeSpokeClient.Get(ctx, bmhNSName, &bmh_v1alpha1.BareMetalHost{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 	})

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -373,11 +373,16 @@ func (r *BMACReconciler) handleBMHFinalizer(ctx context.Context, log logrus.Fiel
 			return reconcileComplete{stop: true, dirty: true}
 		}
 
-		// annotate the agent to inform the agent controller to remove the spoke node when the BMH finishes deprovisioning
-		if _, ok := agent.GetAnnotations()[BMH_FINALIZER_NAME]; !ok {
-			setAnnotation(&agent.ObjectMeta, BMH_FINALIZER_NAME, "true")
+		if bmh.Status.Provisioning.State != bmh_v1alpha1.StateDeleting {
+			log.Info("Waiting for BMH to deprovision")
+			return reconcileRequeue{requeueAfter: defaultRequeueAfterOnError}
+		}
+
+		// annotate the agent to inform the agent controller to remove the spoke resources
+		if _, ok := agent.GetAnnotations()[AgentSpokeCleanupAnnotation]; !ok {
+			setAnnotation(&agent.ObjectMeta, AgentSpokeCleanupAnnotation, "true")
 			if err := r.Update(ctx, agent); err != nil {
-				log.WithError(err).Errorf("failed to set %s annotation on agent", BMH_FINALIZER_NAME)
+				log.WithError(err).Errorf("failed to set %s annotation on agent", AgentSpokeCleanupAnnotation)
 				return reconcileError{err: err, dirty: dirty}
 			}
 		}

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -2501,32 +2501,55 @@ var _ = Describe("handleBMHFinalizer", func() {
 						bmh.Spec.AutomatedCleaningMode = bmh_v1alpha1.CleaningModeMetadata
 					})
 
-					It("annotates and deletes the agent", func() {
-						mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
-							func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
-								Expect(updatedAgent.GetAnnotations()).To(HaveKey(BMH_FINALIZER_NAME))
-								return nil
-							},
-						)
-						mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(nil)
+					It("waits for the BMH to be deprovisioned", func() {
+						mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Times(0)
+						mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Times(0)
 
 						res := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent)
-						Expect(bmh.GetFinalizers()).NotTo(ContainElement(BMH_FINALIZER_NAME))
-						_, err := res.Result()
+						Expect(bmh.GetFinalizers()).To(ContainElement(BMH_FINALIZER_NAME))
+						Expect(res.Stop(ctx)).To(BeTrue())
+						recResult, err := res.Result()
 						Expect(err).NotTo(HaveOccurred())
+						Expect(recResult.RequeueAfter).To(Equal(defaultRequeueAfterOnError))
 					})
 
-					It("fails when annotating the agent fails", func() {
-						mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(fmt.Errorf("failed to update agent"))
-						_, err := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent).Result()
-						Expect(err).To(HaveOccurred())
-					})
+					Context("BMH is deleting", func() {
+						BeforeEach(func() {
+							bmh.Status.Provisioning.State = bmh_v1alpha1.StateDeleting
+						})
+						It("annotates and deletes the agent", func() {
+							mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
+								func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
+									Expect(updatedAgent.GetAnnotations()).To(HaveKey(AgentSpokeCleanupAnnotation))
+									return nil
+								},
+							)
+							mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(nil)
 
-					It("fails when deleting the agent fails", func() {
-						mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(fmt.Errorf("agent delete failed"))
-						setAnnotation(&agent.ObjectMeta, BMH_FINALIZER_NAME, "true")
-						_, err := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent).Result()
-						Expect(err).To(HaveOccurred())
+							res := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent)
+							Expect(bmh.GetFinalizers()).NotTo(ContainElement(BMH_FINALIZER_NAME))
+							_, err := res.Result()
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("fails when annotating the agent fails", func() {
+							mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(fmt.Errorf("failed to update agent"))
+							_, err := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent).Result()
+							Expect(err).To(HaveOccurred())
+						})
+
+						It("fails when deleting the agent fails", func() {
+							mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
+								func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
+									Expect(updatedAgent.GetAnnotations()).To(HaveKey(AgentSpokeCleanupAnnotation))
+									return nil
+								},
+							)
+							mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(fmt.Errorf("agent delete failed"))
+							setAnnotation(&agent.ObjectMeta, BMH_FINALIZER_NAME, "true")
+							_, err := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent).Result()
+							Expect(err).To(HaveOccurred())
+						})
 					})
 				})
 			})


### PR DESCRIPTION
Only BMAC should be aware of the BMH and its status. When deprovisioning a node by deleting a BMH, make BMAC wait for the node to fully deprovision before annotating and deleting the agent and removing the finalizer.

This adds a new annotation for the agent resource (`agent.agent-install/clean-spoke-on-delete`) which is used in place of the bmac annotation to communicate to the agent controller that the node should be removed.

This gets us a bit closer to https://issues.redhat.com/browse/MGMT-10006 by removing the BMH concept from the "remove a node" flow in the agent controller. This will allow this logic to be more easily reused in the late-binding/non-bmh case.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-10006

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested manually using a dev-scripts cluster.
1. Deployed a 6 node OCP cluster from a bare metal hub
2. Annotated and removed a worker node BMH with `bmac.agent-install.openshift.io/remove-agent-and-node-on-delete` and removed the BMH
3. Waited for successful removal

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?