### PR TITLE
MGMT-18418: Reapply "Add certs to ingress when deploying in non-OCP clusters (#6564)"

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1130,8 +1130,8 @@ func newImageServiceConfigMap(ctx context.Context, log logrus.FieldLogger, asc A
 func urlForRoute(ctx context.Context, asc ASC, routeName string) (string, error) {
 	var hostname, scheme string
 
+	scheme = "https"
 	if asc.rec.IsOpenShift {
-		scheme = "https"
 		route := &routev1.Route{}
 		err := asc.Client.Get(ctx, types.NamespacedName{Name: routeName, Namespace: asc.namespace}, route)
 		if err != nil || route.Spec.Host == "" {
@@ -1145,7 +1145,6 @@ func urlForRoute(ctx context.Context, asc ASC, routeName string) (string, error)
 		if asc.spec.Ingress == nil {
 			return "", fmt.Errorf("ingress config is required for non-OpenShift deployments")
 		}
-		scheme = "http"
 		switch routeName {
 		case serviceName:
 			hostname = asc.spec.Ingress.AssistedServiceHostname
@@ -1264,16 +1263,18 @@ func newAssistedCM(ctx context.Context, log logrus.FieldLogger, asc ASC) (client
 			"ENABLE_DATA_COLLECTION": "True",
 			"DATA_UPLOAD_ENDPOINT":   "https://console.redhat.com/api/ingress/v1/upload",
 
-			"NAMESPACE":       asc.namespace,
-			"INSTALL_INVOKER": "assisted-installer-operator",
+			"NAMESPACE":              asc.namespace,
+			"INSTALL_INVOKER":        "assisted-installer-operator",
+			"SKIP_CERT_VERIFICATION": "False",
 		}
-		// enable https only on OCP
+		// serve https only on OCP
 		if asc.rec.IsOpenShift {
 			cm.Data["SERVE_HTTPS"] = "True"
 			cm.Data["HTTPS_CERT_FILE"] = "/etc/assisted-tls-config/tls.crt"
 			cm.Data["HTTPS_KEY_FILE"] = "/etc/assisted-tls-config/tls.key"
 			cm.Data["SERVICE_CA_CERT_PATH"] = "/etc/assisted-ingress-cert/ca-bundle.crt"
-			cm.Data["SKIP_CERT_VERIFICATION"] = "False"
+		} else {
+			cm.Data["SERVICE_CA_CERT_PATH"] = "/etc/assisted-ingress-cert/ca.crt"
 		}
 
 		copyEnv(cm.Data, "HTTP_PROXY")
@@ -1795,6 +1796,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 	}
 	volumeMounts := []corev1.VolumeMount{
 		{Name: "bucket-filesystem", MountPath: "/data"},
+		{Name: "ingress-cert", MountPath: "/etc/assisted-ingress-cert"},
 	}
 	var healthCheckScheme corev1.URIScheme
 	if asc.rec.IsOpenShift {
@@ -1835,7 +1837,6 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 		)
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{Name: "tls-certs", MountPath: "/etc/assisted-tls-config"},
-			corev1.VolumeMount{Name: "ingress-cert", MountPath: "/etc/assisted-ingress-cert"},
 			corev1.VolumeMount{
 				Name:      "trusted-ca-certs",
 				MountPath: common.MirrorRegistriesCertificatePath,
@@ -1844,6 +1845,16 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 		)
 		healthCheckScheme = corev1.URISchemeHTTPS
 	} else {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: "ingress-cert",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: ingressTLSSecretName(serviceName),
+					},
+				},
+			},
+		)
 		healthCheckScheme = corev1.URISchemeHTTP
 	}
 

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -2810,7 +2810,7 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		Expect(cert.Spec.DNSNames).To(ContainElement(fmt.Sprintf("%s.%s.svc.cluster.local", webhookServiceName, testNamespace)))
 	})
 
