### PR TITLE
NO-ISSUE: Add Dedent function

### DIFF
--- a/internal/common/dedent.go
+++ b/internal/common/dedent.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Dedent removes from the given string all the whitespace that is common to all the lines.
+func Dedent(s string) string {
+	// Handle the special case of the empty string:
+	if len(s) == 0 {
+		return s
+	}
+
+	// Split the text into lines, and remember if the last line ended with the end of the
+	// string, as we will need to know that in order to decide if we should add a trailing end
+	// of line when joining the modified lines.
+	var lines []string
+	buffer := &strings.Builder{}
+	for _, r := range s {
+		if r == '\n' {
+			lines = append(lines, buffer.String())
+			buffer.Reset()
+		} else {
+			buffer.WriteRune(r)
+		}
+	}
+	eos := buffer.Len() > 0
+	if eos {
+		lines = append(lines, buffer.String())
+	}
+
+	// Calculate the set of blank space prefixes set for all the non empty lines, and replace
+	// blan lines with empty strings:
+	set := map[string]bool{}
+	for i, line := range lines {
+		index := strings.IndexFunc(line, func(r rune) bool {
+			return !unicode.IsSpace(r)
+		})
+		if index != -1 {
+			prefix := line[0:index]
+			set[prefix] = true
+		} else {
+			lines[i] = ""
+		}
+	}
+
+	// Sort the prefixes by length, from longest to shortest:
+	list := make([]string, len(set))
+	i := 0
+	for prefix := range set {
+		list[i] = prefix
+		i++
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return len(list[i]) > len(list[j])
+	})
+
+	// Find the the length of the longest prefix (first in the sorted list) that is a prefix of
+	// all the non empty lines:
+	var length int
+	for _, prefix := range list {
+		i := 0
+		for _, line := range lines {
+			if len(line) > 0 && !strings.HasPrefix(line, prefix) {
+				break
+			}
+			i++
+		}
+		if i == len(lines) {
+			length = len(prefix)
+			break
+		}
+	}
+
+	// Remove the longest prefix from all the non empty lines:
+	for i, line := range lines {
+		if len(line) > 0 {
+			lines[i] = line[length:]
+		}
+	}
+
+	// Join the lines:
+	buffer.Reset()
+	for i, line := range lines {
+		if i > 0 {
+			buffer.WriteString("\n")
+		}
+		buffer.WriteString(line)
+	}
+	if !eos {
+		buffer.WriteString("\n")
+	}
+	return buffer.String()
+}

--- a/internal/common/dedent_test.go
+++ b/internal/common/dedent_test.go
@@ -1,0 +1,109 @@
+package common
+
+import (
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable(
+	"Dedent",
+	func(input, expected string) {
+		actual := Dedent(input)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry(
+		"Empty",
+		"",
+		"",
+	),
+	Entry(
+		"Line break",
+		"\n",
+		"\n",
+	),
+	Entry(
+		"One line without line break",
+		"first line",
+		"first line",
+	),
+	Entry(
+		"One line with line break",
+		"first line\n",
+		"first line\n",
+	),
+	Entry(
+		"Two lines with one line break",
+		"first line\nsecond line",
+		"first line\nsecond line",
+	),
+	Entry(
+		"Two lines with one line break",
+		"first line\nsecond line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"Trailing blank line without line break",
+		"first line\n ",
+		"first line\n",
+	),
+	Entry(
+		"Leading blank line",
+		" \nfirst line\n",
+		"\nfirst line\n",
+	),
+	Entry(
+		"One leading space",
+		" first line\n second line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"Multiple leading spaces",
+		"  first line\n  second line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"One leading tab",
+		"\tfirst line\n\tsecond line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"Multiple leading tabs",
+		"\t\tfirst line\n\t\tsecond line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"Mix of leading spaces and tabs",
+		"\t first line\n\t second line\n",
+		"first line\nsecond line\n",
+	),
+	Entry(
+		"One empty line in the middle",
+		"  first line\n\n  second line\n",
+		"first line\n\nsecond line\n",
+	),
+	Entry(
+		"Multiple empty lines in the middle",
+		"  first line\n\n\n  second line\n",
+		"first line\n\n\nsecond line\n",
+	),
+	Entry(
+		"Two prefixes of different lengths",
+		"  first line\n second line\n",
+		" first line\nsecond line\n",
+	),
+	Entry(
+		"Two prefixes of different lengths (reversed)",
+		" first line\n  second line\n",
+		"first line\n second line\n",
+	),
+	Entry(
+		"Line with one trailing space",
+		"first line \n",
+		"first line \n",
+	),
+	Entry(
+		"Line with two trailing space",
+		"first line  \n",
+		"first line  \n",
+	),
+)


### PR DESCRIPTION
This patch adds a new `common.Dedent` function that removes all common leading white space from strings. This is intended for situations where it is convenient to include JSON or YAML documents inside Go code, but it is cumbersome to have very long lines or concatenation of strings.

Note that this code has been copied from here: https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/tree/main/ztp/internal/text

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

Tested with the included unit tests.

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
