### PR TITLE
MGMT-18645: Ensure CA bundle exists before assisted-service

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
@@ -96,6 +96,14 @@ var _ = Describe("Agent service config controller storage validation", func() {
 			Client:    client,
 			Namespace: "assisted-installer",
 		}
+		clusterTrustedCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterCAConfigMapName,
+				Namespace: reconciler.Namespace,
+			},
+			Data: map[string]string{caBundleKey: "example-cluster-trusted-bundle"},
+		}
+		Expect(client.Create(ctx, clusterTrustedCM)).To(Succeed())
 	})
 
 	AfterEach(func() {

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -820,6 +820,19 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 		Expect(cm.Data[caBundleKey]).To(Equal(testClusterCert + "\n" + testUserCert))
 	})
 
+	It("should fail if the cluster trusted CA does not have the CA bundle key", func() {
+		clusterCACM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterCAConfigMapName,
+				Namespace: ascr.Namespace,
+			},
+		}
+		ascr = newTestReconciler(asc, ingressCM, route, imageRoute, clusterCACM)
+		_, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal(fmt.Sprintf("waiting for cluster trusted CA bundle to be injected in config map %s", clusterCAConfigMapName)))
+	})
+
 	Context("IPXE routes", func() {
 		var (
 			imageServiceStatefulSet *appsv1.StatefulSet

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
@@ -208,6 +208,16 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		},
 	}
 
+	clusterTrustedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterCAConfigMapName,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			caBundleKey: "example-cluster-trusted-bundle",
+		},
+	}
+
 	konnectivity := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "konnectivity-agent",
@@ -270,7 +280,7 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		crd = newAgentInstallCRD()
 		imageServiceStatefulSet = newImageServiceStatefulSet(*hsc.Spec.ImageStorage)
 		hr = newHSCTestReconciler(mockSpokeClientCache, hsc,
-			kubeconfigSecret, crd, ingressCM, route, imageRoute, imageServiceStatefulSet, service, konnectivity, openshift_service_ca)
+			kubeconfigSecret, crd, ingressCM, route, imageRoute, imageServiceStatefulSet, service, konnectivity, openshift_service_ca, clusterTrustedCM)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
A race condition exists where the assisted-service deployment mounts
the assisted-service trusted ca bundle config map before it contains
anything. This can cause the certificate validation to fail when
using mirror registries because the ca bundle is empty.

This adds a check to make sure the ca bundle config map contains a value
before creating the assisted-service deployment.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 