### PR TITLE
MGMT-19085: fix 'object has been modified' error in kubeapi subsystem

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -396,8 +396,15 @@ func deployBMHCRD(ctx context.Context, client k8sclient.Client, id string, spec 
 	err := client.Create(ctx, &bmh)
 	Expect(err).To(BeNil())
 
-	bmh.Status.Provisioning.State = metal3_v1alpha1.StateReady
-	Expect(client.Status().Update(ctx, &bmh)).To(BeNil())
+	bmhKey := types.NamespacedName{
+		Namespace: bmh.ObjectMeta.Namespace,
+		Name:      bmh.ObjectMeta.Name,
+	}
+	Eventually(func() error {
+		bmh = *getBmhCRD(ctx, client, bmhKey)
+		bmh.Status.Provisioning.State = metal3_v1alpha1.StateReady
+		return client.Status().Update(ctx, &bmh)
+	}, "30s", "10s").Should(BeNil())
 }
 
 func deployPPICRD(ctx context.Context, client k8sclient.Client, name string, spec *metal3_v1alpha1.PreprovisioningImageSpec) {
@@ -981,10 +988,23 @@ func cleanUpCRs(ctx context.Context, client k8sclient.Client) {
 		return client.DeleteAllOf(ctx, &v1beta1.Agent{}, k8sclient.InNamespace(Options.Namespace))
 	}, "1m", "2s").Should(BeNil())
 	Eventually(func() error {
+		return client.DeleteAllOf(ctx, &metal3_v1alpha1.PreprovisioningImage{}, k8sclient.InNamespace(Options.Namespace))
+	}, "1m", "2s").Should(BeNil())
+	Eventually(func() error {
 		return client.DeleteAllOf(ctx, &metal3_v1alpha1.BareMetalHost{}, k8sclient.InNamespace(Options.Namespace))
 	}, "1m", "2s").Should(BeNil())
 	Eventually(func() error {
-		return client.DeleteAllOf(ctx, &metal3_v1alpha1.PreprovisioningImage{}, k8sclient.InNamespace(Options.Namespace))
+		var err error
+		bareMetalHostList := &metal3_v1alpha1.BareMetalHostList{}
+		err = client.List(ctx, bareMetalHostList, k8sclient.InNamespace(Options.Namespace))
+		Expect(err).To(BeNil())
+		// Remove finalizers to avoid stuck BMHs
+		funk.ForEach(bareMetalHostList.Items, func(bmh metal3_v1alpha1.BareMetalHost) {
+			patch := k8sclient.MergeFrom(bmh.DeepCopy())
+			bmh.ObjectMeta.Finalizers = nil
+			err = client.Patch(ctx, &bmh, patch)
+		})
+		return err
 	}, "1m", "2s").Should(BeNil())
 
 	// Check if tests pull secret exists and needs to be deleted


### PR DESCRIPTION
Similar to https://github.com/openshift/assisted-service/pull/6850, fixed timing issue in kube-api test on BMH update. Also, removed BMH finalizers on cleanup.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
