### PR TITLE
MGMT-19027: Fix failing kubeapi subsystem test invalid NMstate YAML

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -71,8 +71,15 @@ func (s *StaticNetworkConfigGenerator) injectIPV4V6FieldsIfNeeded(networkYaml st
 		s.log.WithError(err).Errorf("Error unmarshalling yaml")
 		return "", err
 	}
-	Interfaces := config["interfaces"].([]interface{})
-	for _, iface := range Interfaces {
+	interfaces, exists := config["interfaces"]
+	if !exists || interfaces == nil {
+		return "", nil
+	}
+	interfacesSlice, ok := interfaces.([]interface{})
+	if !ok {
+		return "", nil
+	}
+	for _, iface := range interfacesSlice {
 		nic := iface.(map[interface{}]interface{})
 		if val, exists := nic["ipv4"].(map[interface{}]interface{}); exists {
 			if _, exists := val["dhcp"]; !exists {
@@ -325,10 +332,18 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macIn
 
 	// See 'man systemd.net-naming-scheme' for interface naming protocol
 	predicatableIfaceNamePattern := regexp.MustCompile("^en[PsvxXbucaipod]")
-	Interfaces := config["interfaces"].([]interface{})
 	interfaceWithmacIdentifier := make(map[string]struct{})
 
-	for _, iface := range Interfaces {
+	interfaces, exists := config["interfaces"]
+	if !exists || interfaces == nil {
+		return nil
+	}
+	interfacesSlice, ok := interfaces.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, iface := range interfacesSlice {
 		nic := iface.(map[interface{}]interface{})
 		interfaceName, exists := nic["name"]
 		if !exists {
@@ -340,8 +355,7 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macIn
 			interfaceWithmacIdentifier[interfaceName.(string)] = struct{}{}
 		}
 	}
-
-	for _, iface := range Interfaces {
+	for _, iface := range interfacesSlice {
 		nic := iface.(map[interface{}]interface{})
 		interfaceName, exists := nic["name"]
 		if !exists {
@@ -400,6 +414,7 @@ func (s *StaticNetworkConfigGenerator) ValidateStaticConfigParamsYAML(staticNetw
 		_, validateErr := s.generateConfiguration(hostConfig.NetworkYaml)
 		if validateErr != nil {
 			err = multierror.Append(err, fmt.Errorf("failed to validate network yaml for host %d, %s", i, validateErr))
+			return err.ErrorOrNil()
 		}
 		err = multierror.Append(err, s.validateInterfaceNamesExistenceYAML(hostConfig.MacInterfaceMap, hostConfig.NetworkYaml, ocpVersion, arch, installInvoker))
 	}

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3419,7 +3419,33 @@ var _ = Describe("[kube-api]cluster installation", func() {
 
 		checkAgentCondition(ctx, host.ID.String(), v1beta1.SpecSyncedCondition, v1beta1.BackendErrorReason)
 	})
-
+	It("deploy clusterDeployment and infraEnv and with an invalid NMState config YAML", func() {
+		var (
+			NMStateLabelName  = "someName"
+			NMStateLabelValue = "someValue"
+			nicPrimary        = "eth0"
+			nicSecondary      = "eth1"
+			macPrimary        = "09:23:0f:d8:92:AA"
+			macSecondary      = "09:23:0f:d8:92:AB"
+		)
+		nmstateConfigSpec := getDefaultNMStateConfigSpec(nicPrimary, nicSecondary, macPrimary, macSecondary, "foo: bar")
+		deployNMStateConfigCRD(ctx, kubeClient, "nmstate2", NMStateLabelName, NMStateLabelValue, nmstateConfigSpec)
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterNotReadyReason)
+		infraEnvSpec.NMStateConfigLabelSelector = metav1.LabelSelector{MatchLabels: map[string]string{NMStateLabelName: NMStateLabelValue}}
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		infraEnvKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		// InfraEnv Reconcile takes longer, since it needs to generate the image.
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, "Invalid YAML")
+	})
 	It("ensure StaticNetworkConfig is empty after NMStateConfig deletion", func() {
 		var (
 			NMStateLabelName  = "someName"


### PR DESCRIPTION
This PR addresses the failing kubeapi test, follow-up [this](https://github.com/openshift/assisted-service/pull/6839) PR.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
