### PR TITLE
NO-ISSUE: add MCE to OLM operators dev docs

### DIFF
--- a/docs/dev/olm-operator-plugins.md
+++ b/docs/dev/olm-operator-plugins.md
@@ -5,7 +5,7 @@
   - [OpenShift Virtualization (CNV)](../../internal/operators/cnv)
   - [OpenShift Data Foundation (ODF)](../../internal/operators/odf)
   - [Logical Volume Manager (LVM)](../../internal/operators/lvm)
-  - [Multi-Cluster Enginer (MCE)](../../internal/operators/mce)
+  - [Multi-Cluster Engine (MCE)](../../internal/operators/mce)
 
 ## How to implement a new OLM operator plugin
 

--- a/docs/dev/olm-operator-plugins.md
+++ b/docs/dev/olm-operator-plugins.md
@@ -5,6 +5,7 @@
   - [OpenShift Virtualization (CNV)](../../internal/operators/cnv)
   - [OpenShift Data Foundation (ODF)](../../internal/operators/odf)
   - [Logical Volume Manager (LVM)](../../internal/operators/lvm)
+  - [Multi-Cluster Enginer (MCE)](../../internal/operators/mce)
 
 ## How to implement a new OLM operator plugin
 


### PR DESCRIPTION
Updating the developer docs for the OLM operator plugin infrastructure to include MCE and the relevant repo link.