### PR TITLE
MGMT-18635: Restore missing Host by Agent CR

### DIFF
--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -70,6 +70,20 @@ func (mr *MockInstallerInternalsMockRecorder) CancelInstallationInternal(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelInstallationInternal", reflect.TypeOf((*MockInstallerInternals)(nil).CancelInstallationInternal), arg0, arg1)
 }
 
+// CreateHostInKubeKeyNamespace mocks base method.
+func (m *MockInstallerInternals) CreateHostInKubeKeyNamespace(arg0 context.Context, arg1 types.NamespacedName, arg2 *models.Host) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateHostInKubeKeyNamespace", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateHostInKubeKeyNamespace indicates an expected call of CreateHostInKubeKeyNamespace.
+func (mr *MockInstallerInternalsMockRecorder) CreateHostInKubeKeyNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHostInKubeKeyNamespace", reflect.TypeOf((*MockInstallerInternals)(nil).CreateHostInKubeKeyNamespace), arg0, arg1, arg2)
+}
+
 // DeregisterClusterInternal mocks base method.
 func (m *MockInstallerInternals) DeregisterClusterInternal(arg0 context.Context, arg1 *common.Cluster) error {
 	m.ctrl.T.Helper()

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -32,6 +32,7 @@ import (
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	. "github.com/openshift/assisted-service/api/common"
+	"github.com/openshift/assisted-service/api/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
@@ -65,6 +66,7 @@ import (
 const (
 	AgentFinalizerName                   = "agent." + aiv1beta1.Group + "/ai-deprovision"
 	AgentSkipSpokeCleanupAnnotation      = "agent." + aiv1beta1.Group + "/skip-spoke-cleanup"
+	AgentStateAnnotation                 = "agent." + aiv1beta1.Group + "/state"
 	BaseLabelPrefix                      = aiv1beta1.Group + "/"
 	InventoryLabelPrefix                 = "inventory." + BaseLabelPrefix
 	AgentLabelHasNonrotationalDisk       = InventoryLabelPrefix + "storage-hasnonrotationaldisk"
@@ -145,7 +147,14 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 	h, err := r.Installer.GetHostByKubeKey(req.NamespacedName)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return r.deleteAgent(ctx, log, req.NamespacedName)
+			// Restoring the Host according to values from Agent
+			if err = r.restoreHostByAgent(ctx, agent); err != nil {
+				log.WithError(err).Errorf("failed to restore Host %s according to the Agent", agent.Name)
+				return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+			}
+			// Requeuing as the associated Host should exist now
+			log.Infof("Restored a Host for agent %s", agent.Name)
+			return ctrl.Result{Requeue: true}, nil
 		} else {
 			log.WithError(err).Errorf("failed to retrieve Host %s from backend", agent.Name)
 			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
@@ -162,6 +171,13 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 
 	if err = r.setInfraEnvNameLabel(ctx, log, h, agent); err != nil {
 		log.WithError(err).Warnf("failed to set infraEnv name label on agent %s/%s", agent.Namespace, agent.Name)
+	}
+
+	// Add/Update 'state' annotation (with host's status)
+	if setAgentAnnotation(log, agent, AgentStateAnnotation, swag.StringValue(h.Status)) {
+		if err = r.updateAndReplaceAgent(ctx, agent); err != nil {
+			log.WithError(err).Warnf("failed to set state annotation on agent %s/%s", agent.Namespace, agent.Name)
+		}
 	}
 
 	if agent.Spec.ClusterDeploymentName == nil && h.ClusterID != nil {
@@ -662,20 +678,6 @@ func (r *AgentReconciler) unbindHost(ctx context.Context, log logrus.FieldLogger
 	}
 
 	return r.updateStatus(ctx, log, agent, origAgent, &host.Host, h.ClusterID, nil, true)
-}
-
-func (r *AgentReconciler) deleteAgent(ctx context.Context, log logrus.FieldLogger, agent types.NamespacedName) (ctrl.Result, error) {
-	agentToDelete := &aiv1beta1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      agent.Name,
-			Namespace: agent.Namespace,
-		},
-	}
-	if delErr := r.Client.Delete(ctx, agentToDelete); delErr != nil {
-		log.WithError(delErr).Errorf("Failed to delete resource %s %s", agent.Name, agent.Namespace)
-		return ctrl.Result{Requeue: true}, delErr
-	}
-	return ctrl.Result{}, nil
 }
 
 func (r *AgentReconciler) deregisterHostIfNeeded(ctx context.Context, log logrus.FieldLogger, key types.NamespacedName) (ctrl.Result, error) {
@@ -1760,4 +1762,94 @@ func (r *AgentReconciler) updateHostInstallProgress(ctx context.Context, host *m
 			CurrentStage: stage},
 	})
 	return err
+}
+
+func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, agent *aiv1beta1.Agent) error {
+	// Get InfraEnv
+	infraEnvName, exist := agent.Labels[aiv1beta1.InfraEnvNameLabel]
+	if !exist {
+		r.Log.Errorf("Failed to find infraEnv name for agent %s in namespace %s", agent.Name, agent.Namespace)
+		return errors.New("Missing InfraEnv name label")
+	}
+	key := types.NamespacedName{
+		Name:      infraEnvName,
+		Namespace: agent.Namespace,
+	}
+	infraEnv, err := r.Installer.GetInfraEnvByKubeKey(key)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			r.Log.WithError(err).Errorf("InfraEnv with name '%s' is missing", infraEnvName)
+			return err
+		}
+		r.Log.WithError(err).Errorf("Failed to get InfraEnv with name '%s'", infraEnvName)
+		return err
+	}
+
+	// Get associated cluster if available
+	var clusterID *strfmt.UUID
+	var cluster *common.Cluster
+	if agent.Spec.ClusterDeploymentName != nil {
+		clusterKey := types.NamespacedName{
+			Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+			Name:      agent.Spec.ClusterDeploymentName.Name,
+		}
+		cluster, err = r.Installer.GetClusterByKubeKey(clusterKey)
+		if err != nil {
+			r.Log.WithError(err).Errorf("Failed to get cluster (name: %s namespace: %s)",
+				agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
+			return err
+		}
+		clusterID = cluster.ID
+	}
+
+	host, err := createNewHost(agent, clusterID, *infraEnv.ID)
+	if err != nil {
+		r.Log.WithError(err).Errorf("Failed to create Host with name '%s'", agent.Name)
+		return err
+	}
+
+	return r.Installer.CreateHostInKubeKeyNamespace(ctx, key, host)
+}
+
+func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strfmt.UUID) (*models.Host, error) {
+	// Create Intentory
+	hostInventory := models.Inventory{}
+	manufacturer, exist := agent.Labels[AgentLabelHostManufacturer]
+	if exist {
+		hostInventory.SystemVendor = &models.SystemVendor{}
+		hostInventory.SystemVendor.Manufacturer = manufacturer
+	}
+	inventory, err := json.Marshal(hostInventory)
+	if err != nil {
+		return nil, errors.New("Failed to marshal agent's inventory")
+	}
+
+	// Fetch State
+	var hostStatus string
+	if state, has_annotation := agent.GetAnnotations()[AgentStateAnnotation]; has_annotation {
+		hostStatus = state
+	} else {
+		if clusterID != nil {
+			hostStatus = models.HostStatusKnown
+		} else {
+			hostStatus = models.HostStatusKnownUnbound
+		}
+	}
+
+	// Create Host model
+	hostID := strfmt.UUID(agent.Name)
+	host := &models.Host{
+		ID:            &hostID,
+		Kind:          swag.String(models.HostKindHost),
+		RegisteredAt:  strfmt.DateTime(agent.CreationTimestamp.Time),
+		CheckedInAt:   strfmt.DateTime(agent.CreationTimestamp.Time),
+		Role:          agent.Spec.Role,
+		SuggestedRole: agent.Spec.Role,
+		ClusterID:     clusterID,
+		InfraEnvID:    infraEnvID,
+		Status:        &hostStatus,
+		Inventory:     string(inventory),
+	}
+
+	return host, nil
 }


### PR DESCRIPTION
When applying an Agent CR with a missing associated host, the Agnet CR is currently being deleted by the reconciler. This scenario would happen on restore to a new hub flows since the host is a DB only entity.

Thus, this change introduces handling of a missing host by restoring the object into DB according to properties from the Agent CR.
For restoring the host's status, added 'state' annotation to the agent which is set on reconcile.

See full flow and more details in the enhancement: https://github.com/openshift/assisted-service/blob/master/docs/enhancements/backup-restore-support.md#solution-for-deleted-agent-crs

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
