### PR TITLE
MGMT-18694, MGMT-18575, OCPBUGS-34849: Don't require mapping for names matching physical interfaces

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -180,7 +180,8 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistence(macInterf
 		connectionSection := cfg.Section("connection")
 		interfaceName, err := connectionSection.GetKey("interface-name")
 		if err != nil {
-			return errors.Wrapf(err, "failed to get interface-name for file %s", nc.FilePath)
+			// When the id field is provided the interface-name will not be present
+			continue
 		}
 		interfaceType, err := connectionSection.GetKey("type")
 		if err != nil {

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -306,6 +306,15 @@ var _ = Describe("validate mac interface mapping", func() {
     ipv4:
       enabled: false
       dhcp: false`
+		withMacIdentifier := `interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    identifier: mac-address
+    mac-address: f8:75:a4:a4:00:fe
+    ipv4:
+      enabled: false
+      dhcp: false`
 		It("no mapping needed for physical interface", func() {
 			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
 				{
@@ -316,6 +325,20 @@ var _ = Describe("validate mac interface mapping", func() {
 						},
 					},
 					NetworkYaml: withPhysicalInterface,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("mac-identifier field is allowed", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{
+						{
+							LogicalNicName: "eth0",
+							MacAddress:     "f8:75:a4:a4:00:fe",
+						},
+					},
+					NetworkYaml: withMacIdentifier,
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -238,17 +238,6 @@ var _ = Describe("validate mac interface mapping", func() {
     vlan:
       base-iface: eth1
       id: 101`
-		It("vlan without underlying interface - no mapping", func() {
-			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: nil,
-					NetworkYaml:     withoutUnderlyingInterface,
-				},
-			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no mac address mapping can be associated with the available network interfaces"))
-		})
-
 		It("vlan with underlying interface - no mapping", func() {
 			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
 				{
@@ -306,6 +295,19 @@ var _ = Describe("validate mac interface mapping", func() {
     ipv4:
       enabled: false
       dhcp: false`
+		withNoMappedInterfaces := `interfaces:
+  - name: eno12345
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false
+  - name: eno12399np0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false`
 		withMacIdentifier := `interfaces:
   - name: eth0
     type: ethernet
@@ -328,6 +330,16 @@ var _ = Describe("validate mac interface mapping", func() {
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("at least one mapped interface is required", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{},
+					NetworkYaml:     withNoMappedInterfaces,
+				},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("at least one interface for host"))
 		})
 		It("mac-identifier field is allowed", func() {
 			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -288,6 +288,39 @@ var _ = Describe("validate mac interface mapping", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("no mapping for physical interfaces", func() {
+		withPhysicalInterface := `interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+        - ip: 192.0.2.1
+          prefix-length: 24
+  - name: eno12399np0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false`
+		It("no mapping needed for physical interface", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{
+						{
+							LogicalNicName: "eth0",
+							MacAddress:     "f8:75:a4:a4:00:fe",
+						},
+					},
+					NetworkYaml: withPhysicalInterface,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 var _ = Describe("StaticNetworkConfig", func() {


### PR DESCRIPTION
For static network interface names that match physical interfaces don't require mac-address mapping. This allows the names to be in the networkConfig section only to handle, for example, disabled interfaces.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
