### PR TITLE
MGMT-18628: fix better waiting for deployment

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -110,7 +110,7 @@ function install_from_catalog_source() {
 
   if [ "${DISCONNECTED}" != "true" ]; then
     # In disconnected mode it should be applied already with a different image
-  tee << EOCR >(oc apply -f -)
+  tee << EOCR >(oc apply --wait=true -f -)
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -124,7 +124,7 @@ spec:
 EOCR
   fi
 
-  tee << EOCR >(oc apply -f -)
+  tee << EOCR >(oc apply --wait=true -f -)
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -159,7 +159,7 @@ EOCR
 
   wait_for_crd "agentserviceconfigs.agent-install.openshift.io"
 
-  tee << EOCR >(oc apply -f -)
+  tee << EOCR >(oc apply --wait=true -f -)
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -174,7 +174,7 @@ EOCR
     deploy_mirror_config_map
   fi
 
-  tee << EOCR >(oc apply -f -)
+  tee << EOCR >(oc apply --wait=true -f -)
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
@@ -215,7 +215,7 @@ EOCR
   oc patch -n ${ASSISTED_NAMESPACE} agentserviceconfig agent --type merge -p '{"spec":{"osImages":'"${OS_IMAGES_CAMELCASE}"'}}'
 
   wait_for_operator "assisted-service-operator" "${ASSISTED_NAMESPACE}"
-  wait_for_condition "agentserviceconfigs/agent" "ReconcileCompleted" "5m"
+  wait_for_condition "agentserviceconfigs/agent" "condition=ReconcileCompleted" "5m"
   wait_for_deployment "assisted-service" "${ASSISTED_NAMESPACE}" "5m"
   wait_for_pod "assisted-image-service" "${ASSISTED_NAMESPACE}" "app=assisted-image-service"
 
@@ -303,7 +303,7 @@ data:
 EOCR
 
   python ${__dir}/set_ca_bundle.py "${WORKING_DIR}/registry/certs/registry.2.crt" "./assisted-mirror-config"
-  tee < ./assisted-mirror-config >(oc apply -f -)
+  tee < ./assisted-mirror-config >(oc apply --wait=true -f -)
 }
 
 function from_index_image() {

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -112,7 +112,7 @@ spec:
     featureSet: Custom
 EOF
 
-    wait_for_condition "hiveconfig.hive.openshift.io/hive" "Ready" "10m"
+    wait_for_condition "hiveconfig.hive.openshift.io/hive" "condition=Ready" "10m"
 }
 
 if [ -z "$@" ] || ! declare -F "$@"; then

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -6,8 +6,9 @@ function wait_for_crd() {
     crd="$1"
     namespace="${2:-}"
 
-    wait_for_condition "crd/${crd}" "Established" "60s" "${namespace}"
+    wait_for_condition "crd/${crd}" "condition=Established" "60s" "${namespace}"
 }
