### PR TITLE
OCPBUGS-32592: Add detached annotation to prevent unbinding Agent

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -65,6 +65,7 @@ import (
 const (
 	AgentFinalizerName                   = "agent." + aiv1beta1.Group + "/ai-deprovision"
 	AgentSkipSpokeCleanupAnnotation      = "agent." + aiv1beta1.Group + "/skip-spoke-cleanup"
+	AgentDetachedAnnotation              = "agent." + aiv1beta1.Group + "/detached-agent"
 	BaseLabelPrefix                      = aiv1beta1.Group + "/"
 	InventoryLabelPrefix                 = "inventory." + BaseLabelPrefix
 	AgentLabelHasNonrotationalDisk       = InventoryLabelPrefix + "storage-hasnonrotationaldisk"
@@ -624,6 +625,10 @@ func (r *AgentReconciler) runReclaimAgent(ctx context.Context, log logrus.FieldL
 }
 
 func (r *AgentReconciler) unbindHost(ctx context.Context, log logrus.FieldLogger, agent, origAgent *aiv1beta1.Agent, h *common.Host) (ctrl.Result, error) {
+	if detached := origAgent.Annotations[AgentDetachedAnnotation]; detached == "true" {
+		log.Info("Not unbinding Agent since detached annotation is set")
+		return ctrl.Result{}, nil
+	}
 	var reclaim bool
 
 	// log and don't reclaim if anything fails here

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -269,6 +269,10 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if agent != nil && agentIsUnbindingPendingUserAction(agent) {
+		if detached := agent.Annotations[AgentDetachedAnnotation]; detached == "true" {
+			log.Info("Not unbinding Agent and BMH because detached annotation is set")
+			return ctrl.Result{}, nil
+		}
 		result = reconcileUnboundAgent(log, bmh, r.ConvergedFlowEnabled)
 		if res := r.handleReconcileResult(ctx, log, result, bmh); res != nil {
 			return res.Result()


### PR DESCRIPTION
In the hypershift case, when we're simulating deleting clusters from a user's perspective, it removes the ClusterDeployment the Agents are bound to, and that causes the Agents to begin unbinding. This adds an annotation that, when present, prevents the Agent from going through unbinding in both BMH scenario and BIY scenario.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) - will do manual test and update here 
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 