### PR TITLE
MGMT-19150: add support for RAID drivers for openshift 4.14 an above

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -515,7 +515,12 @@ func (v *validator) getOCPRequirementsForVersion(openshiftVersion string) (*mode
 func (v *validator) getValidDeviceStorageTypes(hostArchitecture string, openshiftVersion string) []string {
 	validTypes := []string{string(models.DriveTypeHDD), string(models.DriveTypeSSD), string(models.DriveTypeMultipath)}
 
-	isGreater, err := common.BaseVersionGreaterOrEqual("4.15.0", openshiftVersion)
+	isGreater, err := common.BaseVersionGreaterOrEqual("4.14.0", openshiftVersion)
+	if err == nil && isGreater {
+		validTypes = append(validTypes, string(models.DriveTypeRAID))
+	}
+
+	isGreater, err = common.BaseVersionGreaterOrEqual("4.15.0", openshiftVersion)
 	if err == nil && isGreater {
 		validTypes = append(validTypes, string(models.DriveTypeISCSI))
 	}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

From openshift 4.14 users have been allowed to use nodes with intel vroc, which makes the device look like a software RAID device (md device).
This pr allows using this device type in assisted-installer as well, if the openshift version is 4.14 or above.

## List all the issues related to this PR

Part of [MGMT-19150](https://issues.redhat.com//browse/MGMT-19150) together with [this pr](https://github.com/openshift/assisted-installer-agent/pull/820) to assisted-installer-agent.

I tested the PRs together, I created an md device on a node I wanted to install as an SNO and saw in the ui that the md device shows up and can be chosen as the installation device if the openshift version is 4.14 or above.

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
