### PR TITLE
MGMT-19237: Update validation hook to support external platform

### DIFF
--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -5,13 +5,21 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 )
 
-func PlatformTypeToPlatform(platformType hiveext.PlatformType) *models.Platform {
-	pType := strings.ToLower(string(platformType))
+func PlatformTypeToPlatform(aciSpec hiveext.AgentClusterInstallSpec) *models.Platform {
+	pType := strings.ToLower(string(aciSpec.PlatformType))
 	platform := &models.Platform{Type: PlatformTypePtr(models.PlatformType(pType))}
+	if aciSpec.ExternalPlatformSpec != nil {
+		platform.External = &models.PlatformExternal{
+			PlatformName:           swag.String(aciSpec.ExternalPlatformSpec.PlatformName),
+			CloudControllerManager: swag.String(string(aciSpec.ExternalPlatformSpec.CloudControllerManager)),
+		}
+	}
+
 	return platform
 }
 

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook.go
@@ -172,7 +172,7 @@ func patchUserManagedNetworking(newObject *hiveext.AgentClusterInstall, logger *
 	// 1. Cluster topology is SNO.
 	// 2. Platform is specified.
 	if !isNonePlatformOrSNO(newObject) && newObject.Spec.PlatformType != "" {
-		platform := common.PlatformTypeToPlatform(newObject.Spec.PlatformType)
+		platform := common.PlatformTypeToPlatform(newObject.Spec)
 		_, platformUserManagedNetworking, err = provider.GetClusterPlatformByHighAvailabilityMode(platform, nil, highAvailabilityMode)
 		if err != nil {
 			logger.Warnf("Cannot set UserManagedNetworking automatically due to: %s", err.Error())

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
@@ -139,6 +139,41 @@ var _ = Describe("ACI mutator hook", func() {
 			patched:         false,
 		},
 		{
+			name: "ACI create with userManagedNetworking not set with External platform --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.ExternalPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with External platform and multi node --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.ExternalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 3, WorkerAgents: 3},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with External platform and SNO --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.ExternalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
 			name: "ACI updated after install start --> no change",
 			oldSpec: hiveext.AgentClusterInstallSpec{
 				Networking:            hiveext.Networking{},

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -363,7 +363,7 @@ func isUserManagedNetworkingSetToFalseWithSNO(newObject *hiveext.AgentClusterIns
 }
 
 func validateCreatePlatformAndUMN(newObject *hiveext.AgentClusterInstall) error {
-	platform := common.PlatformTypeToPlatform(newObject.Spec.PlatformType)
+	platform := common.PlatformTypeToPlatform(newObject.Spec)
 	_, _, err := provider.GetActualCreateClusterPlatformParams(
 		platform, newObject.Spec.Networking.UserManagedNetworking, getHighAvailabilityMode(newObject, nil), "")
 	return err
@@ -376,9 +376,9 @@ func validateUpdatePlatformAndUMNUpdate(oldObject, newObject *hiveext.AgentClust
 	)
 
 	if newObject.Spec.PlatformType != "" {
-		platform = common.PlatformTypeToPlatform(newObject.Spec.PlatformType)
+		platform = common.PlatformTypeToPlatform(newObject.Spec)
 	} else {
-		platform = common.PlatformTypeToPlatform(oldObject.Spec.PlatformType)
+		platform = common.PlatformTypeToPlatform(oldObject.Spec)
 	}
 
 	if newObject.Spec.Networking.UserManagedNetworking != nil {

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -607,6 +607,202 @@ var _ = Describe("ACI web validate", func() {
 			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
+		{
+			name: "ACI create with External platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with External platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI create with External platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Multi node ACI create with External platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "SNO ACI create with External platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with External platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with External platform without ExternalPlatformSpec is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI update External platform to Multi node is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       1,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update External platform with userManagedNetworking set to false not is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update External platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update External platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update BareMetalPlatformType platform with platform External is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				PlatformType: hiveext.ExternalPlatformType,
+				ExternalPlatformSpec: &hiveext.ExternalPlatformSpec{
+					PlatformName:           "test",
+					CloudControllerManager: "",
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
 	}
 
 	for i := range cases {


### PR DESCRIPTION
Update the conversion function that maps hive palatform to AI platform
to handle the external platform spec.
