### PR TITLE
OCPBUGS-32803: Remove setting of staticNetwork in agent-based installer registration

### DIFF
--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -154,14 +154,9 @@ func RegisterInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 			return nil, nmStateErr
 		}
 
-		staticNetworkConfig, processErr := processNMStateConfig(log, infraEnv, nmStateConfig)
+		_, processErr := processNMStateConfig(log, infraEnv, nmStateConfig)
 		if processErr != nil {
 			return nil, processErr
-		}
-
-		if len(staticNetworkConfig) > 0 {
-			log.Infof("Added %d nmstateconfigs", len(staticNetworkConfig))
-			infraEnvParams.InfraenvCreateParams.StaticNetworkConfig = staticNetworkConfig
 		}
 	}
 

--- a/subsystem/agent_based_installer_client_test.go
+++ b/subsystem/agent_based_installer_client_test.go
@@ -37,7 +37,6 @@ var _ = Describe("RegisterClusterAndInfraEnv", func() {
 		Expect(registerInfraEnvErr).NotTo(HaveOccurred())
 		Expect(*modelInfraEnv.Name).To(Equal("myinfraenv"))
 		Expect(modelInfraEnv.ClusterID).To(Equal(*modelCluster.ID))
-		Expect(len(modelInfraEnv.StaticNetworkConfig)).ToNot(BeZero())
 	})
 
 	It("InstallConfig override good flow", func() {
@@ -60,7 +59,6 @@ var _ = Describe("RegisterClusterAndInfraEnv", func() {
 		Expect(registerInfraEnvErr).NotTo(HaveOccurred())
 		Expect(*modelInfraEnv.Name).To(Equal("myinfraenv"))
 		Expect(modelInfraEnv.ClusterID).To(Equal(*modelCluster.ID))
-		Expect(len(modelInfraEnv.StaticNetworkConfig)).ToNot(BeZero())
 	})
 
 	It("missing one of the ZTP manifests", func() {


### PR DESCRIPTION
When registering the agent-based installer with assisted-service, remove the setting of the nmstate info and thus the validations run by assisted-service. Its not required for this field to be set and can cause problems if the nmstate versions used for installer and assisted-service are different.

Confirmed agent-based installer installations succeed when this setting is removed. 
Note that this does not affect the use of static networking in the agent-based installer.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
