### PR TITLE
MGMT-19148: Add OLM operator setup jobs finalizing stage

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -45,6 +45,9 @@ const (
 	// FinalizingStageWaitingForOlmOperatorsCsv captures enum value "Waiting for olm operators csv"
 	FinalizingStageWaitingForOlmOperatorsCsv FinalizingStage = "Waiting for olm operators csv"
 
+	// FinalizingStageWaitingForOLMOperatorSetupJobs captures enum value "Waiting for OLM operator setup jobs"
+	FinalizingStageWaitingForOLMOperatorSetupJobs FinalizingStage = "Waiting for OLM operator setup jobs"
+
 	// FinalizingStageDone captures enum value "Done"
 	FinalizingStageDone FinalizingStage = "Done"
 )
@@ -54,7 +57,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Waiting for OLM operator setup jobs","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/client/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -45,6 +45,9 @@ const (
 	// FinalizingStageWaitingForOlmOperatorsCsv captures enum value "Waiting for olm operators csv"
 	FinalizingStageWaitingForOlmOperatorsCsv FinalizingStage = "Waiting for olm operators csv"
 
+	// FinalizingStageWaitingForOLMOperatorSetupJobs captures enum value "Waiting for OLM operator setup jobs"
+	FinalizingStageWaitingForOLMOperatorSetupJobs FinalizingStage = "Waiting for OLM operator setup jobs"
+
 	// FinalizingStageDone captures enum value "Done"
 	FinalizingStageDone FinalizingStage = "Done"
 )
@@ -54,7 +57,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Waiting for OLM operator setup jobs","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/cluster/finalizing_stages.go
+++ b/internal/cluster/finalizing_stages.go
@@ -25,6 +25,7 @@ var finalizingStagesTimeoutsDefaultsHardTimeous = map[models.FinalizingStage]tim
 	models.FinalizingStageApplyingOlmManifests:                    shortWaitTimeout,
 	models.FinalizingStageWaitingForOlmOperatorsCsv:               generalWaitTimeout,
 	models.FinalizingStageWaitingForOlmOperatorsCsvInitialization: generalWaitTimeout,
+	models.FinalizingStageWaitingForOLMOperatorSetupJobs:          shortWaitTimeout,
 	models.FinalizingStageDone:                                    shortWaitTimeout,
 }
 
@@ -34,6 +35,7 @@ var finalizingStagesTimeoutsDefaultsSoftTimeouts = map[models.FinalizingStage]ti
 	models.FinalizingStageApplyingOlmManifests:                    shortWaitTimeout,
 	models.FinalizingStageWaitingForOlmOperatorsCsv:               generalWaitTimeout,
 	models.FinalizingStageWaitingForOlmOperatorsCsvInitialization: generalWaitTimeout,
+	models.FinalizingStageWaitingForOLMOperatorSetupJobs:          shortWaitTimeout,
 	models.FinalizingStageDone:                                    shortWaitTimeout,
 }
 
@@ -43,6 +45,7 @@ var finalizingStages = []models.FinalizingStage{
 	models.FinalizingStageApplyingOlmManifests,
 	models.FinalizingStageWaitingForOlmOperatorsCsvInitialization,
 	models.FinalizingStageWaitingForOlmOperatorsCsv,
+	models.FinalizingStageWaitingForOLMOperatorSetupJobs,
 	models.FinalizingStageDone,
 }
 
