### PR TITLE
MGMT-19388: Add NTP sources to generated install-config.yaml - ACM 2.12

### DIFF
--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -203,7 +203,7 @@ func (i *installConfigBuilder) getInstallConfig(cluster *common.Cluster, cluster
 		return nil, err
 	}
 
-	err = i.providerRegistry.AddPlatformToInstallConfig(cfg, cluster)
+	err = i.providerRegistry.AddPlatformToInstallConfig(cfg, cluster, clusterInfraenvs)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error while adding Platfom %s to install config, error is: %w", common.PlatformTypeValue(cluster.Platform.Type), err)

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -42,6 +42,7 @@ type BareMetalInstallConfigPlatform struct {
 	ProvisioningNetworkInterface string   `json:"provisioningNetworkInterface,omitempty"`
 	ProvisioningNetworkCIDR      *string  `json:"provisioningNetworkCIDR,omitempty"`
 	ProvisioningDHCPRange        string   `json:"provisioningDHCPRange,omitempty"`
+	AdditionalNTPServers         []string `json:"additionalNTPServers,omitempty"`
 }
 
 type VsphereFailureDomainTopology struct {

--- a/internal/provider/baremetal/installConfig_test.go
+++ b/internal/provider/baremetal/installConfig_test.go
@@ -1,0 +1,129 @@
+package baremetal
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/installcfg"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Add NTP sources", func() {
+	var (
+		logger    logrus.FieldLogger
+		cluster   *common.Cluster
+		infraEnvs []*common.InfraEnv
+		cfg       *installcfg.InstallerConfigBaremetal
+		provider  provider.Provider
+	)
+
+	BeforeEach(func() {
+		logger = common.GetTestLog()
+		cluster = &common.Cluster{
+			Cluster: models.Cluster{
+				OpenshiftVersion: "4.18",
+			},
+		}
+		infraEnvs = []*common.InfraEnv{{
+			InfraEnv: models.InfraEnv{},
+		}}
+		cfg = &installcfg.InstallerConfigBaremetal{
+			ControlPlane: struct {
+				Hyperthreading string "json:\"hyperthreading,omitempty\""
+				Name           string "json:\"name\""
+				Replicas       int    "json:\"replicas\""
+			}{
+				Replicas: 1,
+			},
+			Compute: []struct {
+				Hyperthreading string "json:\"hyperthreading,omitempty\""
+				Name           string "json:\"name\""
+				Replicas       int    "json:\"replicas\""
+			}{{
+				Replicas: 1,
+			}},
+		}
+		provider = NewBaremetalProvider(logger)
+	})
+
+	It("Does nothing if there are no NTP sources", func() {
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(BeEmpty())
+	})
+
+	It("Adds one NTP source from cluster", func() {
+		cluster.AdditionalNtpSource = "1.1.1.1"
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1"))
+	})
+
+	It("Adds multiple NTP sources from cluster", func() {
+		cluster.AdditionalNtpSource = "1.1.1.1,2.2.2.2,3.3.3.3"
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1", "2.2.2.2", "3.3.3.3"))
+	})
+
+	It("Removes extra white space in NTP sources from cluster", func() {
+		cluster.AdditionalNtpSource = "  1.1.1.1,   \t  2.2.2.2 , 3.3.3.3  "
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1", "2.2.2.2", "3.3.3.3"))
+	})
+
+	It("Adds one source from one infrastructure environment", func() {
+		infraEnvs[0].AdditionalNtpSources = "1.1.1.1"
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1"))
+	})
+
+	It("Adds multiple sources from one infrastructure environment", func() {
+		infraEnvs[0].AdditionalNtpSources = "1.1.1.1,2.2.2.2,3.3.3.3"
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1", "2.2.2.2", "3.3.3.3"))
+	})
+
+	It("Removes extra white space in NTP sources from infrastructure environment", func() {
+		infraEnvs[0].AdditionalNtpSources = "  1.1.1.1,   \t  2.2.2.2 , 3.3.3.3  "
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1", "2.2.2.2", "3.3.3.3"))
+	})
+
+	It("Ignores sources from infrastructure environment if there are NTP sources in the cluster", func() {
+		cluster.AdditionalNtpSource = "1.1.1.1"
+		infraEnvs[0].AdditionalNtpSources = "2.2.2.2"
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1"))
+	})
+
+	It("Combines NTP sources from multiple infrastructure environments", func() {
+		infraEnvs := []*common.InfraEnv{
+			{
+				InfraEnv: models.InfraEnv{
+					AdditionalNtpSources: "1.1.1.1",
+				},
+			},
+			{
+				InfraEnv: models.InfraEnv{
+					AdditionalNtpSources: "2.2.2.2",
+				},
+			},
+			{
+				InfraEnv: models.InfraEnv{
+					AdditionalNtpSources: "3.3.3.3",
+				},
+			},
+		}
+		err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Platform.Baremetal.AdditionalNTPServers).To(ConsistOf("1.1.1.1", "2.2.2.2", "3.3.3.3"))
+	})
+})

