### PR TITLE
MGMT-19230: Handle installation preparation status in statemachine

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1289,17 +1289,6 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 		return nil, common.NewApiError(http.StatusNotFound, err)
 	}
 
-	err = b.db.Model(&models.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(&models.Cluster{
-		LastInstallationPreparation: models.LastInstallationPreparation{
-			Status: models.LastInstallationPreparationStatusNotStarted,
-			Reason: "Preparation never performed",
-		},
-	}).Error
-	if err != nil {
-		b.log.WithError(err).Errorf("Failed to reset last installation preparation state for cluster %s", cluster.ID.String())
-		return nil, common.NewApiError(http.StatusInternalServerError, err)
-	}
-
 	var autoAssigned bool
 
 	// auto select hosts roles if not selected yet.

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5307,14 +5307,6 @@ var _ = Describe("cluster", func() {
 				eventstest.WithClusterIdMatcher(clusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo))).MinTimes(0)
 
-			err := db.Model(&models.Cluster{}).Where("id = ?", clusterID).Updates(&models.Cluster{
-				LastInstallationPreparation: models.LastInstallationPreparation{
-					Status: models.LastInstallationPreparationStatusFailed,
-					Reason: "Testing clear of failure reason on installation start",
-				},
-			}).Error
-			Expect(err).ShouldNot(HaveOccurred())
-
 			reply := bm.V2InstallCluster(ctx, installer.V2InstallClusterParams{
 				ClusterID: clusterID,
 			})
@@ -5324,11 +5316,6 @@ var _ = Describe("cluster", func() {
 
 			count := db.Model(&models.Cluster{}).Where("openshift_cluster_id <> ''").First(&models.Cluster{}).RowsAffected
 			Expect(count).To(Equal(int64(1)))
-
-			cluster, err := common.GetClusterFromDBWhere(db, common.UseEagerLoading, common.DeleteRecordsState(false), "id = ? AND last_installation_preparation_status = ?", clusterID, models.LastInstallationPreparationStatusNotStarted)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.LastInstallationPreparation.Status).To(Equal(models.LastInstallationPreparationStatusNotStarted))
-			Expect(cluster.LastInstallationPreparation.Reason).To(Equal("Preparation never performed"))
 		})
 
 		It("Should send event in case of ignored validations", func() {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -997,7 +997,7 @@ func (m *Manager) HandlePreInstallSuccess(ctx context.Context, c *common.Cluster
 	err := m.db.Model(&models.Cluster{}).Where("id = ?", c.ID.String()).Updates(&models.Cluster{
 		LastInstallationPreparation: models.LastInstallationPreparation{
 			Status: models.LastInstallationPreparationStatusSuccess,
-			Reason: "",
+			Reason: constants.InstallationPreparationReasonSuccess,
 		},
 	}).Error
 	if err != nil {

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	eventgen "github.com/openshift/assisted-service/internal/common/events"
 	commontesting "github.com/openshift/assisted-service/internal/common/testing"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/dns"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/events/eventstest"
@@ -427,7 +428,7 @@ var _ = Describe("Progress bar test", func() {
 						},
 						LastInstallationPreparation: models.LastInstallationPreparation{
 							Status: models.LastInstallationPreparationStatusSuccess,
-							Reason: "",
+							Reason: constants.InstallationPreparationReasonSuccess,
 						},
 					},
 				}

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -37,6 +37,8 @@ var resetProgressFields = []interface{}{"progress_finalizing_stage_percentage", 
 
 var resetFields = append(append(resetProgressFields, resetLogsField...), "openshift_cluster_id", "")
 
+var resetInstallationPreparationStatusFields = []interface{}{"last_installation_preparation_status", models.LastInstallationPreparationStatusNotStarted, "last_installation_preparation_reason", constants.InstallationPreparationReasonNotPerformed}
+
 type transitionHandler struct {
 	log                 logrus.FieldLogger
 	db                  *gorm.DB
@@ -175,7 +177,7 @@ func (th *transitionHandler) PostResetCluster(sw stateswitch.StateSwitch, args s
 			return err
 		}
 	}
-
+	extra = append(extra, resetInstallationPreparationStatusFields...)
 	return th.updateTransitionCluster(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sCluster, params.reason, extra...)
 }
 
@@ -201,6 +203,7 @@ func (th *transitionHandler) PostPrepareForInstallation(sw stateswitch.StateSwit
 		return errors.New("PostPrepareForInstallation invalid argument")
 	}
 	extra := append(append(make([]interface{}, 0), "install_started_at", strfmt.DateTime(time.Now())), resetLogsField...)
+	extra = append(extra, resetInstallationPreparationStatusFields...)
 	err = th.updateTransitionCluster(params.ctx, logutil.FromContext(params.ctx, th.log), th.db, sCluster,
 		statusInfoPreparingForInstallation, extra...)
 	if err != nil {

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -589,6 +589,33 @@ var _ = Describe("Reset cluster", func() {
 				Expect(len(cluster.Cluster.IngressVips)).ShouldNot(Equal(0))
 			}
 		})
+
+		It(fmt.Sprintf("resets LastInstallationPreparation in case of cluster reset from state %s", t.state), func() {
+			cluster = common.Cluster{
+				Cluster: models.Cluster{
+					ID:     &clusterId,
+					Status: swag.String(t.state),
+					LastInstallationPreparation: models.LastInstallationPreparation{
+						Status: models.LastInstallationPreparationStatusSuccess,
+						Reason: constants.InstallationPreparationReasonSuccess,
+					},
+				},
+			}
+			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+			acceptNewEvents(t.eventsNum)
+			err := capi.ResetCluster(ctx, &cluster, "reason", db)
+			cluster = getClusterFromDB(clusterId, db)
+			if t.success {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.Cluster.LastInstallationPreparation.Status).Should(Equal(models.LastInstallationPreparationStatusNotStarted))
+				Expect(cluster.Cluster.LastInstallationPreparation.Reason).Should(Equal(constants.InstallationPreparationReasonNotPerformed))
+			} else {
+				Expect(err).Should(HaveOccurred())
+				Expect(err.StatusCode()).Should(Equal(t.statusCode))
+				Expect(cluster.Cluster.LastInstallationPreparation.Status).Should(Equal(models.LastInstallationPreparationStatusSuccess))
+				Expect(cluster.Cluster.LastInstallationPreparation.Reason).Should(Equal(constants.InstallationPreparationReasonSuccess))
+			}
+		})
 	}
 })
 
