### PR TITLE
NO-ISSUE: Ensure that `openshift_version` isn't empty

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -202,7 +202,7 @@ type Cluster struct {
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`
 
 	// Version of the OpenShift cluster.
-	OpenshiftVersion string `json:"openshift_version,omitempty"`
+	OpenshiftVersion string `json:"openshift_version,omitempty" gorm:"not null;check:openshift_version <> ''"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -202,7 +202,7 @@ type Cluster struct {
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`
 
 	// Version of the OpenShift cluster.
-	OpenshiftVersion string `json:"openshift_version,omitempty"`
+	OpenshiftVersion string `json:"openshift_version,omitempty" gorm:"not null;check:openshift_version <> ''"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -202,7 +202,7 @@ type Cluster struct {
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`
 
 	// Version of the OpenShift cluster.
-	OpenshiftVersion string `json:"openshift_version,omitempty"`
+	OpenshiftVersion string `json:"openshift_version,omitempty" gorm:"not null;check:openshift_version <> ''"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6439,7 +6439,8 @@ func init() {
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
-          "type": "string"
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"not null;check:openshift_version \u003c\u003e ''\""
         },
         "org_id": {
           "type": "string"
@@ -17263,7 +17264,8 @@ func init() {
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
-          "type": "string"
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"not null;check:openshift_version \u003c\u003e ''\""
         },
         "org_id": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5150,6 +5150,7 @@ definitions:
       openshift_version:
         type: string
         description: Version of the OpenShift cluster.
+        x-go-custom-tag: gorm:"not null;check:openshift_version <> ''"
       ocp_release_image:
         type: string
         description: OpenShift release image URI.

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -202,7 +202,7 @@ type Cluster struct {
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`
 
 	// Version of the OpenShift cluster.
-	OpenshiftVersion string `json:"openshift_version,omitempty"`
+	OpenshiftVersion string `json:"openshift_version,omitempty" gorm:"not null;check:openshift_version <> ''"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`


### PR DESCRIPTION
We found a situation where the `openshift_version` column of the clusters table is empty. We haven't been able to understand why, but it results in an error when running validations. For example, the dual-stack VIP validation produces a false negative:

```
2024-09-11T05:39:04.055138029Z time="2024-09-11T05:39:04Z"
level=error
msg="Cluster 686c7849-8d68-4340-b81d-9add8c4261fe failed VIP validations"
func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).validateAndUpdateClusterParams"
file="/remote-source/assisted-service/app/internal/bminventory/inventory.go:1889"
error="dual-stack VIPs are not supported in OpenShift "
pkg=Inventory
```

Note how the error message doesn't contain the OpenShift version at the end. It should, as the code is like this:

```go
return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s %s", "dual-stack VIPs are not supported in OpenShift", cluster.OpenshiftVersion))
```

So we are assuming, at least in that code, that the `openshift_version` column is not empty.

This patch changes adds a database constraint to ensure that that `openshift_column` isn't null or empty. That doesn't address the root cause (because we don't know it) but at least it should catch situations where something tries to set that column empty.

Related: https://issues.redhat.com/browse/OCPBUGS-42059
Related: https://github.com/openshift/assisted-service/blob/e59df80246f418b62048d7252e4d79bf5723c81e/internal/cluster/validations/validations.go#L256

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
