### PR TITLE
MGMT-18466: moving to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,96 +1,18 @@
----
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /api
+    directories: [ "/", "/api", "/client", "/models" ]
     schedule:
-      interval: daily
-    labels:
-      - approved
-      - lgtm
-      - dependabot
-      - go
-    commit-message:
-      prefix: NO-ISSUE
+      interval: "daily"
     groups:
-      go-minor-api-dependencies:
+      go-security-dependencies:
+        applies-to: security-updates
         patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-      go-major-api-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - major
-
-  - package-ecosystem: gomod
-    directory: /client
-    schedule:
-      interval: daily
+          - "*"  
     labels:
-      - approved
-      - lgtm
-      - dependabot
-      - go
+      - "approved"
+      - "lgtm"
+      - "go"
+      - "dependabot"
     commit-message:
-      prefix: NO-ISSUE
-    groups:
-      go-minor-client-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-      go-major-client-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - major
-          
-  - package-ecosystem: gomod
-    directory: /models
-    schedule:
-      interval: daily
-    labels:
-      - approved
-      - lgtm
-      - dependabot
-      - go
-    commit-message:
-      prefix: NO-ISSUE
-    groups:
-      go-minor-models-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-      go-major-models-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - approved
-      - lgtm
-      - dependabot
-      - go
-    commit-message:
-      prefix: NO-ISSUE
-    groups:
-      go-minor-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-      go-major-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - major
+      prefix: "NO-ISSUE"


### PR DESCRIPTION
Moving depndabot to security updates only due for the following issues
1. updates the Golang versions 
2. breaking code changes 
3. some URL's stop  working when using `go get -u`


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