--- a/internal/provider/baremetal/suite_test.go
+++ b/internal/provider/baremetal/suite_test.go
@@ -1,0 +1,13 @@
+package baremetal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBaremetalProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Baremetal provider")
+}

--- a/internal/provider/base.go
+++ b/internal/provider/base.go
@@ -26,7 +26,8 @@ type Provider interface {
 	IsProviderForPlatform(platform *models.Platform) bool
 	// AddPlatformToInstallConfig adds the provider platform to the installconfig platform field,
 	// sets platform fields from values within the cluster model.
-	AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error
+	AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster,
+		infraEnvs []*common.InfraEnv) error
 	// CleanPlatformValuesFromDBUpdates remove platform specific values from the `updates` data structure
 	CleanPlatformValuesFromDBUpdates(updates map[string]interface{}) error
 	// SetPlatformUsages uses the usageApi to update platform specific usages

--- a/internal/provider/external/base.go
+++ b/internal/provider/external/base.go
@@ -27,7 +27,8 @@ func (p *baseExternalProvider) AreHostsSupported(hosts []*models.Host) (bool, er
 	return true, nil
 }
 
-func (p *baseExternalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+func (p *baseExternalProvider) AddPlatformToInstallConfig(
+	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster, infraEnvs []*common.InfraEnv) error {
 	cfg.Platform = installcfg.Platform{
 		External: &installcfg.ExternalInstallConfigPlatform{
 			PlatformName:           *cluster.Platform.External.PlatformName,

--- a/internal/provider/mock_base_provider.go
+++ b/internal/provider/mock_base_provider.go
@@ -38,17 +38,17 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // AddPlatformToInstallConfig mocks base method.
-func (m *MockProvider) AddPlatformToInstallConfig(arg0 *installcfg.InstallerConfigBaremetal, arg1 *common.Cluster) error {
+func (m *MockProvider) AddPlatformToInstallConfig(arg0 *installcfg.InstallerConfigBaremetal, arg1 *common.Cluster, arg2 []*common.InfraEnv) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddPlatformToInstallConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddPlatformToInstallConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddPlatformToInstallConfig indicates an expected call of AddPlatformToInstallConfig.
-func (mr *MockProviderMockRecorder) AddPlatformToInstallConfig(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockProviderMockRecorder) AddPlatformToInstallConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPlatformToInstallConfig", reflect.TypeOf((*MockProvider)(nil).AddPlatformToInstallConfig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPlatformToInstallConfig", reflect.TypeOf((*MockProvider)(nil).AddPlatformToInstallConfig), arg0, arg1, arg2)
 }
 
 // AreHostsSupported mocks base method.

--- a/internal/provider/none/installConfig.go
+++ b/internal/provider/none/installConfig.go
@@ -6,7 +6,8 @@ import (
 	"github.com/openshift/assisted-service/internal/provider"
 )
 
-func (p noneProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+func (p noneProvider) AddPlatformToInstallConfig(
+	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster, infraEnvs []*common.InfraEnv) error {
 	cfg.Platform = installcfg.Platform{
 		None: &installcfg.PlatformNone{},
 	}

--- a/internal/provider/nutanix/installConfig.go
+++ b/internal/provider/nutanix/installConfig.go
@@ -39,7 +39,7 @@ func setPlatformValues(platform *installcfg.NutanixInstallConfigPlatform) {
 }
 
 func (p nutanixProvider) AddPlatformToInstallConfig(
-	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster, infraEnvs []*common.InfraEnv) error {
 	nPlatform := &installcfg.NutanixInstallConfigPlatform{}
 	if !swag.BoolValue(cluster.UserManagedNetworking) {
 		if len(cluster.APIVips) == 0 {

--- a/internal/provider/registry/mock_providerregistry.go
+++ b/internal/provider/registry/mock_providerregistry.go
@@ -39,17 +39,17 @@ func (m *MockProviderRegistry) EXPECT() *MockProviderRegistryMockRecorder {
 }
 
 // AddPlatformToInstallConfig mocks base method.
-func (m *MockProviderRegistry) AddPlatformToInstallConfig(arg0 *installcfg.InstallerConfigBaremetal, arg1 *common.Cluster) error {
+func (m *MockProviderRegistry) AddPlatformToInstallConfig(arg0 *installcfg.InstallerConfigBaremetal, arg1 *common.Cluster, arg2 []*common.InfraEnv) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddPlatformToInstallConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddPlatformToInstallConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddPlatformToInstallConfig indicates an expected call of AddPlatformToInstallConfig.
-func (mr *MockProviderRegistryMockRecorder) AddPlatformToInstallConfig(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockProviderRegistryMockRecorder) AddPlatformToInstallConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPlatformToInstallConfig", reflect.TypeOf((*MockProviderRegistry)(nil).AddPlatformToInstallConfig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPlatformToInstallConfig", reflect.TypeOf((*MockProviderRegistry)(nil).AddPlatformToInstallConfig), arg0, arg1, arg2)
 }
 
 // AreHostsSupported mocks base method.

--- a/internal/provider/registry/registry.go
+++ b/internal/provider/registry/registry.go
@@ -31,7 +31,8 @@ type ProviderRegistry interface {
 	GetSupportedProvidersByHosts(hosts []*models.Host) ([]models.PlatformType, error)
 	// AddPlatformToInstallConfig adds the provider platform to the installconfig platform field,
 	// sets platform fields from values within the cluster model.
-	AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error
+	AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster,
+		infraEnvs []*common.InfraEnv) error
 	// SetPlatformUsages uses the usageApi to update platform specific usages
 	SetPlatformUsages(p *models.Platform, usages map[string]models.Usage, usageApi usage.API) error
 	// IsHostSupported checks if the provider supports the host
@@ -88,12 +89,13 @@ func (r *registry) Name() models.PlatformType {
 	return ""
 }
 
-func (r *registry) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+func (r *registry) AddPlatformToInstallConfig(
+	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster, infraEnvs []*common.InfraEnv) error {
 	currentProvider, err := r.Get(cluster.Platform)
 	if err != nil {
 		return fmt.Errorf("error adding platform to install config, platform provider wasn't set: %w", err)
 	}
-	return currentProvider.AddPlatformToInstallConfig(cfg, cluster)
+	return currentProvider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
 }
 
 func (r *registry) SetPlatformUsages(

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 					},
 				},
 			}
-			err := providerRegistry.AddPlatformToInstallConfig(nil, cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(nil, cluster, nil)
 			Expect(err).ToNot(BeNil())
 		})
 	})
@@ -186,7 +186,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.Cluster.OpenshiftVersion = "4.12"
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.Baremetal).ToNot(BeNil())
 			Expect(cfg.Platform.Baremetal.DeprecatedAPIVIP).To(Equal(""))
@@ -215,7 +215,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.Cluster.OpenshiftVersion = "4.8"
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.Baremetal).ToNot(BeNil())
 			Expect(cfg.Platform.Baremetal.APIVIPs[0]).To(Equal(string(cluster.Cluster.APIVips[0].IP)))
