### PR TITLE
OCPBUGS-42705: Use icsp/idms for oc commands instead of releaseMirror

### DIFF
--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -70,11 +70,7 @@ func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 	var workdir, binary, path string
 	var err error
 
-	releaseImageLocation := releaseID
-	if releaseIDMirror != "" {
-		releaseImageLocation = releaseIDMirror
-	}
-	workdir, binary, path, err = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir, ocpVersion)
+	workdir, binary, path, err = ocRelease.GetReleaseBinaryPath(releaseID, i.cacheDir, ocpVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -121,7 +121,7 @@ var _ = Describe("installer cache", func() {
 		fname := filepath.Join(workdir, releaseID)
 
 		mockRelease.EXPECT().GetReleaseBinaryPath(
-			releaseMirrorID, gomock.Any(), version).
+			releaseID, gomock.Any(), version).
 			Return(workdir, releaseID, fname, nil)
 		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
 			gomock.Any(), cacheDir, gomock.Any(), version).

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -390,12 +390,12 @@ var _ = Describe("oc", func() {
 
 		It("extract baremetal-install from release image mirror", func() {
 			command := fmt.Sprintf(templateExtract+" --registry-config=%s",
-				baremetalInstallBinary, filepath.Join(cacheDir, releaseImageMirror), true, releaseImageMirror, "", tempFilePath)
+				baremetalInstallBinary, filepath.Join(cacheDir, releaseImage), true, releaseImageMirror, "", tempFilePath)
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
 			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret, "4.15.0")
-			filePath := filepath.Join(cacheDir+"/"+releaseImageMirror, baremetalInstallBinary)
+			filePath := filepath.Join(cacheDir+"/"+releaseImage, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -540,7 +540,7 @@ var _ = Describe("getImageFromRelease", func() {
 							}
 							doneChan <- true
 						}()
-						ret, err := oc.getImageFromRelease(log, r.imageName, r.releaseName, "pull", false)
+						ret, err := oc.getImageFromRelease(log, r.imageName, r.releaseName, "", "pull")
 						Expect(err).ToNot(HaveOccurred())
 						Expect(ret).To(Equal(r.expectedResult))
 					}()


### PR DESCRIPTION
Currently, the local image mirror url is used when running the 'oc' commands. This can cause a problem if the mirror configuration has multiple mirrors, since there will be no failover if the url is unreachable. Instead, the actual releaseImage should be used when the icsp or idms configuration is provided to ensure proper failover.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD 

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
