### PR TITLE
NO-ISSUE: Don't use `subPath` in `pod-persistent-disconnected.yml`

### DIFF
--- a/deploy/podman/pod-persistent-disconnected.yml
+++ b/deploy/podman/pod-persistent-disconnected.yml
@@ -43,7 +43,6 @@ spec:
       - mountPath: /etc/containers
         name: mirror-registry-config
       - mountPath: /etc/pki/ca-trust/extracted/pem
-        subPath: tls-ca-bundle.pem
         name: mirror-registry-config
   restartPolicy: Never
   volumes:


### PR DESCRIPTION
Currently this pod definition uses a `subPath` to mount the CA bundle, but that isn't necessary and fails with this error:

```
starting container bcb65834269b94764596a6f4ee1a70fd2b1af8f424e724792c7b6a166ee13554: crun: mount `/run/containers/storage/overlay-containers/bcb65834269b94764596a6f4ee1a70fd2b1af8f424e724792c7b6a166ee13554/userdata/subpath360836111` to `etc/pki/ca-trust/extracted/pem`: Not a directory: OCI runtime error
```

This patch removes that incorrect line.

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None
- [X] Podman Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
