### PR TITLE
MGMT-19280: iSCSI volume should be eligible on day2

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -118,9 +118,14 @@ func (v *validator) DiskIsEligible(ctx context.Context, disk *models.Disk, infra
 	if cluster != nil {
 		requirements, err = v.GetClusterHostRequirements(ctx, cluster, host)
 		clusterVersion = cluster.OpenshiftVersion
+		if common.IsDay2Cluster(cluster) {
+			// infer Openshift version from the infraEnv is case of day2
+			// because cluster.OpenshiftVersion will be empty
+			clusterVersion = infraEnv.OpenshiftVersion
+		}
 	} else {
 		requirements, err = v.GetInfraEnvHostRequirements(ctx, infraEnv)
-		clusterVersion = ""
+		clusterVersion = infraEnv.OpenshiftVersion
 	}
 	if err != nil {
 		return nil, err

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -222,10 +222,19 @@ var _ = Describe("Disk eligibility", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ContainElement("Drive type is iSCSI, it must be one of HDD, SSD, Multipath."))
 
-		By("Check infra env iSCSI is not eligible")
+		By("Check iSCSI is eligible on day2 cluster")
+		testDisk.Iscsi = &models.Iscsi{HostIPAddress: "4.5.6.7"}
+		cluster.Kind = swag.String(models.ClusterKindAddHostsCluster)
+		cluster.OpenshiftVersion = ""
+		infraEnv.OpenshiftVersion = "4.16"
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, inventory)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+
+		By("Check infra env iSCSI is eligible")
 		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, inventory)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(eligible).To(ContainElement("Drive type is iSCSI, it must be one of HDD, SSD, Multipath."))
+		Expect(eligible).To(BeEmpty())
 	})
 
 	It("Check that FC multipath is eligible", func() {


### PR DESCRIPTION
Openshift version is empty when the cluster is day2.

This fix infer the openshift version from the infraenv when the cluster
is not available or is day2.
