### PR TITLE
MGMT-19018: Use old static networking flow for VLAN as long as nmstate version < 2.2.30

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3708,7 +3708,14 @@ func (b *bareMetalInventory) DownloadMinimalInitrd(ctx context.Context, params i
 	if infraEnv.StaticNetworkConfig != "" {
 		// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 		var ok bool
-		ok, err = staticnetworkconfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+
+		var staticNetworkConfig []*models.HostStaticNetworkConfig
+		err = json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+		if err != nil {
+			return common.GenerateErrorResponder(errors.Wrapf(err, "Failed to JSON Unmarshal static network config %s", infraEnv.StaticNetworkConfig))
+		}
+
+		ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig)
 		if err != nil {
 			return common.GenerateErrorResponder(err)
 		}
@@ -5878,7 +5885,13 @@ func (b *bareMetalInventory) V2DownloadInfraEnvFiles(ctx context.Context, params
 		if infraEnv.StaticNetworkConfig != "" {
 			// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 			var ok bool
-			ok, err = staticnetworkconfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err = json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			if err != nil {
+				return common.GenerateErrorResponder(errors.Wrapf(err, "Failed to JSON Unmarshal static network config %s", infraEnv.StaticNetworkConfig))
+			}
+
+			ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig)
 			if err != nil {
 				return common.GenerateErrorResponder(err)
 			}

--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -302,7 +302,13 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 
 		// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 		var ok bool
-		ok, err = staticnetworkconfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+		var staticNetworkConfig []*models.HostStaticNetworkConfig
+		err = json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed to JSON Unmarshal static network config %s", infraEnv.StaticNetworkConfig)
+		}
+
+		ok, err = ib.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig)
 		if err != nil {
 			return "", err
 		}

--- a/internal/ignition/discovery_test.go
+++ b/internal/ignition/discovery_test.go
@@ -3,6 +3,7 @@ package ignition
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -500,7 +501,8 @@ var _ = Describe("IgnitionBuilder", func() {
 	})
 
 	Context("static network config", func() {
-		formattedInput := "some formated input"
+		formattedInput := `[{"network_yaml":"","mac_interface_map":[]}]`
+
 		// output for flow involving generating nmconnection files
 		staticnetworkConfigOutput := []staticnetworkconfig.StaticNetworkConfigData{
 			{
@@ -539,6 +541,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(false, nil).Times(1)
+
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -559,6 +567,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingNmstateService
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(true, nil).Times(1)
+
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -580,6 +594,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingNmstateService
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(false, nil).Times(1)
+
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -620,6 +640,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(false, nil).Times(1)
+
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -641,6 +667,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingNmstateService
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(true, nil).Times(1)
+
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -662,6 +694,12 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingNmstateService
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
+
+			var staticNetworkConfig []*models.HostStaticNetworkConfig
+			err := json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)
+			Expect(err).NotTo(HaveOccurred())
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, staticNetworkConfig).Return(false, nil).Times(1)
+
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/staticnetworkconfig/backward_compatibility.go
+++ b/pkg/staticnetworkconfig/backward_compatibility.go
@@ -1,14 +1,3 @@
 package staticnetworkconfig
 
-import "github.com/openshift/assisted-service/internal/common"
-
 const MinimalVersionForNmstatectl = "4.14"
-
-func NMStatectlServiceSupported(version, arch string) (bool, error) {
-	versionOK, err := common.VersionGreaterOrEqual(version, MinimalVersionForNmstatectl)
-	if err != nil {
-		return false, err
-	}
-	// TODO: Remove the architecture condition after fetching the nmstatectl binary from rootfs.
-	return versionOK && arch == common.X86CPUArchitecture, nil
-}

--- a/pkg/staticnetworkconfig/mock_generator.go
+++ b/pkg/staticnetworkconfig/mock_generator.go
@@ -93,3 +93,16 @@ func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParamsYAML(st
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParamsYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParamsYAML), staticNetworkConfig, ocpVersion, arch, installerInvoker)
 }
+
+func (m *MockStaticNetworkConfig) NMStatectlServiceSupported(version, arch string, staticNetworkConfig []*models.HostStaticNetworkConfig) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NMStatectlServiceSupported", version, arch, staticNetworkConfig)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func(mr *MockStaticNetworkConfigMockRecorder) NMStatectlServiceSupported(version, arch string, staticNetworkConfig []*models.HostStaticNetworkConfig) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NMStatectlServiceSupported", reflect.TypeOf((*MockStaticNetworkConfig)(nil).NMStatectlServiceSupported), version, arch, staticNetworkConfig)
+}


### PR DESCRIPTION
1. Versions of nmstate prior to 2.2.30 do not work well with OVN, which may cause issues when VLAN is used for OVN (br-ex) configurations. Therefore, it has been decided to maintain the old flow whenever any interface in any configuration for any host includes VLAN.
2. Starting with nmstate 2.2.30, we use the interface name for the VLAN parent instead of the NM connection UUID.  

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
