### PR TITLE
NO-ISSUE: Update CI gather script and fix failing to scale nodepool

### DIFF
--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -239,6 +239,11 @@ wait_for_condition "hostedcluster/$ASSISTED_CLUSTER_NAME" "Available" "10m" "$SP
 # Scale up
 echo "Scaling the hosted cluster up to contain ${SPOKE_CONTROLPLANE_AGENTS} worker nodes"
 oc scale nodepool/$ASSISTED_CLUSTER_NAME -n $SPOKE_NAMESPACE --replicas=${SPOKE_CONTROLPLANE_AGENTS}
+if [ $? -gt 0 ]
+then
+  echo "Scaling nodepool with oc scale failed, attempting to patch instead."
+  oc patch nodepool/$ASSISTED_CLUSTER_NAME -n $SPOKE_NAMESPACE -p "{\"spec\":{\"replicas\":${SPOKE_CONTROLPLANE_AGENTS}}}" --type=merge
+fi
 
 # Wait for node to appear in the CAPI-deployed cluster
 oc extract -n $SPOKE_NAMESPACE secret/$ASSISTED_CLUSTER_NAME-admin-kubeconfig --to=- > /tmp/$ASSISTED_CLUSTER_NAME-kubeconfig

--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -124,7 +124,7 @@ function gather_imageset_data() {
 }
 
 function gather_capi_data() {
-  CAPI_CRS=(agentmachine agentcluster cluster machine machinedeployment machineset nodepool hostedcluster hostedcontrolplane)
+  CAPI_CRS=(agentmachine agentmachinetemplate agentcluster cluster machine machinedeployment machineset nodepool hostedcluster hostedcontrolplane)
   capi_dir="${LOGS_DEST}/capi"
   mkdir -p "${capi_dir}"
 
@@ -207,7 +207,7 @@ function gather_hypershift_data() {
 
 # Download Hypershift CLI
 function hypershift_cli() {
-  HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:4.11}"
+  HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
   id=$(podman create $HYPERSHIFT_IMAGE)
   mkdir -p ./hypershift-cli
   podman cp $id:/usr/bin/hypershift ./hypershift-cli


### PR DESCRIPTION
Upgrades the default hypershift image tag from
4.11 to latest.

Collects agentmachinetemplates CRs.

Patches the nodepool if scaling it with `oc scale` fails.

---
Came from the CAPI CI tests (such as [this](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-api-provider-agent-master-e2e-ai-operator-ztp-capi-periodic/1848091909545791488))
with the following failure logs
```
[2024-10-20 22:13:08] + oc get nodepool/assisted-test-cluster --selector= --namespace=assisted-spoke-cluster
[2024-10-20 22:13:08] NAME                    CLUSTER                 DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
[2024-10-20 22:13:08] assisted-test-cluster   assisted-test-cluster   0                               False                                                                   


[2024-10-20 22:13:17] + oc scale nodepool/assisted-test-cluster -n assisted-spoke-cluster --replicas=1
[2024-10-20 22:13:17] Error from server (NotFound): nodepools.hypershift.openshift.io "assisted-test-cluster" not found
```

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
