### PR TITLE
MGMT-18702: Fix error due to missing local cluster name

### DIFF
--- a/internal/controller/controllers/local_cluster_import_controller.go
+++ b/internal/controller/controllers/local_cluster_import_controller.go
@@ -330,6 +330,10 @@ func (r *LocalClusterImportReconciler) hasLocalManagedCluster(ctx context.Contex
 // If they are present, they will be deleted
 // No error will be returned if these are not found as this is the desired state.
 func (r *LocalClusterImportReconciler) ensureLocalClusterCRsDeleted(ctx context.Context) error {
+	if r.localClusterName == "" {
+		r.log.Infof("skipping local cluster import cleanup as feature has not previously been enabled")
+		return nil
+	}
 	err := r.deleteClusterDeployment(ctx, r.localClusterName, r.localClusterName)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		r.log.Errorf("could not delete local cluster ClusterDeployment due to error %s", err.Error())


### PR DESCRIPTION
When the local cluster name could not be resolved, we inadvertantly try to clean it up. This issue addresses that by ensuring we do not attempt cleanup in the absence of a name derived from ManagedCluster

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
