### PR TITLE
MGMT-14634: Ensure that nil values and empty values for filenames are handled correctly.

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -74,7 +74,7 @@ func (m *Manifests) CreateClusterManifestInternal(ctx context.Context, params op
 	}
 
 	var manifestContent []byte
-	manifestContent, err = m.decodeUserSuppliedManifest(ctx, params.ClusterID, *params.CreateManifestParams.Content)
+	manifestContent, err = m.decodeUserSuppliedManifest(ctx, params.ClusterID, params.CreateManifestParams.Content, path)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (m *Manifests) UpdateClusterManifestInternal(ctx context.Context, params op
 
 	var content []byte
 	if params.UpdateManifestParams.UpdatedContent != nil {
-		content, err = m.decodeUserSuppliedManifest(ctx, params.ClusterID, *params.UpdateManifestParams.UpdatedContent)
+		content, err = m.decodeUserSuppliedManifest(ctx, params.ClusterID, params.UpdateManifestParams.UpdatedContent, srcPath)
 		if err != nil {
 			return nil, err
 		}
@@ -521,8 +521,14 @@ func isValidYaml(manifestContent []byte) error {
 	return nil
 }
 
-func (m *Manifests) decodeUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, manifest string) ([]byte, error) {
-	manifestContent, err := base64.StdEncoding.DecodeString(manifest)
+func (m *Manifests) decodeUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, manifest *string, filename string) ([]byte, error) {
+	if manifest == nil {
+		return nil, m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s is nil", filename, string(clusterID)))
+	}
+	if strings.Trim(swag.StringValue(manifest), " ") == "" {
+		return nil, m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s is empty", filename, string(clusterID)))
+	}
+	manifestContent, err := base64.StdEncoding.DecodeString(swag.StringValue(manifest))
 	if err != nil {
 		return nil, m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("failed to base64-decode cluster manifest content for cluster %s", string(clusterID)))
 	}


### PR DESCRIPTION
Presently if an empyty filename is passed or if the filename is nil, the code may panic This PR addresses that by adding suitable validations to ensure these panics do not occur.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
