### PR TITLE
MGMT-19331: Secure boot must be disabled for NVIDIA GPUs

### DIFF
--- a/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
@@ -1,0 +1,184 @@
+package nvidiagpu
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("Operator", func() {
+	var (
+		ctx      context.Context
+		operator *operator
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		operator = NewNvidiaGPUOperator(common.GetTestLog())
+	})
+
+	DescribeTable(
+		"Validate hosts",
+		func(inventory *models.Inventory, expected api.ValidationResult) {
+			data, err := json.Marshal(inventory)
+			Expect(err).ToNot(HaveOccurred())
+			host := &models.Host{
+				Inventory: string(data),
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					Hosts: []*models.Host{
+						host,
+					},
+				},
+			}
+			actual, _ := operator.ValidateHost(ctx, cluster, host, nil)
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"With GPU and secure boot enabled",
+			&models.Inventory{
+				Gpus: []*models.Gpu{{
+					VendorID: nvidiaVendorID,
+				}},
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateEnabled,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Failure,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons: []string{
+					"Secure boot is enabled, but it needs to be disabled in order to load NVIDIA " +
+						"GPU drivers",
+				},
+			},
+		),
+		Entry(
+			"With GPU and secure boot disabled",
+			&models.Inventory{
+				Gpus: []*models.Gpu{{
+					VendorID: nvidiaVendorID,
+				}},
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateDisabled,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"With GPU and secure boot not supported",
+			&models.Inventory{
+				Gpus: []*models.Gpu{{
+					VendorID: nvidiaVendorID,
+				}},
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateNotSupported,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"With GPU and secure boot state unknown",
+			&models.Inventory{
+				Gpus: []*models.Gpu{{
+					VendorID: nvidiaVendorID,
+				}},
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateUnknown,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"Without GPU and secure boot enabled",
+			&models.Inventory{
+				Gpus: nil,
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateEnabled,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"Without GPU and secure boot disabled",
+			&models.Inventory{
+				Gpus: nil,
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateDisabled,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"Without GPU and secure boot not supported",
+			&models.Inventory{
+				Gpus: nil,
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateNotSupported,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"Without GPU and secure boot state unknown",
+			&models.Inventory{
+				Gpus: nil,
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateUnknown,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+		Entry(
+			"With non NVIDIA GPU and secure boot enabled",
+			&models.Inventory{
+				Gpus: []*models.Gpu{{
+					VendorID: "1af4",
+				}},
+				Boot: &models.Boot{
+					SecureBootState: models.SecureBootStateEnabled,
+				},
+			},
+			api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: operator.GetHostValidationID(),
+				Reasons:      nil,
+			},
+		),
+	)
+})


### PR DESCRIPTION
Currently when the _OpenShift AI_ operator is enabled the NVIDIA GPU is automatically enabled as well. But this operator will not work if secure boot is enabled: the NVIDIA drivers are built dinamically, and not signed, so they can't be loaded. To ensure that the user is aware of that this patch adds a validation to check that.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19331

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