@@ -240,7 +240,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.Cluster.OpenshiftVersion = "4.6"
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.Baremetal).ToNot(BeNil())
 			Expect(cfg.Platform.Baremetal.APIVIPs[0]).To(Equal(string(cluster.Cluster.APIVips[0].IP)))
@@ -261,7 +261,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.168.1.0/24"}}
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("Failed to find a network interface matching machine network"))
 		})
@@ -272,7 +272,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.MachineNetworks = nil
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("Failed to find machine networks for baremetal cluster"))
 		})
@@ -283,7 +283,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.MachineNetworks = []*models.MachineNetwork{}
 			cluster.Platform = createBaremetalPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("Failed to find machine networks for baremetal cluster"))
 		})
@@ -299,7 +299,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 				cluster := createClusterFromHosts(hosts)
 				cluster.Cluster.OpenshiftVersion = "4.12"
 				cluster.Platform = createVspherePlatformParams()
-				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 				Expect(err).To(BeNil())
 				Expect(cfg.Platform.Vsphere).ToNot(BeNil())
 				Expect(cfg.Platform.Vsphere.DeprecatedAPIVIP).To(Equal(""))
@@ -323,7 +323,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 				cluster := createClusterFromHosts(hosts)
 				cluster.Cluster.OpenshiftVersion = "4.11"
 				cluster.Platform = createVspherePlatformParams()
