### PR TITLE
MGMT-18659: Local cluster name should be picked up from ACM ManagedCluster label

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -208,7 +208,7 @@ func main() {
 
 	// local cluster import is only relevant if assisted installer can manage/scale the local cluster and this is only the case for OpenShift
 	if isOpenShift {
-		if err = (controllers.NewLocalClusterImportReconciler(mgr.GetClient(), "local-cluster", controllers.AgentServiceConfigName, log)).SetupWithManager(mgr); err != nil {
+		if err = (controllers.NewLocalClusterImportReconciler(mgr.GetClient(), controllers.AgentServiceConfigName, log)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "LocalClusterImportReconciler")
 			os.Exit(1)
 		}


### PR DESCRIPTION
When performing a local cluster import - the local cluster name is hardwired to "local-cluster", this is not flexible enough and needs to be changed.
We should be picking up the name from the ManagedCluster that is labelled as "local-cluster" - this should then be used wherever we use the present local-cluster name.
An additional check is performed to ensure that the clusterID referenced in the labels of ManagedCluster matches the clusterID in the labels found in the
clusterVersion of the hub on which the LocalClusterImport is running.

This should be sufficient at this stage as we do not need to handle scenarios such as a "rename", mainly because ACM will be enforcing some rules

From ACM-DDR-022:

```
To ensure backward compatibility, we will not directly allow renaming the local cluster from MCE or ACM installer at the first stage. The user can choose a customized local cluster name with the following step:
Disable local cluster management in MCE or ACM when install
Manually create a ManagedCluster resource with the label “local-cluster=true” on the hub
```

I have also added some entity cleanup that was missed in previous versions, mainly just making sure that unused secrets are deleted.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment

1. Tested and verified to be correctly working in a dev-scripts environment with a custom operator bundle.
2. AgentServiceConfig was created in a way that renders LocalClusterInstall active
3. ManagedCluster was given the clusterID of the hub
4. Expectation was that local managed cluster would have CR's created for it in the namespace specified by the name of ManagedCluster. This expectation was met.

- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
