### PR TITLE
MGMT-19158: Always try to cache the ClusterImageSet

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -200,15 +200,21 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 		log.WithError(err).Error("error setting owner reference")
 		return ctrl.Result{Requeue: true}, err
 	}
+	pullSecret, err := r.getPullSecret(ctx, clusterDeployment, clusterInstall)
+	if err != nil {
+		log.WithError(err).Errorf("failed to get pull secret for cluster deployment %s", clusterDeployment.Name)
+		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
+	}
+	releaseImage, err := r.getReleaseImage(ctx, clusterDeployment, clusterInstall, pullSecret)
+	if err != nil {
+		log.WithError(err).Errorf("failed to get release image for cluster %s, ensure AgentClusterInstall.Spec.ImageSetRef references a ClusterImageSet", clusterDeployment.Name)
+		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
+	}
 
 	cluster, err := r.Installer.GetClusterByKubeKey(req.NamespacedName)
-	if err1 := r.validateClusterDeployment(clusterDeployment, clusterInstall); err1 != nil {
-		log.Error(err1)
-		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err1)
-	}
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		if !isInstalled(clusterDeployment, clusterInstall) {
-			return r.createNewCluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
+			return r.createNewCluster(ctx, log, req.NamespacedName, pullSecret, releaseImage, clusterDeployment, clusterInstall)
 		}
 
 		return r.createNewDay2Cluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
@@ -256,14 +262,20 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 	return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, nil)
 }
 
-func (r *ClusterDeploymentsReconciler) validateClusterDeployment(clusterDeployment *hivev1.ClusterDeployment,
-	clusterInstall *hiveext.AgentClusterInstall) error {
-
-	// Make sure that the ImageSetRef is set for clusters not already installed
-	if clusterInstall.Spec.ImageSetRef == nil && !clusterDeployment.Spec.Installed {
-		return newInputError("missing ImageSetRef for cluster that is not installed")
+func (r *ClusterDeploymentsReconciler) getPullSecret(ctx context.Context, clusterDeployment *hivev1.ClusterDeployment, clusterInstall *hiveext.AgentClusterInstall) (string, error) {
+	if clusterDeployment.Spec.PullSecretRef == nil || clusterDeployment.Spec.PullSecretRef.Name == "" {
+		// Pull secret is not required for already installed clusters
+		if isInstalled(clusterDeployment, clusterInstall) {
+			return "", nil
+		}
+		return "", newInputError("PullSecret is required for ClusterDeployment %s/%s", clusterDeployment.Name, clusterDeployment.Namespace)
 	}
-	return nil
+	// Ensure the pull secret is valid
+	pullSecret, err := r.PullSecretHandler.GetValidPullSecret(ctx, getPullSecretKey(clusterDeployment.Namespace, clusterDeployment.Spec.PullSecretRef))
+	if err != nil {
+		return "", errors.WithMessagef(err, "failed to validate pull secret for ClusterDeployment %s/%s", clusterDeployment.Name, clusterDeployment.Namespace)
+	}
+	return pullSecret, nil
 }
 
 func (r *ClusterDeploymentsReconciler) agentClusterInstallFinalizer(ctx context.Context, log logrus.FieldLogger, req ctrl.Request,
@@ -1353,27 +1365,15 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	key types.NamespacedName,
+	pullSecret string,
+	releaseImage *models.ReleaseImage,
 	clusterDeployment *hivev1.ClusterDeployment,
 	clusterInstall *hiveext.AgentClusterInstall) (ctrl.Result, error) {
 
 	log.Infof("Creating a new cluster %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
-	spec := clusterDeployment.Spec
-
-	pullSecret, err := r.PullSecretHandler.GetValidPullSecret(ctx, getPullSecretKey(key.Namespace, spec.PullSecretRef))
-	if err != nil {
-		log.WithError(err).Error("failed to get pull secret")
-		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
-	}
-
-	releaseImage, err := r.getReleaseImage(ctx, log, clusterInstall.Spec, pullSecret)
-	if err != nil {
-		log.WithError(err).Error("Failed to get release image")
-		_, _ = r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
-		// The controller will requeue after one minute, giving the user a chance to fix releaseImage
-		return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
-	}
 
 	var ignitionEndpoint *models.IgnitionEndpoint
+	var err error
 	if clusterInstall.Spec.IgnitionEndpoint != nil {
 		ignitionEndpoint, err = r.parseIgnitionEndpoint(ctx, clusterInstall.Spec.IgnitionEndpoint)
 		if err != nil {
@@ -1440,14 +1440,24 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 
 func (r *ClusterDeploymentsReconciler) getReleaseImage(
 	ctx context.Context,
-	log logrus.FieldLogger,
-	spec hiveext.AgentClusterInstallSpec,
+	clusterDeployment *hivev1.ClusterDeployment,
+	clusterInstall *hiveext.AgentClusterInstall,
 	pullSecret string) (*models.ReleaseImage, error) {
+
+	// Make sure that the ImageSetRef is set before continuing
+	if clusterInstall.Spec.ImageSetRef == nil {
+		// ImageSetRef is not required for already installed clusters
+		// however we should still try to pull and cache it if it is specified
+		if isInstalled(clusterDeployment, clusterInstall) {
+			return nil, nil
+		}
+		return nil, newInputError("ClusterImageSet must be specified in AgentClusterInstall.Spec.ImageSetRef for cluster that is not installed")
+	}
 
 	clusterImageSet := &hivev1.ClusterImageSet{}
 	key := types.NamespacedName{
 		Namespace: "",
-		Name:      spec.ImageSetRef.Name,
+		Name:      clusterInstall.Spec.ImageSetRef.Name,
 	}
 	if err := r.Client.Get(ctx, key, clusterImageSet); err != nil {
 		return nil, errors.Wrapf(err, "failed to get cluster image set %s", key.Name)
@@ -1464,9 +1474,8 @@ func (r *ClusterDeploymentsReconciler) getReleaseImage(
 				errMsgSuffix = fmt.Sprintf("Release image %q uses a tag (%q), this is usually unsupported in combination with mirror registries, try providing a digest-based image instead", clusterImageSet.Spec.ReleaseImage, ref.Tag)
 			}
 		}
-		log.Error(err)
 		errMsg := "failed to get release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid, %s (error: %s)."
-		return nil, errors.New(fmt.Sprintf(errMsg, clusterImageSet.Spec.ReleaseImage, spec.ImageSetRef.Name, errMsgSuffix, err.Error()))
+		return nil, errors.New(fmt.Sprintf(errMsg, clusterImageSet.Spec.ReleaseImage, key.Name, errMsgSuffix, err.Error()))
 	}
 
 	return releaseImage, nil


### PR DESCRIPTION
Previously, the `ClusterImageSet` defined by a `ClusterDeployment` was only cached if the cluster was being created. This is problematic in the long run if assisted is restarted and the cluster is not recreated. Errors "getting the release image" will occur due to this.

To prevent this, we'll now always try to cache the ClusterImageSet defined for a cluster even if it's already installed. This also allows us to ensure that the image the user specified in the ClusterImageSet as the release image to be installed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
