### PR TITLE
MGMT-19192: Add current stage when restoring host by Agent

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -73,6 +73,7 @@ const (
 	AgentLabelCpuArchitecture            = InventoryLabelPrefix + "cpu-architecture"
 	AgentLabelCpuVirtEnabled             = InventoryLabelPrefix + "cpu-virtenabled"
 	AgentInventoryAnnotation             = "agent." + aiv1beta1.Group + "/inventory"
+	AgentCurrentStageAnnotation          = "agent." + aiv1beta1.Group + "/current-stage"
 	AgentRoleAnnotation                  = "agent." + aiv1beta1.Group + "/role"
 	AgentLabelHostManufacturer           = InventoryLabelPrefix + "host-manufacturer"
 	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
@@ -257,6 +258,9 @@ func updateAnnotations(log logrus.FieldLogger, agent *v1beta1.Agent, h *models.H
 	updated = setAgentAnnotation(log, agent, AgentStateAnnotation, swag.StringValue(h.Status))
 	updated = setAgentAnnotation(log, agent, AgentRoleAnnotation, string(h.Role)) || updated
 	updated = setAgentAnnotation(log, agent, AgentInventoryAnnotation, h.Inventory) || updated
+	if h.Progress != nil {
+		updated = setAgentAnnotation(log, agent, AgentCurrentStageAnnotation, string(h.Progress.CurrentStage))
+	}
 	return updated
 }
 
@@ -1852,6 +1856,14 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 		InfraEnvID:    infraEnvID,
 		Status:        &hostStatus,
 		Inventory:     inventory,
+	}
+
+	// Fetch Current Stage
+	if stage, has_annotation := agent.GetAnnotations()[AgentCurrentStageAnnotation]; has_annotation {
+		currentStage := models.HostStage(stage)
+		if err := currentStage.Validate(nil); err == nil {
+			host.Progress = &models.HostProgressInfo{CurrentStage: currentStage}
+		}
 	}
 
 	return host, nil

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4520,6 +4520,121 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(result).To(Equal(ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}))
 	})
+	Context("Agent Stage", func() {
+		It("should restore the Agent's stage if it's valid", func() {
+			// Create ClusterDeployment
+			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+
+			// Create Agent
+			agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: clusterDeployment.Name, Namespace: clusterDeployment.Namespace}})
+			mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).AnyTimes()
+			agent.ObjectMeta.Labels = map[string]string{
+				v1beta1.InfraEnvNameLabel:  "infraEnvName",
+				AgentLabelHostManufacturer: "RedHat",
+			}
+			agent.ObjectMeta.Annotations = map[string]string{
+				AgentCurrentStageAnnotation: string(models.HostStageDone),
+			}
+			Expect(c.Create(ctx, agent)).To(BeNil())
+
+			// Mock InfraEnv
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			infraEnvKey := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "infraEnvName",
+			}
+			clusterId := *backEndCluster.ID
+			backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+			// Create Host
+			host, err := createNewHost(agent, &clusterId, infraEnvId)
+			Expect(err).To(BeNil())
+			Expect(host.Progress.CurrentStage).To(Equal(models.HostStageDone))
+			mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(gomock.Any(), infraEnvKey, gomock.Any()).Return(nil).Times(1)
+
+			// Reconcile Agent
+			result, err := hr.Reconcile(ctx, newHostRequest(agent))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+			// Ensure the Agent exists
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "agent",
+			}
+			Expect(c.Get(ctx, key, agent)).To(BeNil())
+			Expect(agent.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
+			// Reconcile Agent again to get a status update
+			mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&common.Host{Host: *host}, nil).Times(1)
+			allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, infraEnvKey.Name)
+
+			result, err = hr.Reconcile(ctx, newHostRequest(agent))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(c.Get(ctx, key, agent)).To(BeNil())
+			Expect(agent.Status.Progress.CurrentStage).To(Equal(models.HostStageDone))
+		})
+		It("should not restore the Agent's stage if it's invalid", func() {
+			// Create ClusterDeployment
+			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+
+			// Create Agent
+			agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: clusterDeployment.Name, Namespace: clusterDeployment.Namespace}})
+			mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).AnyTimes()
+			agent.ObjectMeta.Labels = map[string]string{
+				v1beta1.InfraEnvNameLabel:  "infraEnvName",
+				AgentLabelHostManufacturer: "RedHat",
+			}
+			agent.ObjectMeta.Annotations = map[string]string{
+				AgentCurrentStageAnnotation: "invalid-stage",
+			}
+			Expect(c.Create(ctx, agent)).To(BeNil())
+
+			// Mock InfraEnv
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			infraEnvKey := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "infraEnvName",
+			}
+			clusterId := *backEndCluster.ID
+			backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+			// Create Host
+			host, err := createNewHost(agent, &clusterId, infraEnvId)
+			Expect(err).To(BeNil())
+			Expect(host.Progress).To(BeNil())
+			mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(gomock.Any(), infraEnvKey, gomock.Any()).Return(nil).Times(1)
+
+			// Reconcile Agent
+			result, err := hr.Reconcile(ctx, newHostRequest(agent))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+			// Ensure the Agent exists
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "agent",
+			}
+			Expect(c.Get(ctx, key, agent)).To(BeNil())
+			Expect(agent.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(agent.Status.Progress.CurrentStage).To(BeEmpty())
+			// Reconcile Agent again to get a status update
+			mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&common.Host{Host: *host}, nil).Times(1)
+			allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, infraEnvKey.Name)
+
+			result, err = hr.Reconcile(ctx, newHostRequest(agent))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(c.Get(ctx, key, agent)).To(BeNil())
+			Expect(agent.Status.Progress.CurrentStage).To(BeEmpty())
+		})
+	})
 })
 
 var _ = Describe("createNewHost", func() {


### PR DESCRIPTION
For completeness, if a host has begun installing, store the current stage in the Agent's annotations so that if a host needs to be restored, we'll also have that data.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): 
    - Installed a hypershift `HostedCluster` and scaled up the `NodePool` to include one `Agent`
    - wait until the `Agent` was in `Done` stage
    - Saved the `Agent` CR and deleted the `Agent` (ensuring to annotate before deleting with `oc annotate agent --all -n spoke-cluster agent.agent-install.openshift.io/skip-spoke-cleanup=true`)
    - Removed the host from the DB and restored the `Agent` (oc apply)
    - After the `Agent` is restored, checked `oc get agent` to verify that the stage was `Done`
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
