### PR TITLE
MGMT-16437: drop platform_is_external column

### DIFF
--- a/internal/migrations/20240918161800_drop_cluster_platform_is_external.go
+++ b/internal/migrations/20240918161800_drop_cluster_platform_is_external.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func dropClusterPlatformIsExternal() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		var err error
+
+		if err = tx.Exec("ALTER TABLE clusters DROP COLUMN IF EXISTS platform_is_external").Error; err != nil {
+			return err
+		}
+		return nil
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		// No rollback because automigrate will add the column back for a source version with the column
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20240918161800",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/20240918161800_drop_cluster_platform_is_external_test.go
+++ b/internal/migrations/20240918161800_drop_cluster_platform_is_external_test.go
@@ -1,0 +1,41 @@
+package migrations
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("dropClusterPlatformIsExternal", func() {
+	var (
+		db     *gorm.DB
+		dbName string
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("succeeds when the platform_is_external column is present", func() {
+		Expect(migrateToBefore(db, "20240918161800")).To(Succeed())
+
+		Expect(db.Exec("ALTER TABLE clusters ADD COLUMN IF NOT EXISTS platform_is_external BOOLEAN").Error).ToNot(HaveOccurred())
+		Expect(db.Migrator().HasColumn("clusters", "platform_is_external")).To(BeTrue())
+
+		Expect(migrateTo(db, "20240918161800")).To(Succeed())
+		Expect(db.Migrator().HasColumn("clusters", "platform_is_external")).To(BeFalse())
+	})
+
+	It("succeeds when the platform_is_external column is not present", func() {
+		Expect(migrateToBefore(db, "20240918161800")).To(Succeed())
+		Expect(db.Migrator().HasColumn("clusters", "platform_is_external")).To(BeFalse())
+
+		Expect(migrateTo(db, "20240918161800")).To(Succeed())
+		Expect(db.Migrator().HasColumn("clusters", "platform_is_external")).To(BeFalse())
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -44,6 +44,7 @@ func post() []*gormigrate.Migration {
 		deleteEventsWithUnboundCluster(),
 		dropClusterApiVipAndIngressVip(),
 		updateOciToExternalPlatformType(),
+		dropClusterPlatformIsExternal(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })


### PR DESCRIPTION
`platform_is_external` is a left over of the development of the external
platform. Its usage was removed with https://github.com/openshift/assisted-service/pull/5787/files#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L5394-L5399
more than half a year ago.
