### PR TITLE
NO-ISSUE: Change the PostgreSQL port for unit tests to support running both unit tests and the subsystem on the same machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ display-coverage:
 
 run-db-container:
 	$(CONTAINER_COMMAND) ps -q --filter "name=postgres" | xargs -r $(CONTAINER_COMMAND) kill && sleep 3
-	$(CONTAINER_COMMAND) run -d  --rm --tmpfs /var/lib/pgsql/data --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 -p 127.0.0.1:5432:5432 \
+	$(CONTAINER_COMMAND) run -d  --rm --tmpfs /var/lib/pgsql/data --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 -p 127.0.0.1:5433:5432 \
 		$(PSQL_IMAGE)
 	timeout 5m ./hack/wait_for_postgres.sh
 

--- a/hack/start_db.sh
+++ b/hack/start_db.sh
@@ -8,4 +8,4 @@ mkdir -p /tmp/postgres/data
 mkdir -p /tmp/postgres/sockets
 
 initdb -D /tmp/postgres/data -U postgres
-pg_ctl -D /tmp/postgres/data -l /tmp/postgres/logfile -o'-k /tmp/postgres/sockets' start
+pg_ctl -D /tmp/postgres/data -l /tmp/postgres/logfile -o'-k /tmp/postgres/sockets -p 5433' start

--- a/hack/wait_for_postgres.sh
+++ b/hack/wait_for_postgres.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 PG_USER=postgres
 PG_DATABASE=postgres
 PG_HOST=127.0.0.1
-PG_PORT=5432
+PG_PORT=5433
 export PGPASSWORD=admin
 
 if [ -x "$(command -v pg_isready)" ]; then

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -31,11 +31,11 @@ import (
 		* k8s cluster
 		* if k8s connection is not available try to run it as docker container
 
-		When SKIP_UT_DB env var is set localhost:5432 is being used.
+		When SKIP_UT_DB env var is set localhost:5433 is being used.
 */
 const (
 	dbDockerName  = "ut-postgres"
-	dbDefaultPort = "5432"
+	dbDefaultPort = "5433"
 
 	k8sNamespace = "assisted-installer"
 )
@@ -134,9 +134,9 @@ func (c *K8SDBContext) Create() error {
 							Image: "quay.io/sclorg/postgresql-12-c8s",
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          "tcp-5432",
+									Name:          "tcp-5433",
 									Protocol:      corev1.ProtocolTCP,
-									ContainerPort: 5432,
+									ContainerPort: 5433,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -148,7 +148,7 @@ func (c *K8SDBContext) Create() error {
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(5432),
+										Port: intstr.FromInt(5433),
 									},
 								},
 							},
@@ -201,9 +201,9 @@ func (c *K8SDBContext) Create() error {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port:     5432,
+					Port:     5433,
 					Protocol: corev1.ProtocolTCP,
-					Name:     "tcp-5432",
+					Name:     "tcp-5433",
 				},
 			},
 			Type: corev1.ServiceTypeLoadBalancer,


### PR DESCRIPTION
Currently, both the unit test PostgreSQL and subsystem PostgreSQL instances are bound to port 5432, preventing them from running simultaneously. This PR changes the unit test port to 5433, allowing both instances to run concurrently.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @danmanor 