### PR TITLE
[cloud_hotfix_releases] MGMT-19360: do not monitor hosts with status installed (#7030)

### DIFF
--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -14,13 +14,6 @@ import (
 	"gorm.io/gorm"
 )
 
-func (m *Manager) SkipMonitoring(h *models.Host) bool {
-	skipMonitoringStates := []string{string(models.LogsStateCompleted), string(models.LogsStateTimeout), ""}
-	result := ((swag.StringValue(h.Status) == models.HostStatusError || swag.StringValue(h.Status) == models.HostStatusCancelled) &&
-		funk.Contains(skipMonitoringStates, h.LogsInfo))
-	return result
-}
-
 func (m *Manager) initMonitoringQueryGenerator() {
 	if m.monitorClusterQueryGenerator == nil {
 		buildInitialQuery := func(db *gorm.DB) *gorm.DB {
@@ -35,16 +28,29 @@ func (m *Manager) initMonitoringQueryGenerator() {
 				models.HostStatusPreparingSuccessful,
 				models.HostStatusInstalling,
 				models.HostStatusInstallingInProgress,
-				models.HostStatusInstalled,
 				models.HostStatusInstallingPendingUserAction,
 				models.HostStatusResettingPendingUserAction,
-				models.HostStatusCancelled, // for limited time, until log collection finished or timed-out
-				models.HostStatusError,     // for limited time, until log collection finished or timed-out
 			}
 
-			dbWithCondition := common.LoadTableFromDB(db, common.HostsTable, "status in (?)", monitorStates)
-			dbWithCondition = common.LoadClusterTablesFromDB(dbWithCondition, common.HostsTable)
-			dbWithCondition = dbWithCondition.Where("exists (select 1 from hosts where clusters.id = hosts.cluster_id)")
+			// monitor following states for limited time, until log collection finished or timed-out
+			monitorStatesUntilLogCollection := []string{
+				models.HostStatusCancelled,
+				models.HostStatusError,
+			}
+			logCollectionEndStates := []string{
+				string(models.LogsStateCompleted),
+				string(models.LogsStateTimeout),
+				string(models.LogsStateEmpty),
+			}
+
+			dbWithCondition := common.LoadClusterTablesFromDB(db)
+			dbWithCondition = dbWithCondition.Where(
+				"id IN (SELECT cluster_id FROM hosts WHERE hosts.status in (?) OR (hosts.status in (?) AND hosts.logs_info not in (?)))",
+				monitorStates, monitorStatesUntilLogCollection, logCollectionEndStates)
+			dbWithCondition = dbWithCondition.Or(
+				"id IN (SELECT cluster_id FROM hosts WHERE clusters.id = hosts.cluster_id AND hosts.status = ? AND clusters.status <> ?)",
+				models.HostStatusInstalled, models.ClusterStatusInstalled)
+
 			return dbWithCondition
 		}
 		m.monitorClusterQueryGenerator = common.NewMonitorQueryGenerator(m.db, buildInitialQuery, m.Config.MonitorBatchSize)
@@ -160,21 +166,20 @@ func (m *Manager) clusterHostMonitoring() int64 {
 					m.log.Debugf("Not a leader, exiting cluster HostMonitoring")
 					return monitored
 				}
-				if !m.SkipMonitoring(host) {
-					monitored += 1
-					err = m.refreshStatusInternal(ctx, host, c, nil, inventoryCache, m.db)
+
+				monitored += 1
+				err = m.refreshStatusInternal(ctx, host, c, nil, inventoryCache, m.db)
+				if err != nil {
+					log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
+				}
+				//the refreshed role will be taken into account in the validations
+				//on the next monitor cycle. The roles will not be calculated until
+				//all the hosts in the cluster has inventory to avoid race condition
+				//with the reset auto-assign mechanism.
+				if canRefreshRoles {
+					err = m.refreshRoleInternal(ctx, host, m.db, false)
 					if err != nil {
-						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
-					}
-					//the refreshed role will be taken into account in the validations
-					//on the next monitor cycle. The roles will not be calculated until
-					//all the hosts in the cluster has inventory to avoid race condition
-					//with the reset auto-assign mechanism.
-					if canRefreshRoles {
-						err = m.refreshRoleInternal(ctx, host, m.db, false)
-						if err != nil {
-							log.WithError(err).Errorf("failed to refresh host %s role", *host.ID)
-						}
+						log.WithError(err).Errorf("failed to refresh host %s role", *host.ID)
 					}
 				}
 			}

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	eventgen "github.com/openshift/assisted-service/internal/common/events"
@@ -316,6 +317,60 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			mockMetricApi.EXPECT().MonitoredHostsCount(int64(765)).Times(1)
 			registerAndValidateDisconnected(765)
 		})
+	})
+
+	Context("validate host status monitoring", func() {
+		DescribeTable("status", func(clusterStatus string, hostStatus string, logState models.LogsState, expectedCount int) {
+			clusterID = strfmt.UUID(uuid.New().String())
+			cluster := hostutil.GenerateTestCluster(clusterID)
+			cluster.Status = swag.String(clusterStatus)
+			Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
+
+			host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, models.HostStatusDiscovering)
+			host.Inventory = workerInventory()
+			host.LogsInfo = logState
+			Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
+			Expect(db.Model(&host).Update("status", hostStatus).Error).ShouldNot(HaveOccurred())
+
+			mockMetricApi.EXPECT().MonitoredHostsCount(int64(expectedCount)).Times(1)
+			state.HostMonitoring()
+		},
+			Entry("HostStatusAddedToExistingCluster is not monitored", models.ClusterStatusReady, models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
+			Entry("HostStatusBinding is not monitored", models.ClusterStatusReady, models.HostStatusBinding, models.LogsStateCompleted, 0),
+			Entry("HostStatusCancelled is monitored when waiting for log state", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateCollecting, 1),
+			Entry("HostStatusCancelled is not monitored when log state has timed out", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateTimeout, 0),
+			Entry("HostStatusCancelled is not monitored when log state is completed", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateCompleted, 0),
+			Entry("HostStatusCancelled is not monitored when log state is empty", models.ClusterStatusReady, models.HostStatusCancelled, models.LogsStateEmpty, 0),
+			Entry("HostStatusDisabled is not monitored", models.ClusterStatusReady, models.HostStatusDisabled, models.LogsStateCompleted, 0),
+			Entry("HostStatusDisabledUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDisabledUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusDisconnected is monitored", models.ClusterStatusReady, models.HostStatusDisconnected, models.LogsStateCompleted, 1),
+			Entry("HostStatusDisconnectedUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDisconnectedUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusDiscovering is monitored", models.ClusterStatusReady, models.HostStatusDiscovering, models.LogsStateCompleted, 1),
+			Entry("HostStatusDiscoveringUnbound is not monitored", models.ClusterStatusReady, models.HostStatusDiscoveringUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusError is monitored when waiting for log state", models.ClusterStatusReady, models.HostStatusError, models.LogsStateCollecting, 1),
+			Entry("HostStatusError is not monitored when log state has timed out", models.ClusterStatusReady, models.HostStatusError, models.LogsStateTimeout, 0),
+			Entry("HostStatusError is not monitored when log state is completed", models.ClusterStatusReady, models.HostStatusError, models.LogsStateCompleted, 0),
+			Entry("HostStatusError is not monitored when log state is empty", models.ClusterStatusReady, models.HostStatusError, models.LogsStateEmpty, 0),
+			Entry("HostStatusInstalled is monitored when cluster status not installed", models.ClusterStatusReady, models.HostStatusInstalled, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstalled is not monitored when cluster status is installed", models.ClusterStatusInstalled, models.HostStatusInstalled, models.LogsStateCompleted, 0),
+			Entry("HostStatusInstalling is monitored", models.ClusterStatusReady, models.HostStatusInstalling, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstallingInProgress is monitored", models.ClusterStatusReady, models.HostStatusInstallingInProgress, models.LogsStateCompleted, 1),
+			Entry("HostStatusInstallingPendingUserAction is monitored", models.ClusterStatusReady, models.HostStatusInstallingPendingUserAction, models.LogsStateCompleted, 1),
+			Entry("HostStatusInsufficient is monitored", models.ClusterStatusReady, models.HostStatusInsufficient, models.LogsStateCompleted, 1),
+			Entry("HostStatusInsufficientUnbound is not monitored", models.ClusterStatusReady, models.HostStatusInsufficientUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusKnown is monitored", models.ClusterStatusReady, models.HostStatusKnown, models.LogsStateCompleted, 1),
+			Entry("HostStatusKnownUnbound is not monitored", models.ClusterStatusReady, models.HostStatusKnownUnbound, models.LogsStateCompleted, 0),
+			Entry("HostStatusPendingForInput is monitored", models.ClusterStatusReady, models.HostStatusPendingForInput, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingFailed is monitored", models.ClusterStatusReady, models.HostStatusPreparingFailed, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingForInstallation is monitored", models.ClusterStatusReady, models.HostStatusPreparingForInstallation, models.LogsStateCompleted, 1),
+			Entry("HostStatusPreparingSuccessful is monitored", models.ClusterStatusReady, models.HostStatusPreparingSuccessful, models.LogsStateCompleted, 1),
+			Entry("HostStatusReclaiming is not monitored", models.ClusterStatusReady, models.HostStatusReclaiming, models.LogsStateCompleted, 0),
+			Entry("HostStatusReclaimingRebooting is not monitored", models.ClusterStatusReady, models.HostStatusReclaimingRebooting, models.LogsStateCompleted, 0),
+			Entry("HostStatusResetting is not monitored", models.ClusterStatusReady, models.HostStatusResetting, models.LogsStateCompleted, 0),
+			Entry("HostStatusResettingPendingUserAction is monitored", models.ClusterStatusReady, models.HostStatusResettingPendingUserAction, models.LogsStateCompleted, 1),
+			Entry("HostStatusUnbinding is not monitored", models.ClusterStatusReady, models.HostStatusUnbinding, models.LogsStateCompleted, 0),
+			Entry("HostStatusUnbindingPendingUserAction is not monitored", models.ClusterStatusReady, models.HostStatusUnbindingPendingUserAction, models.LogsStateCompleted, 0),
+		)
 	})
 })
 


### PR DESCRIPTION
Performance test in stage showed that the assisted-service continued to
monitor hosts even after the cluster installed. This behavior consumes
a lot of CPU, this PR disables it by stopping monitoring  hosts in "Installed" 
state when cluster state is "Installed".

Also, move the logic from `SkipMonitoring` function into the SQL query so
we avoid to retrieve hosts that we be skipped anyway (and save some
un-marshaling operations).

