### PR TITLE
NO-ISSUE: Remove failing NMState kube api test until it is fixed

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3417,34 +3417,6 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		checkAgentCondition(ctx, host.ID.String(), v1beta1.SpecSyncedCondition, v1beta1.BackendErrorReason)
 	})
 
-	It("deploy clusterDeployment and infraEnv and with an invalid NMState config YAML", func() {
-		var (
-			NMStateLabelName  = "someName"
-			NMStateLabelValue = "someValue"
-			nicPrimary        = "eth0"
-			nicSecondary      = "eth1"
-			macPrimary        = "09:23:0f:d8:92:AA"
-			macSecondary      = "09:23:0f:d8:92:AB"
-		)
-		nmstateConfigSpec := getDefaultNMStateConfigSpec(nicPrimary, nicSecondary, macPrimary, macSecondary, "foo: bar")
-		deployNMStateConfigCRD(ctx, kubeClient, "nmstate2", NMStateLabelName, NMStateLabelValue, nmstateConfigSpec)
-		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
-		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
-		installkey := types.NamespacedName{
-			Namespace: Options.Namespace,
-			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
-		}
-		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterNotReadyReason)
-		infraEnvSpec.NMStateConfigLabelSelector = metav1.LabelSelector{MatchLabels: map[string]string{NMStateLabelName: NMStateLabelValue}}
-		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
-		infraEnvKubeName := types.NamespacedName{
-			Namespace: Options.Namespace,
-			Name:      infraNsName.Name,
-		}
-		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, "Invalid YAML")
-	})
-
 	It("ensure StaticNetworkConfig is empty after NMStateConfig deletion", func() {
 		var (
 			NMStateLabelName  = "someName"


### PR DESCRIPTION
Due to a temporary issue, the kube-api subsystem tests passed falsely. Thus, masking the failure of `deploy clusterDeployment and infraEnv and with an invalid NMState config YAML`  in https://github.com/openshift/assisted-service/pull/6695. See [job](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-assisted-service-master-edge-subsystem-kubeapi-aws-periodic). To avoid blocking PRs, I am temporarily removing this test until it is fixed.

A follow up issue - https://issues.redhat.com/browse/MGMT-19027

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
