### PR TITLE
OCPBUGS-43513: allow configuring cluster UserManagedNetworking field when importing a cluster

### DIFF
--- a/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
+++ b/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"testing"
 	"testing/fstest"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/client"
+	installerclient "github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/client/manifests"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -103,38 +107,112 @@ var _ = DescribeTable(
 	}),
 )
 
+type importCase struct {
+	files                map[string]string
+	expectedImportParams *models.ImportClusterParams
+	expectedUpdateParams *models.V2ClusterUpdateParams
+}
+
+var clusterID = strfmt.UUID("e679ea3f-3b85-40e0-8dc9-82fd6945d9b2")
+
+var _ = DescribeTable(
+	"Import",
+	func(tc importCase) {
+		fakeLogger, _ := test.NewNullLogger()
+
+		fakeFileSystem := fstest.MapFS{}
+		for name, data := range tc.files {
+			fakeFileSystem[name] = &fstest.MapFile{Data: []byte(data)}
+		}
+
+		fakeTransport := NewMockTransport()
+		fakeInstallerClient := installerclient.New(fakeTransport, nil, nil)
+		fakeBMClient := &client.AssistedInstall{
+			Installer: fakeInstallerClient,
+		}
+
+		_, err := ImportCluster(fakeFileSystem, context.Background(), fakeLogger, fakeBMClient, clusterID, "ostest", "api.ostest")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(fakeTransport.lastImportParamsReceived).To(BeEquivalentTo(tc.expectedImportParams))
+		Expect(fakeTransport.lastUpdateParamsReceived).To(BeEquivalentTo(tc.expectedUpdateParams))
+	},
+	Entry("default", importCase{
+		files: map[string]string{
+			"import-cluster-config.json": "{\"networking\": {\"userManagedNetworking\": true}}",
+		},
+		expectedImportParams: &models.ImportClusterParams{
+			APIVipDnsname:      swag.String("api.ostest"),
+			Name:               swag.String("ostest"),
+			OpenshiftClusterID: &clusterID,
+		},
+		expectedUpdateParams: &models.V2ClusterUpdateParams{
+			UserManagedNetworking: swag.Bool(true),
+		},
+	}),
+	Entry("(optional) ignition endpoint config", importCase{
+		files: map[string]string{
+			"import-cluster-config.json":    "{\"networking\": {\"userManagedNetworking\": false}}",
+			"worker-ignition-endpoint.json": "{\"url\": \"https://192.168.111.5:22623/config/worker\", \"ca_certificate\": \"LS0tL_FakeCertificate_LS0tCg==\"}",
+		},
+		expectedImportParams: &models.ImportClusterParams{
+			APIVipDnsname:      swag.String("api.ostest"),
+			Name:               swag.String("ostest"),
+			OpenshiftClusterID: &clusterID,
+		},
+		expectedUpdateParams: &models.V2ClusterUpdateParams{
+			IgnitionEndpoint: &models.IgnitionEndpoint{
+				URL:           swag.String("https://192.168.111.5:22623/config/worker"),
+				CaCertificate: swag.String("LS0tL_FakeCertificate_LS0tCg=="),
+			},
+			UserManagedNetworking: swag.Bool(false),
+		},
+	}),
+)
+
 func TestAgentbasedinstaller(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Agentbasedinstaller Suite")
 }
 
 type mockTransport struct {
-	filesReceived map[string]string
-	result        manifests.V2CreateClusterManifestCreated
-	err           error
+	filesReceived            map[string]string
+	lastImportParamsReceived *models.ImportClusterParams
+	lastUpdateParamsReceived *models.V2ClusterUpdateParams
+	err                      error
 }
 
 func NewMockTransport() *mockTransport {
 	return &mockTransport{
 		filesReceived: make(map[string]string),
-		result:        manifests.V2CreateClusterManifestCreated{},
 	}
 }
 
 func (m *mockTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	var result interface{}
 
-	params, _ := op.Params.(*manifests.V2CreateClusterManifestParams)
-	m.filesReceived[*params.CreateManifestParams.FileName] = *params.CreateManifestParams.Content
+	switch v := op.Params.(type) {
+	case *manifests.V2CreateClusterManifestParams:
+		m.filesReceived[*v.CreateManifestParams.FileName] = *v.CreateManifestParams.Content
+		result = &manifests.V2CreateClusterManifestCreated{}
+	case *installerclient.V2ImportClusterParams:
+		m.lastImportParamsReceived = v.NewImportClusterParams
+		result = &installerclient.V2ImportClusterCreated{
+			Payload: &models.Cluster{
+				ID: v.NewImportClusterParams.OpenshiftClusterID,
+			},
+		}
+	case *installerclient.V2UpdateClusterParams:
+		m.lastUpdateParamsReceived = v.ClusterUpdateParams
+		result = &installerclient.V2UpdateClusterCreated{}
+	default:
+		return nil, fmt.Errorf("[mockTransport] unmanaged type: %T", v)
+	}
 
 	if m.err != nil {
 		return nil, m.err
 	}
 
-	return &m.result, nil
-}
-
-func (m *mockTransport) SetResult(res manifests.V2CreateClusterManifestCreated) {
-	m.result = res
+	return result, nil
 }
 
 func (m *mockTransport) SetError(errMsg string) {

--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -272,7 +272,7 @@ func importCluster(ctx context.Context, log *log.Logger, bmInventory *client.Ass
 	}
 
 	clusterID := strfmt.UUID(ImportOptions.ClusterID)
-	_, err = agentbasedinstaller.ImportCluster(ctx, log, bmInventory, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName, ImportOptions.ClusterConfigDir)
+	_, err = agentbasedinstaller.ImportCluster(os.DirFS(ImportOptions.ClusterConfigDir), ctx, log, bmInventory, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName)
 	if err != nil {
 		log.Fatal("Failed to import cluster with assisted-service: ", err)
 	}


### PR DESCRIPTION
This patch allows the agent-installer-client to consume the new ISO config file `/etc/assisted/clusterconfig/worker-ignition-endpoint.json` to further configure a cluster after having imported it, during the add nodes workflow (day2).

Required by https://github.com/openshift/installer/pull/9129

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] ABI - add nodes
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)