@@ -1714,23 +1741,25 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 	})
 
 	tests := []struct {
-		name               string
-		apiVip             string
-		apiVips            []*models.APIVip
-		ingressVip         string
-		ingressVips        []*models.IngressVip
-		dstState           string
-		installationStatus string
-		hosts              []models.Host
-		statusInfoChecker  statusInfoChecker
-		validationsChecker *validationsChecker
+		name                              string
+		apiVip                            string
+		apiVips                           []*models.APIVip
+		ingressVip                        string
+		ingressVips                       []*models.IngressVip
+		dstState                          string
+		lastInstallationPreparationStatus string
+		lastInstallationPreparationReason string
+		hosts                             []models.Host
+		statusInfoChecker                 statusInfoChecker
+		validationsChecker                *validationsChecker
 	}{
 		{
-			name:               "no change",
-			apiVips:            common.TestIPv4Networking.APIVips,
-			ingressVips:        common.TestIPv4Networking.IngressVips,
-			dstState:           models.ClusterStatusPreparingForInstallation,
-			installationStatus: models.LastInstallationPreparationStatusNotStarted,
+			name:                              "no change",
+			apiVips:                           common.TestIPv4Networking.APIVips,
+			ingressVips:                       common.TestIPv4Networking.IngressVips,
+			dstState:                          models.ClusterStatusPreparingForInstallation,
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusNotStarted,
+			lastInstallationPreparationReason: constants.InstallationPreparationReasonNotPerformed,
 			hosts: []models.Host{
 				{
 					ID:     &hid1,
@@ -1748,11 +1777,12 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 			statusInfoChecker: makeValueChecker(statusInfoPreparingForInstallation),
 		},
 		{
-			name:               "one insufficient host",
-			apiVips:            common.TestIPv4Networking.APIVips,
-			ingressVips:        common.TestIPv4Networking.IngressVips,
-			dstState:           models.ClusterStatusInsufficient,
-			installationStatus: models.LastInstallationPreparationStatusNotStarted,
+			name:                              "one insufficient host",
+			apiVips:                           common.TestIPv4Networking.APIVips,
+			ingressVips:                       common.TestIPv4Networking.IngressVips,
+			dstState:                          models.ClusterStatusInsufficient,
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusNotStarted,
+			lastInstallationPreparationReason: constants.InstallationPreparationReasonNotPerformed,
 			hosts: []models.Host{
 				{
 					ID:     &hid1,
@@ -1788,8 +1818,9 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					Status: swag.String(models.HostStatusInsufficient),
 				},
 			},
-			installationStatus: models.LastInstallationPreparationStatusFailed,
-			statusInfoChecker:  makeValueChecker(statusInfoUnpreparingHostExists),
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusFailed,
+			lastInstallationPreparationReason: "arbitrary failure reason",
+			statusInfoChecker:                 makeValueChecker(statusInfoUnpreparingHostExists),
 		},
 		{
 			name:        "one insufficient host + preparation succeeded",
@@ -1810,8 +1841,9 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					Status: swag.String(models.HostStatusInsufficient),
 				},
 			},
-			installationStatus: models.LastInstallationPreparationStatusSuccess,
-			statusInfoChecker:  makeValueChecker(statusInfoUnpreparingHostExists),
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusSuccess,
+			lastInstallationPreparationReason: constants.InstallationPreparationReasonSuccess,
+			statusInfoChecker:                 makeValueChecker(statusInfoUnpreparingHostExists),
 		},
 		{
 			name:        "preparation failed",
@@ -1832,8 +1864,9 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					Status: swag.String(models.HostStatusPreparingForInstallation),
 				},
 			},