+
 
 function remote_agents() {
 	namespace="$1"
@@ -26,41 +27,78 @@ function installed_remote_agents() {
 export -f installed_remote_agents
 
 function wait_for_operator() {
-    subscription="$1"
-    namespace="${2:-}"
-    echo "Waiting for operator ${subscription} to get installed on namespace ${namespace}..."
+   subscription="$1"
+   namespace="${2:-}"
+   
+   timeout=10m
+   wait_for_resource "subscriptions.operators.coreos.com/${subscription}" "${namespace}"
+   
+    
+   wait_for_field "subscriptions.operators.coreos.com/${subscription}" "${namespace}" '{..status.state}'
+   oc wait -n "${namespace}" --for=jsonpath='{..status.state}'=AtLatestKnown "subscriptions.operators.coreos.com/${subscription}" --timeout=${timeout} -o json
 
-    for _ in $(seq 1 60); do
-        csv=$(oc -n "${namespace}" get subscription "${subscription}" -o jsonpath='{.status.installedCSV}' || true)
-        if [[ -n "${csv}" ]]; then
-            if [[ "$(oc -n "${namespace}" get csv "${csv}" -o jsonpath='{.status.phase}')" == "Succeeded" ]]; then
-                echo "ClusterServiceVersion (${csv}) is ready"
-                return 0
-            fi
-        fi
 
-        sleep 10
-    done
+   wait_for_field "subscriptions.operators.coreos.com/${subscription}" "${namespace}" '{..status.installedCSV}'
+   csv=$(oc get subscriptions.operators.coreos.com/${subscription} --namespace=${namespace} -o jsonpath='{..status.installedCSV}')
+   wait_for_condition "clusterserviceversions.operators.coreos.com/${csv}"  jsonpath='{.status.phase}'="Succeeded" "5m" "${namespace}"
+ }
 
-    echo "Timed out waiting for csv to become ready!"
-    return 1
-}
+ function wait_for_field() {
+   object="$1"
+   namespace="$2"
+   jsonPath="$3"
+   retry="${4:-120}"
+  
+  counter=1
+  echo "Waiting for ${object} in namespace ${namespace} with field ${jsonPath}"
+  until [[ $(oc get "${object}"  --namespace="${namespace}" -o jsonpath="${jsonPath}" 2> /dev/null ) ]]
+  do
+    if [[ "${counter}" -eq "${retry}" ]]
+    then
+      echo "$(date --rfc-3339=seconds) ERROR: failed Waiting for ${object} in namespace ${namespace} with field ${jsonPath}"
+      oc get ${object}  --namespace="${namespace}" -o json
+      exit 1
+    fi
+    ((counter++)) && sleep 5
+  done
+ }
+
 
 function wait_for_pod() {
     pod="$1"
     namespace="${2:-}"
     selector="${3:-}"
 
-    wait_for_condition "pod" "Ready" "30m" "${namespace}" "${selector}"
+    wait_for_resource "pod" "${namespace}" "${selector}"
+    counter=1
+
+    until [[ $(oc wait -n "${namespace}" --all --for=condition=Ready pod --timeout=15m --selector="${selector}") ]]
+    do
+      if [[ "${counter}" -eq 5 ]]
+      then
+        echo "$(date --rfc-3339=seconds) ERROR: failed Waiting for pods in namespace ${namespace}"
+        oc get pods --namespace="${namespace}"
+        oc get pods --namespace="${namespace}" -o json
+        exit 1
+        break 
+      fi
+      ((counter++)) && sleep 5
+    done
+
+
 }
 
 function wait_for_pods(){
-  while [[ $(oc get pods -n $1 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'| tr ' ' '\n'  | sort -u) != "True" ]]; do
-    echo "Waiting for pods in namespace $1 to be ready"
-    oc get pods -n $1 -o 'jsonpath={..status.containerStatuses}' | jq "."
-    sleep 5;
-  done
-  echo "Pods in namespace $1 are ready"
+  namespace=$1
+
+  if [[ $(oc wait --namespace "${namespace}" --all --for=condition=Ready pod --timeout 1m) ]]; then
+    echo "All Pods in namespace ${namespace} are ready"}
+  else
+    echo "ERROR: Failed waiting for pods"
+    # debug output
+    oc get pods --namespace  "${namespace}"
+    exit 1
+  fi
 }
 
 function wait_for_deployment() {
@@ -70,11 +108,18 @@ function wait_for_deployment() {
 
     echo "Waiting for (deployment) on namespace (${namespace}) with name (${deployment}) to be created..."
     for i in {1..40}; do
-        oc get deployment "${deployment}" --namespace="${namespace}" |& grep -ivE "(no resources found|not found)" && break || sleep 10
+        oc get deployments.apps "${deployment}" --namespace="${namespace}" |& grep -ivE "(no resources found|not found)" && break || sleep 10
     done
+    if [ $i -eq 40 ]; then
+   echo "ERROR: failed Waiting for (deployment) on namespace (${namespace}) with name (${deployment}) to be created..."
+      exit 1
+    fi
 
     echo "Waiting for (deployment) on namespace (${namespace}) with name (${deployment}) to rollout..."
-    oc rollout status "deploy/${deployment}" -n "${namespace}" --timeout="${timeout}"
+
+    wait_for_field "deployments.apps/${deployment}" "${namespace}" '{..status.availableReplicas}' "600" 
+    REPLICAS=$(oc get deployments.apps --namespace="${namespace}" "${deployment}"  -o jsonpath='{..status.replicas}')
+    wait_for_condition "deployments.apps/${deployment}"  jsonpath='{..status.availableReplicas}'="${REPLICAS}" "5m" "${namespace}"
 }
 
 function hash() {
@@ -96,14 +141,11 @@ function wait_for_condition() {
     timeout="$3"
     namespace="${4:-}"
     selector="${5:-}"
-
-    echo "Waiting for (${object}) on namespace (${namespace}) with labels (${selector}) to be created..."
-    for i in {1..40}; do
-        oc get ${object} --selector="${selector}" --namespace=${namespace} |& grep -ivE "(no resources found|not found)" && break || sleep 10
-    done
+    
+    wait_for_resource "${object}" "${namespace}"
 
     echo "Waiting for (${object}) on namespace (${namespace}) with labels (${selector}) to become (${condition})..."
-    oc wait -n "${namespace}" --for=condition=${condition} --selector "${selector}" ${object} --timeout=${timeout}
+    oc wait -n "${namespace}" --for="${condition}"  "${object}" --timeout="${timeout}" --selector "${selector}" -o json
 }
 
 function wait_for_object_amount() {
@@ -153,20 +195,22 @@ function wait_for_boolean_field() {
 function wait_for_resource() {
     object="$1"
     namespace="$2"
-    interval="${4:-10}"
+    selector="${3:-}"
     set +e
-    for i in {1..50}; do
-        date --rfc-3339=seconds
-        value=$(oc get -n ${namespace} ${object} --no-headers | wc -l)
-        if [ "${value}" -ne 0 ]; then
-            return 0
-        fi
-        sleep ${interval}
-    done
-    set -e
 
-    echo "The object ${object} under namespace ${namespace} not found!"
-    return 1
+    counter=1
+    echo "$(date --rfc-3339=seconds) Waiting for resource ${object} to be create in namespace ${namespace}"
+    until [[ $(oc get "${object}"  --namespace="${namespace}" --selector "${selector}"  2> /dev/null ) ]]
+    do
+      if [[ "${counter}" -eq 150 ]]; # 2 minutes 
+      then
+        echo "$(date --rfc-3339=seconds) ERROR: failed Waiting for ${object} on namespace ${namespace}"
+        oc get ${object}  --namespace="${namespace}" -o json
+        exit 1
+        break 
+      fi
+      ((counter++)) && sleep 2
+    done
 }
 
 function get_image_without_tag() {

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -99,7 +99,7 @@ for manifest in $(find ${__dir}/generated -type f); do
     oc apply -f "${manifest}"
 done
 
-wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "ImageCreated" "5m" "${SPOKE_NAMESPACE}"
+wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "condition=ImageCreated" "5m" "${SPOKE_NAMESPACE}"
 
 echo "Waiting until at least ${SPOKE_CONTROLPLANE_AGENTS} agents are available..."
 
@@ -130,10 +130,10 @@ if [ ${SPOKE_CONTROLPLANE_AGENTS} -ne 1 ] && [ "${USER_MANAGED_NETWORKING}" == "
     fi
 fi
 
-wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "Stopped" "90m" "${SPOKE_NAMESPACE}"
+wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "condition=Stopped" "90m" "${SPOKE_NAMESPACE}"
 echo "Cluster installation has been stopped (either for good or bad reasons)"
 
-wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "Completed" "1m" "${SPOKE_NAMESPACE}"
+wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "condition=Completed" "1m" "${SPOKE_NAMESPACE}"
 echo "Cluster has been installed successfully!"
 
 wait_for_boolean_field "clusterdeployment/${ASSISTED_CLUSTER_DEPLOYMENT_NAME}" spec.installed "${SPOKE_NAMESPACE}"


### PR DESCRIPTION
Improve waiting function and debugging messages when deploying resources 

This is a fix for unstable tests, which are failing to loops timed out without error or displaying error message 
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