-	It("creates the assisted configmap without https config", func() {
+	It("creates the assisted configmap without https server config and with ingress https config", func() {
 		res, err := reconciler.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
@@ -2821,11 +2821,11 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		Expect(cm.Data).ToNot(HaveKey("SERVE_HTTPS"))
 		Expect(cm.Data).ToNot(HaveKey("HTTPS_CERT_FILE"))
 		Expect(cm.Data).ToNot(HaveKey("HTTPS_KEY_FILE"))
-		Expect(cm.Data).ToNot(HaveKey("SERVICE_CA_CERT_PATH"))
-		Expect(cm.Data).ToNot(HaveKey("SKIP_CERT_VERIFICATION"))
+
+		Expect(cm.Data["SERVICE_CA_CERT_PATH"]).To(Equal("/etc/assisted-ingress-cert/ca.crt"))
 	})
 
-	It("creates the assisted deployment without https config", func() {
+	It("creates the assisted deployment without serving https, but with ingress https config", func() {
 		res, err := reconciler.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
@@ -2842,11 +2842,18 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		}
 
 		By("ensure no cert volumes are present")
-		Expect(container.VolumeMounts).To(Equal([]corev1.VolumeMount{{Name: "bucket-filesystem", MountPath: "/data"}}))
+		Expect(container.VolumeMounts).To(ConsistOf(
+			corev1.VolumeMount{Name: "bucket-filesystem", MountPath: "/data"},
+			corev1.VolumeMount{Name: "ingress-cert", MountPath: "/etc/assisted-ingress-cert"},
+		))
+		foundIngressVol := false
 		for _, vol := range deploy.Spec.Template.Spec.Volumes {
 			Expect(vol.Name).NotTo(Equal("tls-certs"))
-			Expect(vol.Name).NotTo(Equal("ingress-cert"))
+			if vol.Name == "ingress-cert" {
+				foundIngressVol = true
+			}
 		}
+		Expect(foundIngressVol).To(BeTrue(), "expected ingress volume to be present")
 
 		By("ensure probe scheme is http")
 		Expect(container.ReadinessProbe.ProbeHandler.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTP))
@@ -2886,6 +2893,7 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 	validateIngress := func(ingress *netv1.Ingress, host string, service string, port int32) {
 		Expect(ingress.Spec.IngressClassName).To(HaveValue(Equal(*asc.Spec.Ingress.ClassName)))
 		Expect(len(ingress.Spec.Rules)).To(Equal(1))
+
 		rule := ingress.Spec.Rules[0]
 		Expect(rule.Host).To(Equal(host))
 		Expect(rule.IngressRuleValue.HTTP).NotTo(BeNil())
@@ -2897,6 +2905,10 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 			Port: netv1.ServiceBackendPort{Number: port},
 		}
 		Expect(rule.IngressRuleValue.HTTP.Paths[0].Backend.Service).To(HaveValue(Equal(serviceBackend)))
+
+		Expect(len(ingress.Spec.TLS)).To(Equal(1))
+		tls := ingress.Spec.TLS[0]
+		Expect(tls.Hosts).To(Equal([]string{host}))
 	}
 
 	It("creates ingress instead of routes", func() {
@@ -2928,8 +2940,8 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		cm := corev1.ConfigMap{}
 		key := types.NamespacedName{Name: serviceName, Namespace: testNamespace}
 		Expect(reconciler.Client.Get(ctx, key, &cm)).To(Succeed())
-		Expect(cm.Data["SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.AssistedServiceHostname)))
-		Expect(cm.Data["IMAGE_SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.ImageServiceHostname)))
+		Expect(cm.Data["SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.AssistedServiceHostname)))
+		Expect(cm.Data["IMAGE_SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.ImageServiceHostname)))
 	})
 
 	It("sets the image service base URL env to the ingress host", func() {
@@ -2945,7 +2957,7 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		var found bool
 		for _, env := range ss.Spec.Template.Spec.Containers[0].Env {
 			if env.Name == "IMAGE_SERVICE_BASE_URL" {
-				Expect(env.Value).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.ImageServiceHostname)))
+				Expect(env.Value).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.ImageServiceHostname)))
 				found = true
 			}
 		}


### PR DESCRIPTION
This reverts commit 9964f0870d5df042a782bb9c6394835d05ad807a.

The re-adds the ingress certs now that the CAPI provider is using the internal service IP for the BMH.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-18418
Requires https://github.com/openshift-assisted/cluster-api-agent/pull/51 (merged)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested manually in a Sylva test environment with the updated CAPI provider.
Saw that a SNO was installed successfully.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