-			installationStatus: models.LastInstallationPreparationStatusFailed,
-			statusInfoChecker:  makeValueChecker(statusInfoClusterFailedToPrepare),
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusFailed,
+			lastInstallationPreparationReason: "arbitrary failure reason",
+			statusInfoChecker:                 makeValueChecker(statusInfoClusterFailedToPrepare),
 		},
 		{
 			name:        "all hosts prepared + preparation succeeded",
@@ -1854,8 +1887,9 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					Status: swag.String(models.HostStatusPreparingSuccessful),
 				},
 			},
-			installationStatus: models.LastInstallationPreparationStatusSuccess,
-			statusInfoChecker:  makeValueChecker(statusInfoInstalling),
+			lastInstallationPreparationStatus: models.LastInstallationPreparationStatusSuccess,
+			lastInstallationPreparationReason: constants.InstallationPreparationReasonSuccess,
+			statusInfoChecker:                 makeValueChecker(statusInfoInstalling),
 		},
 	}
 	for i := range tests {
@@ -1872,8 +1906,8 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					StatusInfo:      swag.String(statusInfoPreparingForInstallation),
 					StatusUpdatedAt: strfmt.DateTime(time.Now()),
 					LastInstallationPreparation: models.LastInstallationPreparation{
-						Status: t.installationStatus,
-						Reason: "",
+						Status: t.lastInstallationPreparationStatus,
+						Reason: t.lastInstallationPreparationReason,
 					},
 				},
 			}
@@ -4670,7 +4704,7 @@ var _ = Describe("Single node", func() {
 					cluster.Cluster.StatusUpdatedAt = strfmt.DateTime(time.Now())
 					cluster.LastInstallationPreparation = models.LastInstallationPreparation{
 						Status: models.LastInstallationPreparationStatusSuccess,
-						Reason: "",
+						Reason: constants.InstallationPreparationReasonSuccess,
 					}
 
 					mockMetric.EXPECT().InstallationStarted().Times(1)

--- a/internal/constants/installation_preparation_status_reasons.go
+++ b/internal/constants/installation_preparation_status_reasons.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	InstallationPreparationReasonNotPerformed = "Installation preparation not performed"
+	InstallationPreparationReasonSuccess      = "Installation preparation successful"
+)

--- a/internal/host/refresh_status_preprocessor_test.go
+++ b/internal/host/refresh_status_preprocessor_test.go
@@ -112,10 +112,6 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		cluster.Status = &clusterStatus
 		hostToAdd := createHost()
 		cluster.Hosts = []*models.Host{&hostToAdd}
-		cluster.LastInstallationPreparation = models.LastInstallationPreparation{
-			Status: models.LastInstallationPreparationStatusFailed,
-			Reason: "",
-		}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 	}
 


### PR DESCRIPTION
There is a bug that manifests when the installation endpoint for a cluster is called while the cluster is in an invalid state for install.
The installation request is correctly rejected, however the "Last Installation Preparation Status" fields are prematurely reset to LastInstallationPreparationStatusNotStarted.
These should only be reset when the cluster transitions between the "ready" and "preparing for installation" states.

This PR introduces a test for this assertion and additionally changes behaviour to match.

I introduced a test for "reset" cluster and functionality to apply the Last Installation Preparation Status reset when the cluster installation is reset.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
