### PR TITLE
NO-ISSUE: Explicitly set DEBUG_SERVICE with true value to avoid unexplicit setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ else
 	EVENT_STREAMING_OPTIONS=
 endif
 
-ifdef DEBUG_SERVICE
+ifeq ("${DEBUG_SERVICE}", "true")
 	DEBUG_ARGS=-gcflags "all=-N -l"
 	DEBUG_PORT_OPTIONS= --port ${DEBUG_SERVICE_PORT} debug-port
 	UPDATE_IMAGE=update-debug-minimal
@@ -275,7 +275,7 @@ patch-service: load-image
 	$(KUBECTL) patch deployment assisted-service \
 		--type json \
 		-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "$(LOCAL_ASSISTED_SERVICE_IMAGE)"},{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}]'
-	if [ -n "${DEBUG_SERVICE}" ]; then \
+	if [ "${DEBUG_SERVICE}" == "true" ]; then \
 		$(MAKE) remove_assisted_service_deployment_liveness_probe set_assisted_service_deployment_replicas_to_one; \
 	fi
 	$(MAKE) restart_service_pods
@@ -410,7 +410,7 @@ deploy-service-for-subsystem-test: create-hub-cluster load-image
 		echo "Deploying assisted-service for subsystem tests in kube-api mode..."; \
 		skipper make enable-kube-api-for-subsystem; \
 	fi
-	if [ -n "${DEBUG_SERVICE}" ]; then \
+	if [ "${DEBUG_SERVICE}" == "true" ]; then \
 		$(MAKE) prepare_assisted_service_for_debug; \
 	fi
 	echo "assited service deployment for subsystem tests is ready"
@@ -432,7 +432,7 @@ deploy-on-openshift-ci:
 
 deploy-on-k8s: create-hub-cluster
 	skipper $(MAKE) deploy-all IP=$(shell ip route get 1 | sed 's/^.*src \([^ ]*\).*$$/\1/;q')
-	if [ "$(USE_LOCAL_SERVICE)" == "true" ] || [ -n "${DEBUG_SERVICE}" ]; then \
+	if [ "$(USE_LOCAL_SERVICE)" == "true" ] || [ "${DEBUG_SERVICE}" == "true" ]; then \
 		$(MAKE) patch-service; \
 	fi
 	skipper $(MAKE) deploy-ui


### PR DESCRIPTION
Conditioning a bash var according if it is set or not is a bad practice especially because we use multiple layers of variables setting in this scripts.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
