### PR TITLE
MGMT-19129: Migrate assisted-service to Konflux

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -8,6 +8,8 @@ DOCKER_CONF="${PWD}/.docker"
 mkdir -p "${DOCKER_CONF}"
 docker --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
+docker tag "${ASSISTED_SERVICE_IMAGE}:${TAG}" "${ASSISTED_SERVICE_IMAGE}:${SHORT_TAG}"
 docker tag "${ASSISTED_SERVICE_IMAGE}:${TAG}" "${ASSISTED_SERVICE_IMAGE}:latest"
 docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${SHORT_TAG}"
 docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"

--- a/build_images.sh
+++ b/build_images.sh
@@ -5,7 +5,8 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-TAG=$(git rev-parse --short=7 HEAD)
+TAG=$(git rev-parse HEAD)
+SHORT_TAG=$(git rev-parse --short=7 HEAD)
 ASSISTED_SERVICE_IMAGE=quay.io/app-sre/assisted-service
 export SERVICE="${ASSISTED_SERVICE_IMAGE}:${TAG}"
 export CONTAINER_BUILD_EXTRA_PARAMS="--no-cache"


### PR DESCRIPTION
We want to change app-interface to deploy the images that Konflux builds and by default Konflux uses the full commit sha as the tag.
In order to avoid issues with telling app-interface to use the full commit sha, I am updating build_deploy.sh to push both the full sha and the short sha as image tags.

Part of [MGMT-19129](https://issues.redhat.com//browse/MGMT-19129)