### PR TITLE
NO-ISSUE: Prepare base documents and targets for devel environments using kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,12 @@ deploy-on-k8s: create-hub-cluster
 	fi
 	skipper $(MAKE) deploy-ui
 
+deploy-sylva: create-hub-cluster
+	./hack/kind/dev-env-sylva.sh
+
+deploy-dev-infra: create-hub-cluster
+	./hack/kind/dev-env-infra.sh
+
 ########
 # Test #
 ########

--- a/deploy/kind/agent-svc-config.yaml
+++ b/deploy/kind/agent-svc-config.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assisted-service-config
+  namespace: assisted-installer
+data:
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+  namespace: assisted-installer
+  annotations:
+    unsupported.agent-install.openshift.io/assisted-service-configmap: assisted-service-config
+spec:
+  ingress:
+    className: nginx
+    assistedServiceHostname: assisted-service.example.com
+    imageServiceHostname: image-service.example.com
+  databaseStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 8Gi
+  filesystemStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 8Gi
+  imageStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  osImages:
+  - openshiftVersion: "4.15"
+    cpuArchitecture: "x86_64"
+    url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.15/4.15.0/rhcos-4.15.0-x86_64-live.x86_64.iso"
+    version: "415.92.202402130021-0"

--- a/deploy/kind/assisted-service-portmap.yaml
+++ b/deploy/kind/assisted-service-portmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: assisted-service-nodeport
+  namespace: assisted-installer
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      nodePort: 30000
+      port: 8090
+  selector:
+    app: assisted-service

