### PR TITLE
MGMT-19360: do not monitor hosts with status installed

### DIFF
--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -35,7 +35,6 @@ func (m *Manager) initMonitoringQueryGenerator() {
 				models.HostStatusPreparingSuccessful,
 				models.HostStatusInstalling,
 				models.HostStatusInstallingInProgress,
-				models.HostStatusInstalled,
 				models.HostStatusInstallingPendingUserAction,
 				models.HostStatusResettingPendingUserAction,
 				models.HostStatusCancelled, // for limited time, until log collection finished or timed-out

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -40,7 +40,7 @@ func (m *Manager) initMonitoringQueryGenerator() {
 			logCollectionEndStates := []string{
 				string(models.LogsStateCompleted),
 				string(models.LogsStateTimeout),
-				"",
+				string(models.LogsStateEmpty),
 			}
 
 			dbWithCondition := common.LoadTableFromDB(db, common.HostsTable, "status in (?) or (status in (?) and logs_info not in (?))", monitorStates, monitorStatesUntilLogCollection, logCollectionEndStates)

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -320,59 +320,58 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 	})
 
 	Context("validate host status monitoring", func() {
-		BeforeEach(func() {
+		DescribeTable("status", func(clusterStatus string, hostStatus string, logState models.LogsState, expectedCount int) {
 			clusterID = strfmt.UUID(uuid.New().String())
 			cluster := hostutil.GenerateTestCluster(clusterID)
+			cluster.Status = swag.String(clusterStatus)
 			Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
 
 			host.CheckedInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 			db.Save(&host)
-		})
-
-		DescribeTable("status", func(status string, logState models.LogsState, expectedCount int) {
 			host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, models.HostStatusDiscovering)
 			host.Inventory = workerInventory()
 			host.LogsInfo = logState
 			Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
-			Expect(db.Model(&host).Update("status", status).Error).ShouldNot(HaveOccurred())
+			Expect(db.Model(&host).Update("status", hostStatus).Error).ShouldNot(HaveOccurred())
 
 			mockMetricApi.EXPECT().MonitoredHostsCount(int64(expectedCount)).Times(1)
 			state.HostMonitoring()
 		},
-			Entry("HostStatusAddedToExistingCluster is not monitored", models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
-			Entry("HostStatusBinding is not monitored", models.HostStatusBinding, models.LogsStateCompleted, 0),
-			Entry("HostStatusCancelled is monitored when waiting for log state", models.HostStatusCancelled, models.LogsStateCollecting, 1),
-			Entry("HostStatusCancelled is not monitored when log state has timed out", models.HostStatusCancelled, models.LogsStateTimeout, 0),
-			Entry("HostStatusCancelled is not monitored when log state is completed", models.HostStatusCancelled, models.LogsStateCompleted, 0),
-			Entry("HostStatusCancelled is not monitored when log state is empty", models.HostStatusCancelled, models.LogsStateEmpty, 0),
-			Entry("HostStatusDisabled is not monitored", models.HostStatusDisabled, models.LogsStateCompleted, 0),
-			Entry("HostStatusDisabledUnbound is not monitored", models.HostStatusDisabledUnbound, models.LogsStateCompleted, 0),
-			Entry("HostStatusDisconnected is monitored", models.HostStatusDisconnected, models.LogsStateCompleted, 1),
-			Entry("HostStatusDisconnectedUnbound is not monitored", models.HostStatusDisconnectedUnbound, models.LogsStateCompleted, 0),
-			Entry("HostStatusDiscovering is monitored", models.HostStatusDiscovering, models.LogsStateCompleted, 1),
-			Entry("HostStatusDiscoveringUnbound is not monitored", models.HostStatusDiscoveringUnbound, models.LogsStateCompleted, 0),
-			Entry("HostStatusError is monitored when waiting for log state", models.HostStatusError, models.LogsStateCollecting, 1),
-			Entry("HostStatusError is not monitored when log state has timed out", models.HostStatusError, models.LogsStateTimeout, 0),
-			Entry("HostStatusError is not monitored when log state is completed", models.HostStatusError, models.LogsStateCompleted, 0),
-			Entry("HostStatusError is not monitored when log state is empty", models.HostStatusError, models.LogsStateEmpty, 0),
-			Entry("HostStatusInstalled is not monitored", models.HostStatusInstalled, models.LogsStateCompleted, 0),
-			Entry("HostStatusInstalling is monitored", models.HostStatusInstalling, models.LogsStateCompleted, 1),
-			Entry("HostStatusInstallingInProgress is monitored", models.HostStatusInstallingInProgress, models.LogsStateCompleted, 1),
-			Entry("HostStatusInstallingPendingUserAction is monitored", models.HostStatusInstallingPendingUserAction, models.LogsStateCompleted, 1),
-			Entry("HostStatusInsufficient is monitored", models.HostStatusInsufficient, models.LogsStateCompleted, 1),
-			Entry("HostStatusInsufficientUnbound is not monitored", models.HostStatusInsufficientUnbound, models.LogsStateCompleted, 0),
-			Entry("HostStatusKnown is monitored", models.HostStatusKnown, models.LogsStateCompleted, 1),
-			Entry("HostStatusKnownUnbound is not monitored", models.HostStatusKnownUnbound, models.LogsStateCompleted, 0),
-			Entry("HostStatusPendingForInput is monitored", models.HostStatusPendingForInput, models.LogsStateCompleted, 1),
-			Entry("HostStatusPreparingFailed is monitored", models.HostStatusPreparingFailed, models.LogsStateCompleted, 1),
-			Entry("HostStatusPreparingForInstallation is monitored", models.HostStatusPreparingForInstallation, models.LogsStateCompleted, 1),
-			Entry("HostStatusPreparingSuccessful is monitored", models.HostStatusPreparingSuccessful, models.LogsStateCompleted, 1),
-			Entry("HostStatusReclaiming is not monitored", models.HostStatusReclaiming, models.LogsStateCompleted, 0),
-			Entry("HostStatusReclaimingRebooting is not monitored", models.HostStatusReclaimingRebooting, models.LogsStateCompleted, 0),
-			Entry("HostStatusResetting is not monitored", models.HostStatusResetting, models.LogsStateCompleted, 0),
-			Entry("HostStatusResettingPendingUserAction is monitored", models.HostStatusResettingPendingUserAction, models.LogsStateCompleted, 1),
-			Entry("HostStatusUnbinding is not monitored", models.HostStatusUnbinding, models.LogsStateCompleted, 0),
-			Entry("HostStatusUnbindingPendingUserAction is not monitored", models.HostStatusUnbindingPendingUserAction, models.LogsStateCompleted, 0),
+			Entry("HostStatusAddedToExistingCluster is not monitored", models.ClusterStatusReady, models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
+			Entry("HostStatusBinding is not monitored", models.ClusterStatusReady, models.HostStatusBinding, models.LogsStateCompleted, 0),
+			Entry("HostStatusCancelled is monitored when waiting for log state", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateCollecting, 1),
+			Entry("HostStatusCancelled is not monitored when log state has timed out", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateTimeout, 0),
+			Entry("HostStatusCancelled is not monitored when log state is completed", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateCompleted, 0),
+			Entry("HostStatusCancelled is not monitored when log state is empty", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateEmpty, 0),
+			Entry("HostStatusDisabled is not monitored", models.ClusterStatusReady, models.HostStatusDisabled, models.LogsStateCompleted, 0),
+			Entry("HostStatusDisabledUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDisabledUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusDisconnected is monitored", models.ClusterStatusReady, models.HostStatusDisconnected, models.LogsStateCompleted, 1),
+			Entry("HostStatusDisconnectedUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDisconnectedUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusDiscovering is monitored", models.ClusterStatusReady, models.HostStatusDiscovering, models.LogsStateCompleted, 1),
+			Entry("HostStatusDiscoveringUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDiscoveringUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusError is monitored when waiting for log state", models.ClusterStatusReady, models.HostStatusError, models.LogsStateCollecting, 1),
+			Entry("HostStatusError is not monitored when log state has timed out", models.ClusterStatusReady, models.HostStatusError, models.LogsStateTimeout, 0),
+			Entry("HostStatusError is not monitored when log state is completed", models.ClusterStatusReady, models.HostStatusError, models.LogsStateCompleted, 0),
+			Entry("HostStatusError is not monitored when log state is empty", models.ClusterStatusReady, models.HostStatusError, models.LogsStateEmpty, 0),
+			Entry("HostStatusInstalled is monitored when cluster status not installed", models.ClusterStatusReady, models.HostStatusInstalled, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstalled is not monitored when cluster status is installed", models.ClusterStatusInstalled, models.HostStatusInstalled, models.LogsStateCompleted, 0),
+			Entry("HostStatusInstalling is monitored", models.ClusterStatusReady, models.HostStatusInstalling, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstallingInProgress is monitored", models.ClusterStatusReady, models.HostStatusInstallingInProgress, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstallingPendingUserAction is monitored", models.ClusterStatusReady, models.HostStatusInstallingPendingUserAction, models.LogsStateCompleted, 1),
+			Entry("HostStatusInsufficient is monitored", models.ClusterStatusReady, models.HostStatusInsufficient, models.LogsStateCompleted, 1),
+			Entry("HostStatusInsufficientUnbound is not monitored", models.ClusterStatusReady, models.HostStatusInsufficientUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusKnown is monitored", models.ClusterStatusReady, models.HostStatusKnown, models.LogsStateCompleted, 1),
+			Entry("HostStatusKnownUnbound is not monitored", models.ClusterStatusReady, models.HostStatusKnownUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusPendingForInput is monitored", models.ClusterStatusReady, models.HostStatusPendingForInput, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingFailed is monitored", models.ClusterStatusReady, models.HostStatusPreparingFailed, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingForInstallation is monitored", models.ClusterStatusReady, models.HostStatusPreparingForInstallation, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingSuccessful is monitored", models.ClusterStatusReady, models.HostStatusPreparingSuccessful, models.LogsStateCompleted, 1),
+			Entry("HostStatusReclaiming is not monitored", models.ClusterStatusReady, models.HostStatusReclaiming, models.LogsStateCompleted, 0),
+			Entry("HostStatusReclaimingRebooting is not monitored", models.ClusterStatusReady, models.HostStatusReclaimingRebooting, models.LogsStateCompleted, 0),
+			Entry("HostStatusResetting is not monitored", models.ClusterStatusReady, models.HostStatusResetting, models.LogsStateCompleted, 0),
+			Entry("HostStatusResettingPendingUserAction is monitored", models.ClusterStatusReady, models.HostStatusResettingPendingUserAction, models.LogsStateCompleted, 1),
+			Entry("HostStatusUnbinding is not monitored", models.ClusterStatusReady, models.HostStatusUnbinding, models.LogsStateCompleted, 0),
+			Entry("HostStatusUnbindingPendingUserAction is not monitored", models.ClusterStatusReady, models.HostStatusUnbindingPendingUserAction, models.LogsStateCompleted, 0),
 		)
 	})
 })

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -326,8 +326,6 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			cluster.Status = swag.String(clusterStatus)
 			Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
 
-			host.CheckedInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
-			db.Save(&host)
 			host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, models.HostStatusDiscovering)
 			host.Inventory = workerInventory()
 			host.LogsInfo = logState


### PR DESCRIPTION
Performance test in stage showed that the assisted-service continued to
monitor hosts even after the cluster installed. This behavior consumes
a lot of CPU, this PR disables it by stopping monitoring  hosts in "Installed" 
state when cluster state is "Installed".

Also, move the logic from `SkipMonitoring` function into the SQL query so
we avoid to retrieve hosts that we be skipped anyway (and save some
un-marshaling operations).
