### PR TITLE
MGMT-19159: Switch kube api release image cache to map

### DIFF
--- a/internal/versions/common.go
+++ b/internal/versions/common.go
@@ -53,9 +53,10 @@ func NewHandler(
 	}
 
 	if enableKubeAPI {
+		releaseImagesCache := convertReleaseImagesToMap(releaseImages)
 		h := &kubeAPIVersionsHandler{
 			mustGatherVersions: mustGatherVersions,
-			releaseImages:      releaseImages,
+			releaseImages:      releaseImagesCache,
 			releaseHandler:     releaseHandler,
 			releaseImageMirror: releaseImageMirror,
 			log:                log,
@@ -280,4 +281,20 @@ func validateReleaseImage(releaseImage *models.ReleaseImage) error {
 
 	// To validate CPU architecture enum
 	return releaseImage.Validate(strfmt.Default)
+}
+
+func convertReleaseImagesToMap(releaseImages models.ReleaseImages) map[string]*models.ReleaseImage {
+	releaseImagesCache := make(map[string]*models.ReleaseImage, len(releaseImages))
+	for _, releaseImage := range releaseImages {
+		releaseImagesCache[*releaseImage.URL] = releaseImage
+	}
+	return releaseImagesCache
+}
+
+func convertMapToReleaseImages(releaseImagesMap map[string]*models.ReleaseImage) models.ReleaseImages {
+	var releaseImages []*models.ReleaseImage
+	for _, img := range releaseImagesMap {
+		releaseImages = append(releaseImages, img)
+	}
+	return releaseImages
 }


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

In the event that there are a large amount of `ClusterImageSets`, looping through an array to find a release image takes a long time, and sometimes results in operations timing out. This switches the storage of cached release images to a map instead of an array to speed up the lookup. This should prevent timeouts from occurring when release image lookup is needed.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 