### PR TITLE
MGMT-19297: Handle user_name, org_id correctly when AUTH_TYPE RHSSO used

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -427,11 +427,6 @@ func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParam
 
 	events := []*common.Event{}
 
-	// add authorization check to query
-	if e.authz != nil {
-		tx = e.authz.OwnedBy(ctx, tx)
-	}
-
 	tx = e.prepareEventsTable(ctx, tx, params.ClusterID, params.HostIds, params.InfraEnvID, params.Severities, params.Message, params.DeletedHosts)
 	if tx == nil {
 		return make([]*common.Event, 0), &common.EventSeverityCount{}, swag.Int64(0), nil
@@ -470,6 +465,13 @@ func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParam
 		return make([]*common.Event, 0), eventSeverityCount, &eventCount, nil
 	}
 
+	// if we need to apply authorization check then repackage tx as a subquery
+	// this is to ensure that user_name and org_id are unambiguous
+	// only check this for non admin users as an admin has visibility of everything
+	// and running this as admin will result in a broken query.
+	if e.authz != nil && !e.authz.IsAdmin(ctx) {
+		tx = e.authz.OwnedBy(ctx, cleanQuery.Table("(?) as s", tx))
+	}
 	err = tx.Offset(int(*params.Offset)).Limit(int(*params.Limit)).Find(&events).Error
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -570,6 +570,16 @@ var _ = Describe("Events library", func() {
 				evs := response.GetEvents()
 				Expect(len(evs)).To(Equal(0))
 			})
+
+			It("can fetch events by host id when org tenancy is not enabled", func() {
+				cfg := &auth.Config{AuthType: auth.TypeRHSSO, EnableOrgTenancy: false}
+				authz_handler := auth.NewAuthzHandler(cfg, nil, logrus.New(), db)
+				theEvents.(*Events).authz = authz_handler
+				response, err := theEvents.V2GetEvents(ctx, common.GetDefaultV2GetEventsParams(nil, []strfmt.UUID{host}, nil))
+				Expect(err).ShouldNot(HaveOccurred())
+				evs := response.GetEvents()
+				Expect(len(evs)).To(Equal(2))
+			})
 		})
 	})
 


### PR DESCRIPTION
Presently there is a bug in the way we handle AUTH_TYPE RHSSO while fetching the events list.

A join is performed between infra_envs and either hosts or clusters, this leads to some ambiguity around column names in WHERE clauses.

Specifically the fields `user_name` and `org_id`, combinations of which appear in hosts, clusters and infra_envs.

This change applies the authorization check by turning the final database query into a subquery and then filtering on the returned user_name, org_id columns in the subquery.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