@@ -50,6 +53,12 @@ var nonFailingFinalizingStages = []models.FinalizingStage{
 	models.FinalizingStageApplyingOlmManifests,
 	models.FinalizingStageWaitingForOlmOperatorsCsvInitialization,
 	models.FinalizingStageWaitingForOlmOperatorsCsv,
+}
+
+var olmOperatorFinalizingStages = []models.FinalizingStage{
+	models.FinalizingStageWaitingForOlmOperatorsCsvInitialization,
+	models.FinalizingStageWaitingForOlmOperatorsCsv,
+	models.FinalizingStageWaitingForOLMOperatorSetupJobs,
 }
 
 func convertStageToEnvVar(stage models.FinalizingStage) string {
@@ -80,7 +89,7 @@ func finalizingStageDefaultTimeout(stage models.FinalizingStage, softTimeoutEnab
 
 func finalizingStageTimeout(stage models.FinalizingStage, operators []*models.MonitoredOperator, softTimeoutEnabled bool, log logrus.FieldLogger) time.Duration {
 	timeout := finalizingStageDefaultTimeout(stage, softTimeoutEnabled, log)
-	if funk.Contains([]models.FinalizingStage{models.FinalizingStageWaitingForOlmOperatorsCsvInitialization, models.FinalizingStageWaitingForOlmOperatorsCsv}, stage) {
+	if funk.Contains(olmOperatorFinalizingStages, stage) {
 		timeoutSeconds := timeout.Seconds()
 		for _, m := range operators {
 			if m.OperatorType == models.OperatorTypeOlm {

--- a/internal/cluster/finalizing_stages_test.go
+++ b/internal/cluster/finalizing_stages_test.go
@@ -32,6 +32,7 @@ var _ = DescribeTable("finalizing stage timeouts",
 			olmStages = []models.FinalizingStage{
 				models.FinalizingStageWaitingForOlmOperatorsCsvInitialization,
 				models.FinalizingStageWaitingForOlmOperatorsCsv,
+				models.FinalizingStageWaitingForOLMOperatorSetupJobs,
 			}
 			nonOlmStages = funk.Subtract(finalizingStages, olmStages).([]models.FinalizingStage)
 			toSeconds    = func(d time.Duration) int64 {

--- a/models/finalizing_stage.go
+++ b/models/finalizing_stage.go
@@ -45,6 +45,9 @@ const (
 	// FinalizingStageWaitingForOlmOperatorsCsv captures enum value "Waiting for olm operators csv"
 	FinalizingStageWaitingForOlmOperatorsCsv FinalizingStage = "Waiting for olm operators csv"
 
+	// FinalizingStageWaitingForOLMOperatorSetupJobs captures enum value "Waiting for OLM operator setup jobs"
+	FinalizingStageWaitingForOLMOperatorSetupJobs FinalizingStage = "Waiting for OLM operator setup jobs"
+
 	// FinalizingStageDone captures enum value "Done"
 	FinalizingStageDone FinalizingStage = "Done"
 )
@@ -54,7 +57,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Waiting for OLM operator setup jobs","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7748,6 +7748,7 @@ func init() {
         "Applying olm manifests",
         "Waiting for olm operators csv initialization",
         "Waiting for olm operators csv",
+        "Waiting for OLM operator setup jobs",
         "Done"
       ]
     },
@@ -18539,6 +18540,7 @@ func init() {
         "Applying olm manifests",
         "Waiting for olm operators csv initialization",
         "Waiting for olm operators csv",
+        "Waiting for OLM operator setup jobs",
         "Done"
       ]
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5104,6 +5104,7 @@ definitions:
     - Applying olm manifests
     - Waiting for olm operators csv initialization
     - Waiting for olm operators csv
+    - Waiting for OLM operator setup jobs
     - Done
 
 

--- a/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -45,6 +45,9 @@ const (
 	// FinalizingStageWaitingForOlmOperatorsCsv captures enum value "Waiting for olm operators csv"
 	FinalizingStageWaitingForOlmOperatorsCsv FinalizingStage = "Waiting for olm operators csv"
 
+	// FinalizingStageWaitingForOLMOperatorSetupJobs captures enum value "Waiting for OLM operator setup jobs"
+	FinalizingStageWaitingForOLMOperatorSetupJobs FinalizingStage = "Waiting for OLM operator setup jobs"
+
 	// FinalizingStageDone captures enum value "Done"
 	FinalizingStageDone FinalizingStage = "Done"
 )
@@ -54,7 +57,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Waiting for OLM operator setup jobs","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
This patch adds a new finalizing stage that indicates that the assisted installer controller is waiting for OLM setup jobs to complete.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19148
https://issues.redhat.com/browse/MGMT-19056

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
