### PR TITLE
NO-ISSUE: Allow configuring suported GPUs

### DIFF
--- a/internal/operators/openshiftai/openshift_ai_config.go
+++ b/internal/operators/openshiftai/openshift_ai_config.go
@@ -13,4 +13,9 @@ type Config struct {
 	// `oc` command, and that way we don't need an additional image. But in the future we will probably want to have
 	// a separate image that contains the things that we need to run these setup jobs.
 	ControllerImage string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-controller:latest"`
+
+	// SupportedGPUS is a comma separated list of vendor identifiers of supported GPUs. For examaple, to enable
+	// support for NVIDIA and Virtio GPUS the value should be `10de,1af4`. By default only NVIDIA GPUs are
+	// supported.
+	SupportedGPUs []string `envconfig:"OPENSHIFT_AI_SUPPORTED_GPUS" default:"10de"`
 }

--- a/internal/operators/openshiftai/openshift_ai_operator.go
+++ b/internal/operators/openshiftai/openshift_ai_operator.go
@@ -3,6 +3,7 @@ package openshiftai
 import (
 	"context"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
@@ -18,8 +19,6 @@ import (
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 )
-
-const nvidiaVendorID = "10de"
 
 var Operator = models.MonitoredOperator{
 	Namespace:        "redhat-ods-operator",
@@ -166,12 +165,12 @@ func (o *operator) gpusInHost(host *models.Host) (result []*models.Gpu, err erro
 }
 
 func (o *operator) isSupportedGpu(gpu *models.Gpu) (result bool, err error) {
-	result, err = o.isNvidiaGpu(gpu)
-	return
-}
-
-func (o *operator) isNvidiaGpu(gpu *models.Gpu) (result bool, err error) {
-	result = gpu.VendorID == nvidiaVendorID
+	for _, supportedGpu := range o.config.SupportedGPUs {
+		if strings.EqualFold(gpu.VendorID, supportedGpu) {
+			result = true
+			return
+		}
+	}
 	return
 }
 

--- a/internal/operators/openshiftai/openshift_ai_operator_test.go
+++ b/internal/operators/openshiftai/openshift_ai_operator_test.go
@@ -2,6 +2,7 @@ package openshiftai
 
 import (
 	"context"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -94,6 +95,81 @@ var _ = Describe("Operator", func() {
 				Status:       api.Success,
 				ValidationId: operator.GetHostValidationID(),
 			},
+		),
+	)
+
+	DescribeTable(
+		"Is supported GPU",
+		func(env map[string]string, gpu *models.Gpu, expected bool) {
+			// Set the environment variables and restore the previous values when finished:
+			for name, value := range env {
+				oldValue, present := os.LookupEnv(name)
+				if present {
+					defer func() {
+						err := os.Setenv(name, oldValue)
+						Expect(err).ToNot(HaveOccurred())
+					}()
+				} else {
+					defer func() {
+						err := os.Unsetenv(name)
+						Expect(err).ToNot(HaveOccurred())
+					}()
+				}
+				err := os.Setenv(name, value)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Create the operator:
+			operator = NewOpenShiftAIOperator(common.GetTestLog())
+
+			// Run the check:
+			actual, err := operator.isSupportedGpu(gpu)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"NVIDIA is supported by default",
+			nil,
+			&models.Gpu{
+				VendorID: "10de",
+			},
+			true,
+		),
+		Entry(
+			"Virtio isn't supported by default",
+			nil,
+			&models.Gpu{
+				VendorID: "1af4",
+			},
+			false,
+		),
+		Entry(
+			"Virtio is supported if explicitly added",
+			map[string]string{
+				"OPENSHIFT_AI_SUPPORTED_GPUS": "10de,1af4",
+			},
+			&models.Gpu{
+				VendorID: "1af4",
+			},
+			true,
+		),
+		Entry(
+			"Order isn't relevant",
+			map[string]string{
+				"OPENSHIFT_AI_SUPPORTED_GPUS": "1af4,10de",
+			},
+			&models.Gpu{
+				VendorID: "10de",
+			},
+			true,
+		),
+		Entry(
+			"Case isn't relevant",
+			nil,
+			&models.Gpu{
+				VendorID: "10DE",
+			},
+			true,
 		),
 	)
 })

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -222,6 +222,8 @@ parameters:
   value: "false"
 - name: ENVOY_CONFIGMAP_NAME
   value: assisted-service-envoy-config
+- name: OPENSHIFT_AI_SUPPORTED_GPUS
+  value: "10de"
 apiVersion: v1
 kind: Template
 metadata:
@@ -497,6 +499,8 @@ objects:
                 value: ${OPENSHIFT_SUPPORT_LEVEL_API_BASE_URL}
               - name: IGNORED_OPENSHIFT_VERSIONS
                 value: ${IGNORED_OPENSHIFT_VERSIONS}
+              - name: OPENSHIFT_AI_SUPPORTED_GPUS
+                value: ${OPENSHIFT_AI_SUPPORTED_GPUS}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
Currently the OpenShift AI operator only supports NVIDIA GPUs. This complicates testing in environments where there are no such GPUs. To simplify that this patch adds a new `OPENSHIFT_AI_SUPPORTED_GPUS` environment variable that contains the vendor identifiers of the supported GPUs. By default the value is `10de`, which is the NVIDIA vendor identifier, so we still only support NVIDIA GPUs by default. But the value can be a comma separated list of vendor identifiers. For example, the value `10de,1af4` means that both NVIDIA and Virtio GPUs are supported. This can be used in the testing environments to be able to test the operator using virtual GPUs without any real hardware.

Note that this use of Virtio GPUs is intended only for tests: it isn't possible to actually use those virtual GPUs to run AI workloads.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19317
https://issues.redhat.com/browse/MGMT-19056

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
