### PR TITLE
MGMT-18510: Add an annotation to override ironic IP family to provide in dual-stack hubs

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -234,6 +234,19 @@ This can be found using the following command:
 oc adm release info --image-for=ironic-agent <hub-release-image>
 ```
 
+### Ironic Agent callback IP family
+
+If the hub cluster is a dual stack cluster the preprovisioning image controller needs to pick which IP family to provide to the ironic agent for callback purposes.
+
+This is done using the following priority system:
+
+1. Use the IP family from the `infraenv.agent-install.openshift.io/ip-family` annotation
+  - This can be `v4`, `v6`, or `v4,v6` depending on what the hosts in this infraenv support
+  - Use this option when using late binding or when the following behavior doesn't work for your use case
+2. IP family of the cluster associated with the InfraEnv
+  - If the InfraEnv has a cluster associated with it that cluster's networking will be checked to determine the correct IP family to use
+3. Default to the primary IP family of the hub cluster
+
 [ZTP converged flow](ZTP_converged_flow.png)
 
 ## Working with mirror registry

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -58,10 +58,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const defaultRequeueAfterPerRecoverableError = 2 * bminventory.WindowBetweenRequestsInSeconds
-const InfraEnvFinalizerName = "infraenv." + aiv1beta1.Group + "/ai-deprovision"
-const EnableIronicAgentAnnotation = "infraenv." + aiv1beta1.Group + "/enable-ironic-agent"
-const ironicAgentImageOverrideAnnotation = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override"
+const (
+	defaultRequeueAfterPerRecoverableError = 2 * bminventory.WindowBetweenRequestsInSeconds
+	InfraEnvFinalizerName                  = "infraenv." + aiv1beta1.Group + "/ai-deprovision"
+	EnableIronicAgentAnnotation            = "infraenv." + aiv1beta1.Group + "/enable-ironic-agent"
+	ironicAgentImageOverrideAnnotation     = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override"
+	infraEnvIPFamilyAnnotation             = "infraenv." + aiv1beta1.Group + "/ip-family"
+	ipv4Family                             = "v4"
+	ipv6Family                             = "v6"
+)
 
 type InfraEnvConfig struct {
 	ImageType models.ImageType `envconfig:"ISO_IMAGE_TYPE" default:"minimal-iso"`


### PR DESCRIPTION
Currently when a hub cluster is dual-stack the only way the preprovisioning image controller can determine which callback IP family to provide to the ironic agent is to use the cluster reference in the infraenv. If there is no cluster reference (for late binding cases) then the controller always provides the primary IP family of the hub cluster.

This prevents users from using late-binding to deploy ipv6 only hosts from an ipv4-primary dual-stack hub (or vice versa).

This commit adds an annotation on the infraenv that can be used to override the ip family used when discovering hosts with a particular discovery image. `infraenv.agent-install.openshift.io/ip-family` can be set to `v4`, `v6`, or `v4,v6` to indicate to the controller which family should be used.

In newer OCP versions the ironic agent supports multiple callback URLs in its config, but the infrastructure-operator still supports running on hubs that don't have this change so this annotation is still required for those situations.

## List all the issues related to this PR

Partially resolves https://issues.redhat.com/browse/MGMT-18510

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Unit tests only - I don't have a dual-stack hub cluster to test this on

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) - docs added
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