--- a/docs/dev/kind/README.md
+++ b/docs/dev/kind/README.md
@@ -1,0 +1,141 @@
+# Development environment using kind
+Using `kind` we can start a lightweight environment for **assisted-service** development.  
+The **assisted-service** does not require all the components of Openshift Container Platform, so we can use this environment to save time and resources.  
+
+## Requirements
+We usually use the **podman** provider with `kind`, so it must be installed in our Operating System.  
+Nowadays, **podman** is available in the packaging system of all major GNU/Linux distributions.  
+Ir order to manage the kind cluster, we will also need to have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl9) or [oc](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html) installed.
+
+## Build the environment
+This repository provides some tools to install `kind`, **assisted-service** and their dependencies.  
+We can build developer environments by using `make` targets:
+* infrastructure operator on kind:
+```shell
+make deploy-dev-infra
+```
+* developer environment for sylva:
+```
+make deploy-sylva
+```
+When `make` finishes, we will have an environment ready to work.  
+We can prepare the kind `kubeconfig` credentials with:
+```shell
+kind get kubeconfig -n assisted-hub-cluster > ~/.kube/kind-assisted-service
+```
+To validate if kind is working, check the running pods:
+```shell
+$ export KUBECONFIG="${HOME}/.kube/kind-assisted-service"
+
+$ kubectl get nodes
+NAME                                    STATUS   ROLES           AGE     VERSION
+assisted-hub-cluster-control-plane      Ready    control-plane   6m23s   v1.30.0
+
+$ kubectl get pods -A
+NAMESPACE                   NAME                                                            READY   STATUS    RESTARTS   AGE
+assisted-installer          agentinstalladmission-67c949b84-7l2hr                           1/1     Running   0          6m48s
+assisted-installer          agentinstalladmission-67c949b84-jchzp                           1/1     Running   0          6m48s
+assisted-installer          assisted-image-service-0                                        1/1     Running   0          6m48s
+assisted-installer          assisted-service-5b68cbdfc6-rg4nf                               2/2     Running   0          6m48s
+baremetal-operator-system   baremetal-operator-controller-manager-5546cbc489-m2vvq          2/2     Running   0          7m10s
+baremetal-operator-system   ironic-659b44f9c8-mghwb                                         3/3     Running   0          10m
+cert-manager                cert-manager-cainjector-9d956987c-tzds4                         1/1     Running   0          11m
+cert-manager                cert-manager-fdd97855b-2v8nh                                    1/1     Running   0          11m
+cert-manager                cert-manager-webhook-9f799c7d7-t7cvr                            1/1     Running   0          11m
+kube-system                 coredns-7db6d8ff4d-jmw84                                        1/1     Running   0          11m
+kube-system                 coredns-7db6d8ff4d-rgr8r                                        1/1     Running   0          11m
+kube-system                 etcd-assisted-hub-cluster-control-plane                         1/1     Running   0          11m
+kube-system                 kindnet-mnhts                                                   1/1     Running   0          11m
+kube-system                 kube-apiserver-assisted-hub-cluster-control-plane               1/1     Running   0          11m
+kube-system                 kube-controller-manager-assisted-hub-cluster-control-plane      1/1     Running   0          11m
+kube-system                 kube-proxy-cgv7b                                                1/1     Running   0          11m
+kube-system                 kube-scheduler-assisted-hub-cluster-control-plane               1/1     Running   0          11m
+local-path-storage          local-path-provisioner-988d74bc-2ww6k                           1/1     Running   0          11m
+```
+
+### Build time
+The build time depends on the components and your own resources, such as computer hardware or Internet bandwidth. However, for reference, this should be the estimated time for known scenarios:
+
+| environment | description | time |
+| :---------: | :---------: | :--: |
+| sylva | ironic + BMO + assisted | 15m |
+| infra | infrastructure operator + assisted | 4m |
+
+## Verify the `assisted-service`
+Once all pods are in `Running` state, you can validate if the `assisted-service` is available by running this command:
+```shell
+# In the sylva environment the service uses https
+curl -sk https://127.0.0.1:8090/api/assisted-install/v2/infra-envs
+{"code":401,"message":"unauthenticated for invalid credentials"}
+
+# In the infra environment the service uses http
+curl -sk http://127.0.0.1:8090/api/assisted-install/v2/infra-envs
+{"code":401,"message":"unauthenticated for invalid credentials"}
+```
+The error code 401 is OK, it means that the service is unable to authenticate you, but is running.  
+You can disable the REST API authentication by following [these steps](#disable-the-rest-api-authentication).
+
+## assisted-service configuration
+In this environment, the configuration of the assisted-service is managed by a `ConfigMap`.  
+It is located in the `assisted-installer` namespace and is called `assisted-service`.  
+We can see or manage the options by editing it:
+```shell
+$ kubectl edit cm -n assisted-installer assisted-service
+```
+Remember to restart the **assisted-service** pods after the changes:
+```shell
+$ kubectl rollout restart deploy -n assisted-installer assisted-service
+```
+
+## Disable the REST API authentication
+If we want to disable the REST API authentication of the **assisted-service** for our tests we can change the option `AUTH_TYPE` in the configuration and restart the deployment to apply the changes:
+```shell
+$ kubectl patch cm/assisted-service -n assisted-installer -p '{"data":{"AUTH_TYPE":"none"}}'
+$ kubectl rollout restart deploy -n assisted-installer assisted-service
+```
+If we use the infrastructure operator, the assisted-service settings are managed using the ConfigMap `assisted-service-config`:
+```shell
+$ kubectl create cm assisted-service-config --from-literal=AUTH_TYPE=none -n assisted-installer
+```
+
+After this change we can send REST requests as explained [here](../../user-guide/rest-api-getting-started.md) without using the authentication bearer.  
+Our development environment exposes the REST API in the port **8090**.
+
+## Replace assisted-service image
+During our development perhaps we would like to replace the current `assisted-service` image with our own custom image.  
+To replace the **assisted-service** image that we are using we can do it by changing the `image` in the `assisted-service` deployment:
+```shell
+kubectl patch deploy/assisted-service \
+  -n assisted-installer \
+  --type merge \
+  -p '{"spec":{"template":{"spec":{"containers":[{"name":"assisted-service","image":"<YOUR IMAGE>:<TAG>"}]}}}}'
+```
+
+## Delete the environment
+To delete the environment simply execute the `kind.sh` script with the `delete` parameter:
+```shell
+<repository-dir>/hack/kind/kind.sh delete
+```
+> Warning: This action **REMOVES** all work done on the local cluster.
+
+## Additional working environments
+This document covers the setup of a **assisted-service** development scenario using previous work provided by the [sylva-poc project](https://github.com/jianzzha/sylva-poc), but it's not the only option.
+
+It is also possible to configure an **assisted-service** development environment using the infrastructure operator. This setup is described in the document [operator-on-kind](../operator-on-kind.md).
+
+And, if you only need to start up the assisted-service application, for small tests without integration with other operators, you can also do it using podman following the instructions written in [deploy/podman](../../../deploy/podman/README.md).
+
+## Known issues
+### Starting docker instead of podman
+* Error:
+```shell
+ERROR: failed to list clusters: command "docker ps -a --filter label=io.x-k8s.kind.cluster --format '{{.Label "io.x-k8s.kind.cluster"}}'" failed with error: exit status 1
+Command Output: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json?all=1&filters=%7B%22label%22%3A%7B%22io.x-k8s.kind.cluster%22%3Atrue%7D%7D": dial unix /var/run/docker.sock: connect: permission denied
+```
+* Explanation:  
+The scripts to create the environment have been prepared to work with `podman`. If you have `docker` installed, they may fail because for some operations docker requires root permissions.  
+* Solution:
+Set the variable `KIND_EXPERIMENTAL_PROVIDER` to **podman** and start the environment again.
+```shell
+export KIND_EXPERIMENTAL_PROVIDER=podman
+```

--- a/hack/hub_cluster.sh
+++ b/hack/hub_cluster.sh
@@ -3,7 +3,6 @@
 set -o nounset
 set -o pipefail
 set -o errexit
-set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/hack/kind/dev-env-infra.sh
+++ b/hack/kind/dev-env-infra.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+CERTMANAGER_VERSION="1.15.1"
+
+# cert-manager installation
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml"
+echo "Waiting for cert-manager ..."
+for app in webhook cainjector cert-manager; do
+  while ! kubectl wait -n cert-manager -l app="${app}" --for=condition=Ready pods --timeout=300s > /dev/null 2>&1; do
+    sleep 10
+  done
+done
+
+# Create required CRDs
+kubectl apply -f "$(dirname "${0}")/../crds/"
+
+# Deploy nginx ingress controller
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+# label nodes as ingress-ready
+while read -r node; do
+  kubectl label node "${node}" ingress-ready='true'
+done < <(kubectl get nodes -o 'jsonpath={.items[0].metadata.name}{"\n"}')
+
+# assisted-service installation
+kubectl apply -k https://github.com/openshift/assisted-service//config/default
+kubectl apply -f deploy/kind/agent-svc-config.yaml
+kubectl apply -f deploy/kind/assisted-service-portmap.yaml

--- a/hack/kind/dev-env-sylva.sh
+++ b/hack/kind/dev-env-sylva.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CERTMANAGER_VERSION="1.15.1"
+# export KUBECONFIG="${HOME}/.kube/kind-assisted-service"
+
+# cert-manager installation
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml"
+echo "Waiting for cert-manager ..."
+for app in webhook cainjector cert-manager; do
+  while ! kubectl wait -n cert-manager -l app="${app}" --for=condition=Ready pods --timeout=300s > /dev/null 2>&1; do
+    sleep 10
+  done
+done
+
+# metal3 baremetal-operator ironic deployment
+kubectl apply -k https://github.com/jianzzha/sylva-poc//manifests/ironic/
+echo "Waiting for ironic ..."
+while ! kubectl wait -n baremetal-operator-system -l name=ironic --for=condition=Ready pods --timeout=300s > /dev/null 2>&1; do
+  sleep 10
+done
+
+# metal3 baremetal-operator
+kubectl apply -k https://github.com/jianzzha/sylva-poc//manifests/bmo/
+echo "Waiting for baremetal-operator ..."
+while ! kubectl wait -n baremetal-operator-system -l webhook=metal3-io-v1alpha1-baremetalhost --for=condition=Ready pods --timeout=300s > /dev/null 2>&1; do
+  sleep 10
+done
+
+# assisted-service installation
+kubectl apply -k https://github.com/jianzzha/sylva-poc//manifests/
+kubectl apply -f deploy/kind/assisted-service-portmap.yaml

--- a/hack/kind/kind-config.yaml
+++ b/hack/kind/kind-config.yaml
@@ -1,3 +1,4 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: assisted-hub-cluster
@@ -27,4 +28,16 @@ nodes:
   # debugger
   - containerPort: 30005
     hostPort: 40000
+    protocol: TCP
+  # Ironic httpd
+  - containerPort: 30006
+    hostPort: 6180
+    protocol: TCP
+  # Ironic API
+  - containerPort: 30007
+    hostPort: 6385
+    protocol: TCP
+  # Inspector API
+  - containerPort: 30008
+    hostPort: 5050
     protocol: TCP

--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -14,7 +14,7 @@ function check() {
 		echo "'kind' is installed. '$(kind --version)' will be used"
 		return 0
 	else
-		echo "'kind' executable is not avialable in PATH"
+		echo "'kind' executable is not available in PATH"
 		return 1
 	fi
 }


### PR DESCRIPTION
This commit adds additional documentation and files to create development environments using kind.
In this 1st phase, a couple of scenarios have been created to start an environment with the infrastructure operator and another with CAPI (sylva project).
In future, I will continue by getting feedback from other team members and evolving the functionalities to increase the coverage of our work scenarios.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Enhancement
- [ ] Bug fix
- [ ] Tests
- [X] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- With these changes it should be possible to start small `assisted-service` environments using `make deploy-dev-infra`. More specific information on how to try this out is in the README file included with the commit.