### PR TITLE
NO-ISSUE: Avoid ineffective log statements

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2684,7 +2684,7 @@ func (b *bareMetalInventory) updateNtpSources(params installer.V2UpdateClusterPa
 
 		if additionalNtpSourcesDefined && !pkgvalidations.ValidateAdditionalNTPSource(ntpSource) {
 			err := errors.Errorf("Invalid NTP source: %s", ntpSource)
-			log.WithError(err)
+			log.WithError(err).Error("Failed to validate additional NTP sources")
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 		updates["additional_ntp_source"] = ntpSource
@@ -2698,7 +2698,7 @@ func (b *bareMetalInventory) updateNtpSources(params installer.V2UpdateClusterPa
 
 func validateUserManagedNetworkConflicts(params *models.V2ClusterUpdateParams, log logrus.FieldLogger) error {
 	if err := validations.ValidateVIPsWereNotSetUserManagedNetworking(params.APIVips, params.IngressVips, swag.BoolValue(params.VipDhcpAllocation)); err != nil {
-		log.WithError(err)
+		log.WithError(err).Error("Failed to validate VIPs")
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
 	return nil
@@ -2800,7 +2800,7 @@ func (b *bareMetalInventory) updateClusterTags(params installer.V2UpdateClusterP
 	if params.ClusterUpdateParams.Tags != nil {
 		tags := swag.StringValue(params.ClusterUpdateParams.Tags)
 		if err := pkgvalidations.ValidateTags(tags); err != nil {
-			log.WithError(err)
+			log.WithError(err).Error("Failed to validate tags")
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 		updates["tags"] = tags
@@ -3900,7 +3900,7 @@ func (b *bareMetalInventory) GetCredentialsInternal(ctx context.Context, params 
 	if operatorscommon.HasOperator(cluster.Cluster.MonitoredOperators, operators.OperatorConsole.Name) {
 		if !b.clusterApi.IsOperatorAvailable(&cluster, operators.OperatorConsole.Name) {
 			err := errors.New("console-url isn't available yet, it will be once console operator is ready as part of cluster finalizing stage")
-			log.WithError(err)
+			log.WithError(err).Error("Failed to validate if operator is available")
 			return nil, common.NewApiError(http.StatusConflict, err)
 		}
 		consoleURL = common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain)
@@ -5215,7 +5215,7 @@ func (b *bareMetalInventory) updateInfraEnvNtpSources(params installer.UpdateInf
 
 		if additionalNtpSourcesDefined && !pkgvalidations.ValidateAdditionalNTPSource(ntpSource) {
 			err := errors.Errorf("Invalid NTP source: %s", ntpSource)
-			log.WithError(err)
+			log.WithError(err).Error("Failed to validate additional NTP sources")
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 		if ntpSource != infraEnv.AdditionalNtpSources {

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1367,7 +1367,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 
 	releaseImage, err := r.getReleaseImage(ctx, log, clusterInstall.Spec, pullSecret)
 	if err != nil {
-		log.WithError(err)
+		log.WithError(err).Error("Failed to get release image")
 		_, _ = r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
 		// The controller will requeue after one minute, giving the user a chance to fix releaseImage
 		return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -754,21 +754,21 @@ func newHypershiftWebHookAPIService(ctx context.Context, log logrus.FieldLogger,
 	data, ok := asc.properties["ca"]
 	if !ok {
 		err := pkgerror.Errorf("no ca data on context %v on namespace %s", asc.properties, asc.namespace)
-		log.WithError(err)
+		log.WithError(err).Error("Failed to create webhook API service")
 		return nil, nil, err
 	}
 
 	cmdata, ok := data.(map[string]string)
 	if !ok {
 		err := pkgerror.Errorf("bad format of ca context %v on namespace %s", asc.properties, asc.namespace)
-		log.WithError(err)
+		log.WithError(err).Error("Failed to create webhook API service")
 		return nil, nil, err
 	}
 
 	ca, ok := cmdata["service-ca.crt"]
 	if !ok {
 		err := pkgerror.Errorf("Missing ca certificate for API service on namespace %s", asc.namespace)
-		log.WithError(err)
+		log.WithError(err).Error("Failed to create webhook API service")
 		return nil, nil, err
 	}
 
@@ -785,7 +785,7 @@ func newKonnectivityAgentDeployment(ctx context.Context, log logrus.FieldLogger,
 	ka := &appsv1.Deployment{}
 	if e := asc.Client.Get(ctx, types.NamespacedName{Name: "konnectivity-agent", Namespace: asc.namespace}, ka); e != nil {
 		err := pkgerror.Wrap(e, fmt.Sprintf("Failed to retrieve konnectivity-agent Deployment from namespace %s", asc.namespace))
-		log.WithError(err)
+		log.WithError(err).Error("Failed to create konnectivity agent deployment")
 		return nil, nil, err
 	}
 	ka.ObjectMeta = metav1.ObjectMeta{


### PR DESCRIPTION
While debugging an issue where apparently there is no OpenShift version in the cluster I noticed that when retrieving that version from the release image we have a line like this to apparently report the error:

```go
log.WithError(err)
```

But that doesn't write anything to the log: it needs to be like this instead:

```go
log.WithError(err).Error("Some explanation of the error")
```

It isn't probably very important, but it is weird. This patch changes all the places where I found that construct (using `git grep -E '^\s+log\.WithError\(err\)$'`). Alternatively those lines could be removed.

Related: https://github.com/openshift/assisted-service/blob/3d57d098694c68a53f6cf7055f23d1b75d68ad6c/internal/controller/controllers/clusterdeployments_controller.go#L1370

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
