### PR TITLE
OCPBUGS-42275: abi add-nodes workflow: configure openshift version field when importing a cluster

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -256,7 +256,11 @@ func configure(ctx context.Context, log *log.Logger, bmInventory *client.Assiste
 }
 
 func importCluster(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall) {
-	err := envconfig.Process("", &ImportOptions)
+	err := envconfig.Process("", &RegisterOptions)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	err = envconfig.Process("", &ImportOptions)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -271,8 +275,13 @@ func importCluster(ctx context.Context, log *log.Logger, bmInventory *client.Ass
 		log.Fatal("No Cluster_API_VIP_DNS_Name specified")
 	}
 
+	pullSecret, err := agentbasedinstaller.GetPullSecret(RegisterOptions.PullSecretFile)
+	if err != nil {
+		log.Fatal("Failed to get pull secret: ", err.Error())
+	}
+
 	clusterID := strfmt.UUID(ImportOptions.ClusterID)
-	_, err = agentbasedinstaller.ImportCluster(ctx, log, bmInventory, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName, ImportOptions.ClusterConfigDir)
+	_, err = agentbasedinstaller.ImportCluster(ctx, log, bmInventory, pullSecret, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName, ImportOptions.ClusterConfigDir, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
 	if err != nil {
 		log.Fatal("Failed to import cluster with assisted-service: ", err)
 	}

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -984,6 +984,11 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		KubeKeyNamespace: kubeKey.Namespace,
 	}
 
+	if params.NewImportClusterParams.OpenshiftVersion != "" {
+		log.Infof("Import add-hosts-cluster: %s, version %s", clusterName, params.NewImportClusterParams.OpenshiftVersion)
+		newCluster.OpenshiftVersion = params.NewImportClusterParams.OpenshiftVersion
+	}
+
 	err := validations.ValidateClusterNameFormat(clusterName, getPlatformType(newCluster.Platform))
 	if err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -12641,7 +12641,6 @@ var _ = Describe("Register AddHostsCluster test", func() {
 			NewImportClusterParams: &models.ImportClusterParams{
 				APIVipDnsname:      &apiVIPDnsname,
 				Name:               &clusterName,
-				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
 				OpenshiftClusterID: &openshiftClusterID,
 			},
 		}
@@ -12653,6 +12652,33 @@ var _ = Describe("Register AddHostsCluster test", func() {
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
 		Expect(actual.Payload.OpenshiftVersion).To(BeEmpty())
+		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
+		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
+		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))
+	})
+
+	It("Create V2 AddHosts cluster (with version)", func() {
+		defaultHostNetworks := make([]*models.HostNetwork, 0)
+		defaultHosts := make([]*models.Host, 0)
+		openshiftClusterID := strfmt.UUID(uuid.New().String())
+
+		params := installer.V2ImportClusterParams{
+			HTTPRequest: request,
+			NewImportClusterParams: &models.ImportClusterParams{
+				APIVipDnsname:      &apiVIPDnsname,
+				Name:               &clusterName,
+				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
+				OpenshiftClusterID: &openshiftClusterID,
+			},
+		}
+		mockClusterApi.EXPECT().RegisterAddHostsCluster(ctx, gomock.Any()).Return(nil).Times(1)
+		mockMetric.EXPECT().ClusterRegistered().Times(1)
+		res := bm.V2ImportCluster(ctx, params)
+		actual := res.(*installer.V2ImportClusterCreated)
+
+		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
+		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))


### PR DESCRIPTION
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

### Note

The ABI add-nodes workflow has been impacted after the introduction of #6695, since the Openshift version was used for some validation.
This patch fixes the issue by:
- Configuring the OpenShift version  in the agent-install-client when importing a new cluster
- Using the OpenShift version field in the ImportClusterInternal, which was previously ignored