### PR TITLE
MGMT-17230: Update scripts and docs to use IDMS instead of ICSP

### DIFF
--- a/deploy/podman/README-disconnected.md
+++ b/deploy/podman/README-disconnected.md
@@ -161,7 +161,10 @@ You will apply this file as a part of the [Build/Deploy a Cluster](#builddeploy-
 
 ## Build/Deploy a Cluster
 
-At this point, you can now follow standard Assisted Installer workflows to create a cluster. Keep in mind that you will need to add your mirror registry certificate to the install_config as and _additionalTrustBundle_ well as add the _imageContentSources_ that define your mirror registry. The process that you use to do this will vary based on if you are using the Assisted Installer Web UI, via all api calls, or using [aicli](https://github.com/karmab/aicli).
+At this point, you can now follow standard Assisted Installer workflows to create a cluster. Keep in mind that you will need to add your mirror registry certificate to the install_config as and _additionalTrustBundle_ well as add the _imageDigestSources_[^icsp_deprecated] that define your mirror registry. The process that you use to do this will vary based on if you are using the Assisted Installer Web UI, via all api calls, or using [aicli](https://github.com/karmab/aicli).
+
+[^icsp_deprecated]: For older versions of OpenShift, before 4.14, the name of the field for the mirror registry is
+    _imageContentSources_ instead of _imageDigestSources_.
 
 ### Using the Assisted Installer GUI
 
@@ -178,12 +181,15 @@ installconfig:
       -----BEGIN CERTIFICATE-----
       <contents of your signing certificate>
       -----END CERTIFICATE-----
-    imageContentSources:
+    imageDigestSources:
       <the values here are based on the output from the OpenShift mirror command>
 ignition_config_override: <contents of the discovery-ignition.json file created earlier>
 ```
 
-The values for the imageContentSources will be based on the output of the OpenShift mirror command that you used. See the "imageContentSourcePolicy.yaml" file that is generated after the successful creation of a mirror for the exact information that should go here.
+The values for the imageDigestSources[^icsp_deprecated] will be based on the output of the OpenShift mirror command that you used. See the "imageMirrorDigestSet.yaml"[^icsp_deprecated_2] file that is generated after the successful creation of a mirror for the exact information that should go here.
+
+[^icsp_deprecated_2]: Forolder versions of OpenShift, before 4.14, the name of the file is
+    `imageContentSourcePolicy.yaml` instead of `imageMirrorDigestSet.yaml`.
 
 ### Using the API
 
@@ -195,7 +201,7 @@ Follow the instructions [rest api getting started](https://github.com/openshift/
 
 Then use the instructions [Install Customization - Discovery Ignition](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/install-customization.md#discovery-ignition) to apply the discovery-ignition.json file created in the [Ignition Config Override](#ignition-config-override)
 
-Then use the instructions [Install Customization - Install Config](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/install-customization.md#install-config) to apply the _additionalTrustBundle_ and _imageContentSources_ to the OpenShift install_config.yaml.
+Then use the instructions [Install Customization - Install Config](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/install-customization.md#install-config) to apply the _additionalTrustBundle_ and _imageDigestSources_[^icsp_deprecated] to the OpenShift install_config.yaml.
 
 ## Appendix
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -251,9 +251,16 @@ A ConfigMap can be used to configure assisted service to create installations us
 
 Supplying this ConfigMap makes several changes to the installation flow and assisted-service deployment:
 - Changes the discovery image's ignition config such that `ca-bundle.crt` is written out to `/etc/pki/ca-trust/source/anchors/domain.crt` and `registries.conf` is written out to `/etc/containers/registries.conf`.
-- Changes the `install-config.yaml` file used to install a new cluster, with the contents of `ca-bundle.crt` added to `additionalTrustBundle` and with the registries defined `registries.conf` added to `imageContentSources` as mirrors.
-- The assisted-service pod converts the registries.conf into an imageContentSourcesPolicy file, and use it with the --icsp flag in a few `oc adm` commands run against the release image (executed from within the assisted-service pod itself).
+- Changes the `install-config.yaml` file used to install a new cluster, with the contents of `ca-bundle.crt` added to `additionalTrustBundle` and with the registries defined `registries.conf` added to `imageDigestSources`[^icsp_deprecated] as mirrors.
+- The assisted-service pod converts the registries.conf into an `ImageDigestMirrorSet` file, and use it with the `--idms-file`[^icsp_deprecated_2] flag in a few `oc adm` commands run against the release image (executed from within the assisted-service pod itself).
 - The certificate bundle is added to the list of trusted certs provided by the cluster. A combined ConfigMap is created which includes the provided bundle. This is mounted into the assisted-service pod at path `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`
+
+[^icsp_deprecated]: For older versions of OpenShift, before 4.14, the name of the field for the mirror registry is
+    _imageContentSources_ instead of _imageDigestSources_,
+
+[^icsp_deprecated_2]: For older versions of OpenShift, before 4.14, assisted service generates an
+    `ImageContentSourcePolicy` instead of an `ImageDigestMirrorSet`, and the flag is `--icsp-file` instead of
+    `--idms-file`.
 
 The ca-bundle.crt and registries.conf keys can be added individually or together.
 

--- a/docs/user-guide/cloud-with-mirror.md
+++ b/docs/user-guide/cloud-with-mirror.md
@@ -183,7 +183,7 @@ $ jq -n --arg BUNDLE "$(cat tls-ca-bundle-registry.pem)" --arg SECRET "$(cat pul
 '{
     "pullSecret": $SECRET,
     "additionalTrustBundle": $BUNDLE,
-    "imageContentSources": [
+    "imageDigestSources": [
         {
             "mirrors": [
                 "<mirror_host_name>:<mirror_host_port>/ocp4/openshift4"
@@ -199,6 +199,9 @@ $ jq -n --arg BUNDLE "$(cat tls-ca-bundle-registry.pem)" --arg SECRET "$(cat pul
     ]
 }| tojson' > $install_config_patch
 ```
+
+> **NOTE:** For older versions of OpenShift, before 4.14, the name of the fields for image mirrors is
+> `imageContentSources` instead of `imageDigestSources`.
 
 > **NOTE:** Make sure to update the "mirror_host_name" and "mirror_host_port" to reflect your local registry mirror
 ​


### PR DESCRIPTION
This patch updates scripts and documentation to use the `ImageDigestMirrorSet` instead of the deprecated
`ImageContentSourcePolicy` where possible. The deprecated behaviour is preserved to support versions of OpenShift older than 4.14.

Related: https://issues.redhat.com/browse/MGMT-17230
Related: https://github.com/openshift/enhancements/blob/master/enhancements/api-review/add-new-CRD-ImageDigestMirrorSet-and-ImageTagMirrorSet-to-config.openshift.io.mdTmp

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [X] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