-				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 				Expect(err).To(BeNil())
 				Expect(cfg.Platform.Vsphere).ToNot(BeNil())
 				Expect(cfg.Platform.Vsphere.APIVIPs[0]).To(Equal(string(cluster.Cluster.APIVips[0].IP)))
@@ -336,7 +336,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 				cluster := createClusterFromHosts([]*models.Host{})
 				cluster.Cluster.OpenshiftVersion = "4.11"
 				cluster.Platform = createVspherePlatformParams()
-				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 				Expect(err).To(BeNil())
 				Expect(cfg.Platform.Vsphere).ToNot(BeNil())
 				Expect(cfg.Platform.Vsphere.APIVIPs[0]).To(Equal(string(cluster.Cluster.APIVips[0].IP)))
@@ -356,7 +356,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 				cluster := createClusterFromHosts([]*models.Host{})
 				cluster.Cluster.OpenshiftVersion = "4.13"
 				cluster.Platform = createVspherePlatformParams()
-				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+				err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 				Expect(err).To(BeNil())
 				Expect(cfg.Platform.Vsphere).ToNot(BeNil())
 				Expect(cfg.Platform.Vsphere.APIVIPs).To(Not(BeNil()))
@@ -397,7 +397,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.Cluster.OpenshiftVersion = "4.12"
 			cluster.Platform = createNutanixPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.Nutanix).ToNot(BeNil())
 			installConfigByte, err := yaml.Marshal(cfg.Platform.Nutanix)
@@ -415,7 +415,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster := createClusterFromHosts(hosts)
 			cluster.Cluster.OpenshiftVersion = "4.11"
 			cluster.Platform = createNutanixPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.Nutanix).ToNot(BeNil())
 			installConfigByte, err := yaml.Marshal(cfg.Platform.Nutanix)
@@ -435,7 +435,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			hosts = append(hosts, createHost(false, models.HostStatusKnown, getBaremetalInventoryStr("hostname4", "bootMode", true, false)))
 			cluster := createClusterFromHosts(hosts)
 			cluster.Platform = createExternalOciPlatformParams()
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.External).ToNot(BeNil())
 			Expect(cfg.Platform.External.PlatformName).To(Equal(common.ExternalPlatformNameOci))
@@ -463,7 +463,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 					CloudControllerManager: &cloudControllerManager,
 				},
 			}
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.External).ToNot(BeNil())
 			Expect(cfg.Platform.External.PlatformName).To(Equal(platformName))
@@ -489,7 +489,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 					CloudControllerManager: &cloudControllerManager,
 				},
 			}
-			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.External).ToNot(BeNil())
 			Expect(cfg.Platform.External.PlatformName).To(Equal(platformName))

--- a/internal/provider/vsphere/installConfig.go
+++ b/internal/provider/vsphere/installConfig.go
@@ -52,7 +52,8 @@ func setPlatformValues(openshiftVersion string, platform *installcfg.VsphereInst
 	}
 }
 
-func (p vsphereProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+func (p vsphereProvider) AddPlatformToInstallConfig(
+	cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster, infraEnvs []*common.InfraEnv) error {
 	vsPlatform := &installcfg.VsphereInstallConfigPlatform{}
 
 	if !swag.BoolValue(cluster.UserManagedNetworking) {


### PR DESCRIPTION
This is a backport of OCPBUGS-44882 for ACM 2.12.

In OpenShift 4.18 a new `additionalNTPServers` field was added to the baremetal platform section of the `install-config.yaml` file . This needs to be populated with the NTP sources provided by the user in order to correctly set time before installation of new nodes using the baremetal provisioning flow.

## List all the issues related to this PR

Related: https://issues.redhat.com/browse/MGMT-19388
Related: https://issues.redhat.com/browse/OCPBUGS-44882

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manually verifying that the generated `install-config.yaml` contains the NTP sources.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
