### PR TITLE
MGMT-18579: Remove generateConfiguration call and its associated error check

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -128,12 +128,6 @@ func (s *StaticNetworkConfigGenerator) GenerateStaticNetworkConfigDataYAML(stati
 	}
 
 	for i, hostConfig := range staticNetworkConfig {
-		// We currently use this to validate the YAML file only
-		_, err = s.generateConfiguration(hostConfig.NetworkYaml)
-		if err != nil {
-			return nil, err
-		}
-
 		nmpolicy, err := s.injectNMPolicyCaptures(hostConfig)
 		if err != nil {
 			return nil, err

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -592,17 +592,6 @@ var _ = Describe("StaticNetworkConfig.GenerateStaticNetworkConfigDataYAML - gene
 	escapedYamlContent, err := escapeYAMLForJSON(hostYAML)
 	Expect(err).NotTo(HaveOccurred())
 
-	It("Fail with an empty host YAML", func() {
-		_, err := staticNetworkGenerator.GenerateStaticNetworkConfigDataYAML(`[{"network_yaml": ""}]`)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("Fail with an invalid host YAML", func() {
-		_, err := staticNetworkGenerator.GenerateStaticNetworkConfigDataYAML(`[{"network_yaml": "interfaces:\n    - foo: badConfig"}]`)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("InvalidArgument"))
-	})
-
 	It("Success - without ini file", func() {
 
 		config, err := staticNetworkGenerator.GenerateStaticNetworkConfigDataYAML(fmt.Sprintf(hostsYAML, escapedYamlContent))


### PR DESCRIPTION
I removed the execution of generateConfiguration and its associated error check in GenerateStaticNetworkConfigDataYAML because it is not needed at this stage of the code. The validation, where it is required, already handles this.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
