### PR TITLE
NO-ISSUE: Fix unit tests that fail locally

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -3069,7 +3069,8 @@ var _ = Describe("Deregister inactive clusters", func() {
 	})
 
 	It("Deregister inactive cluster", func() {
-		Expect(state.DeregisterInactiveCluster(ctx, 10, strfmt.DateTime(time.Now()))).ShouldNot(HaveOccurred())
+		lastActive := strfmt.DateTime(time.Now().Add(time.Second))
+		Expect(state.DeregisterInactiveCluster(ctx, 10, lastActive)).ShouldNot(HaveOccurred())
 		Expect(wasDeregisterd(db, *c.ID)).To(BeTrue())
 	})
 

--- a/internal/operators/handler/handler_test.go
+++ b/internal/operators/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -164,7 +165,7 @@ var _ = Describe("Operators manager", func() {
 
 			Expect(operators[0].StatusInfo).To(Equal(statusInfo))
 			Expect(operators[0].Status).To(Equal(newStatus))
-			Expect(operators[0].StatusUpdatedAt.String()).ShouldNot(Equal(lastUpdatedTime.String()))
+			Expect(time.Time(operators[0].StatusUpdatedAt).UTC()).ToNot(Equal(time.Time(lastUpdatedTime).UTC()))
 			Expect(operators[0].Version).To(Equal(operatorVersion))
 		})
 
@@ -182,7 +183,7 @@ var _ = Describe("Operators manager", func() {
 			operators, err := handler.GetMonitoredOperators(context.TODO(), *c.ID, swag.String(""), db)
 			Expect(err).ToNot(HaveOccurred())
 			for _, operator := range operators {
-				Expect(operator.StatusUpdatedAt.String()).Should(Equal(lastUpdatedTime.String()))
+				Expect(time.Time(operator.StatusUpdatedAt).UTC()).To(Equal(time.Time(lastUpdatedTime).UTC()))
 			}
 		})
 
@@ -200,7 +201,7 @@ var _ = Describe("Operators manager", func() {
 			operators, err := handler.GetMonitoredOperators(context.TODO(), *c.ID, swag.String(""), db)
 			Expect(err).ToNot(HaveOccurred())
 			for _, operator := range operators {
-				Expect(operator.StatusUpdatedAt.String()).Should(Equal(lastUpdatedTime.String()))
+				Expect(time.Time(operator.StatusUpdatedAt).UTC()).To(Equal(time.Time(lastUpdatedTime).UTC()))
 			}
 		})
 	})


### PR DESCRIPTION
This patch fixes several tests that fail when executed locally with a recent version of PostgreSQL, in particular version 16.

- _Test that DHCP VIPs were cleared when switching to UserManagedNetworking: true_.

  This test fails when executed individually because it tries to update
  the VIPs in the database doing `db.Save(&cluster)`, but that only
  saves the cluster itself, and not other referenced tables, like the
  VIPs tables. I believe this works in CI today because of the state of
  the database generated by previous tests. The patch changes it to
  explicitly save the VIPs using `db.Save(&models.APIVip{...})`.

- _single SNO vsphere host_ and other related tests.

  These fail because in recent versions of PostgreSQL it is not the OK to update the database with zero timestamps: the database server rejects the update, but _Gorm_ ignores it and just does nothing. The net result is that nothing is updated. The patch changes those tests to update only the required columns, so there is no problem with zero time stamps.

- _Deregister inactive cluster_.

  This test fails because it uses `time.Now()` as the last activity date, and depending on the speed of the machine the date may change between that call to `time.Now()` and the actual check. The patch changes it to use a data that is a second in the future.

- Operator handler tests.

  These tests fail because they compare the string representation of time stamps. But depending on the machine and database configuration the time zone may be `nil` or different to what is stored in the database, so the string representation may be different even if the time stamp is the same. To avoid that the patch adds a new `EqualTime` Gomega matcher that compares time stamps converting them to the same time stamp.

## List all the issues related to this PR

No related issue.

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Executed unit tests locally.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
