### PR TITLE
MGMT-19362: Explicitly add OpenShift AI incompatibilities

### DIFF
--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -47,6 +47,7 @@ func (feature *SnoFeature) getIncompatibleFeatures(string) *[]models.FeatureSupp
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDVIPAUTOALLOC,
+		models.FeatureSupportLevelIDOPENSHIFTAI,
 	}
 }
 

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -84,6 +84,7 @@ func (feature *LvmFeature) getIncompatibleFeatures(OCPVersion string) *[]models.
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDODF,
+		models.FeatureSupportLevelIDOPENSHIFTAI,
 	}
 	if isEqual, _ := common.BaseVersionLessThan("4.15", OCPVersion); isEqual {
 		incompatibleFeatures = append(incompatibleFeatures,
@@ -582,7 +583,12 @@ func (f *OpenShiftAIFeature) getIncompatibleArchitectures(_ *string) *[]models.A
 }
 
 func (f *OpenShiftAIFeature) getIncompatibleFeatures(string) *[]models.FeatureSupportLevelID {
-	return &[]models.FeatureSupportLevelID{}
+	return &[]models.FeatureSupportLevelID{
+		// These aren't directly incompatible with OpenShift AI, rather with ODF, but the feature support
+		// mechanism doesn't currently understand operator dependencies, so we need to add these explicitly.
+		models.FeatureSupportLevelIDLVM,
+		models.FeatureSupportLevelIDSNO,
+	}
 }
 
 func (f *OpenShiftAIFeature) getFeatureActiveLevel(cluster *common.Cluster, _ *models.InfraEnv, clusterUpdateParams *models.V2ClusterUpdateParams, _ *models.InfraEnvUpdateParams) featureActiveLevel {

--- a/internal/featuresupport/features_olm_operators_test.go
+++ b/internal/featuresupport/features_olm_operators_test.go
@@ -114,6 +114,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDOPENSHIFTAI,
 				models.FeatureSupportLevelIDVIPAUTOALLOC,
 				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 			}
@@ -122,6 +123,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDOPENSHIFTAI,
 				models.FeatureSupportLevelIDVIPAUTOALLOC,
 				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 			}
@@ -130,11 +132,13 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDOPENSHIFTAI,
 			}
 			incompatibleFeatures["4.16.0-rc0"] = &[]models.FeatureSupportLevelID{
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDOPENSHIFTAI,
 			}
 
 			testIncompatibleFeatures := []struct {


### PR DESCRIPTION
The OpenShift AI requires ODF, and that means that it is indirectly incompatible with LVM and SNO. But our feature support mechanism doesn't currently understand dependencies between operators. As a result it is possible to update a cluster so that it will have OpenShift AI and SNO, for example, enabled simultaneously. To avoid that this patch adds those indirect incompatibilities to the OpenShift AI operator, like they were direct incompatibilities.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19362

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manually creating a cluster with SNO enabled and then patching it to add OpenShift AI. Same for LVM.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
