### PR TITLE
NO-ISSUE: Enable static network using the nmstate flow across all architectures

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3800,7 +3800,7 @@ func (b *bareMetalInventory) DownloadMinimalInitrd(ctx context.Context, params i
 	if infraEnv.StaticNetworkConfig != "" {
 		// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 		var ok bool
-		ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+		ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion)
 		if err != nil {
 			return common.GenerateErrorResponder(err)
 		}
@@ -4871,7 +4871,7 @@ func (b *bareMetalInventory) validateInfraEnvCreateParams(ctx context.Context, p
 	}
 
 	if params.InfraenvCreateParams.StaticNetworkConfig != nil {
-		if err = b.staticNetworkConfig.ValidateStaticConfigParamsYAML(params.InfraenvCreateParams.StaticNetworkConfig, params.InfraenvCreateParams.OpenshiftVersion, params.InfraenvCreateParams.CPUArchitecture, b.installerInvoker); err != nil {
+		if err = b.staticNetworkConfig.ValidateStaticConfigParamsYAML(params.InfraenvCreateParams.StaticNetworkConfig, params.InfraenvCreateParams.OpenshiftVersion, b.installerInvoker); err != nil {
 			return err
 		}
 	}
@@ -5058,7 +5058,7 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 		}
 
 		if params.InfraEnvUpdateParams.StaticNetworkConfig != nil {
-			if err = b.staticNetworkConfig.ValidateStaticConfigParamsYAML(params.InfraEnvUpdateParams.StaticNetworkConfig, infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, b.installerInvoker); err != nil {
+			if err = b.staticNetworkConfig.ValidateStaticConfigParamsYAML(params.InfraEnvUpdateParams.StaticNetworkConfig, infraEnv.OpenshiftVersion, b.installerInvoker); err != nil {
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
 		}
@@ -6013,7 +6013,7 @@ func (b *bareMetalInventory) V2DownloadInfraEnvFiles(ctx context.Context, params
 		if infraEnv.StaticNetworkConfig != "" {
 			// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 			var ok bool
-			ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+			ok, err = b.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion)
 			if err != nil {
 				return common.GenerateErrorResponder(err)
 			}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -8784,7 +8784,7 @@ var _ = Describe("infraEnvs", func() {
 			mockInfraEnvRegisterSuccess()
 			mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.InfraEnvRegisteredEventName))).Times(1)
-			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "x86_64", "")
+			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "")
 			mockUsage.EXPECT().Add(gomock.Any(), gomock.Not(usage.StaticNetworkConfigUsage), gomock.Any()).AnyTimes()
 			mockUsage.EXPECT().Remove(gomock.Any(), usage.StaticNetworkConfigUsage).Times(1)
 			mockUsage.EXPECT().Remove(gomock.Any(), gomock.Not(usage.StaticNetworkConfigUsage)).AnyTimes()
@@ -8815,7 +8815,7 @@ var _ = Describe("infraEnvs", func() {
 				eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
 			mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.InfraEnvRegisteredEventName))).Times(1)
-			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "x86_64", "")
+			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "")
 
 			mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("static network format result", nil).Times(1)
 			mockUsage.EXPECT().Add(gomock.Any(), usage.StaticNetworkConfigUsage, nil)
@@ -9496,7 +9496,7 @@ location = "%s"
 					common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 					common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 				}
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "x86_64", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 					InfraEnvID: *i.ID,
@@ -9533,7 +9533,7 @@ location = "%s"
 					common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 					common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 				}
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "x86_64", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 					InfraEnvID: *i.ID,
@@ -9563,7 +9563,7 @@ location = "%s"
 				}
 
 				mockInfraEnvUpdateSuccess()
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "x86_64", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				mockUsage.EXPECT().Add(gomock.Any(), usage.StaticNetworkConfigUsage, nil).Times(1)
 				mockUsage.EXPECT().Save(gomock.Any(), *cluster.ID, gomock.Any()).Times(1)
@@ -9590,7 +9590,7 @@ location = "%s"
 				staticNetworkConfig := []*models.HostStaticNetworkConfig{}
 
 				mockInfraEnvUpdateSuccess()
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "x86_64", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				mockUsage.EXPECT().Remove(gomock.Any(), usage.StaticNetworkConfigUsage).Times(1)
 				mockUsage.EXPECT().Save(gomock.Any(), *cluster.ID, gomock.Any()).Times(1)
@@ -9997,7 +9997,7 @@ location = "%s"
 						common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 						common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 					}
-					mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "", "").Return(nil).Times(2)
+					mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(2)
 					mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(2)
 					params.StaticNetworkConfig = staticNetworkConfig
 					newURL = updateInfraEnv(params)

--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -339,7 +339,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 
 		// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
 		var ok bool
-		ok, err = ib.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+		ok, err = ib.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion)
 		if err != nil {
 			return "", err
 		}

--- a/internal/ignition/discovery_test.go
+++ b/internal/ignition/discovery_test.go
@@ -540,7 +540,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -562,7 +562,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(true, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -585,7 +585,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -626,7 +626,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -649,7 +649,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(true, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -672,7 +672,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/staticnetworkconfig/backward_compatibility.go
+++ b/pkg/staticnetworkconfig/backward_compatibility.go
@@ -10,7 +10,7 @@ type Config struct {
 	MinVersionForNmstateService string `envconfig:"MIN_VERSION_FOR_NMSTATE_SERVICE" default:"4.19"`
 }
 
-func (s *StaticNetworkConfigGenerator) NMStatectlServiceSupported(version, arch string) (bool, error) {
+func (s *StaticNetworkConfigGenerator) NMStatectlServiceSupported(version string) (bool, error) {
 	// When a cluster is imported, the OpenshiftVersion isn't stored in the database.
 	// Consequently, a bound InfraEnv with static networking uses the Cluster's OpenshiftVersion, which is empty.
 	if version == "" {
@@ -21,6 +21,5 @@ func (s *StaticNetworkConfigGenerator) NMStatectlServiceSupported(version, arch 
 	if err != nil {
 		return false, err
 	}
-	// TODO: Remove the architecture condition after fetching the nmstatectl binary from rootfs.
-	return versionOK && arch == common.X86CPUArchitecture, nil
+	return versionOK, nil
 }

--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -32,8 +32,8 @@ type StaticNetworkConfig interface {
 	GenerateStaticNetworkConfigData(ctx context.Context, hostsYAMLS string) ([]StaticNetworkConfigData, error)
 	GenerateStaticNetworkConfigDataYAML(staticNetworkConfigStr string) ([]StaticNetworkConfigData, error)
 	FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetworkConfig) (string, error)
-	ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, arch, installerInvoker string) error
-	NMStatectlServiceSupported(version, arch string) (bool, error)
+	ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, installerInvoker string) error
+	NMStatectlServiceSupported(version string) (bool, error)
 }
 
 type StaticNetworkConfigGenerator struct {
@@ -293,7 +293,7 @@ func (s *StaticNetworkConfigGenerator) formatNMConnection(nmConnection string) (
 	return buf.String(), nil
 }
 
-func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macInterfaceMap models.MacInterfaceMap, networksYaml, ocpVersion, arch, installerInvoker string) error {
+func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macInterfaceMap models.MacInterfaceMap, networksYaml, ocpVersion, installerInvoker string) error {
 	interfaceNames := lo.Map(macInterfaceMap, func(m *models.MacInterfaceMapItems0, _ int) string { return m.LogicalNicName })
 
 	var config map[string]interface{}
@@ -339,7 +339,7 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macIn
 
 		identifier, exists := nic["identifier"]
 		isMacAddressIdentifier := exists && identifier == "mac-address"
-		isVersionOK, err := s.NMStatectlServiceSupported(ocpVersion, arch)
+		isVersionOK, err := s.NMStatectlServiceSupported(ocpVersion)
 		if err != nil {
 			return err
 		}
@@ -382,7 +382,7 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistenceYAML(macIn
 	return nil
 }
 
-func (s *StaticNetworkConfigGenerator) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, arch, installInvoker string) error {
+func (s *StaticNetworkConfigGenerator) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, installInvoker string) error {
 	var err *multierror.Error
 	for i, hostConfig := range staticNetworkConfig {
 		err = multierror.Append(err, s.validateMacInterfaceName(i, hostConfig.MacInterfaceMap))
@@ -391,7 +391,7 @@ func (s *StaticNetworkConfigGenerator) ValidateStaticConfigParamsYAML(staticNetw
 			err = multierror.Append(err, fmt.Errorf("failed to validate network yaml for host %d, %s", i, validateErr))
 			return err.ErrorOrNil()
 		}
-		err = multierror.Append(err, s.validateInterfaceNamesExistenceYAML(hostConfig.MacInterfaceMap, hostConfig.NetworkYaml, ocpVersion, arch, installInvoker))
+		err = multierror.Append(err, s.validateInterfaceNamesExistenceYAML(hostConfig.MacInterfaceMap, hostConfig.NetworkYaml, ocpVersion, installInvoker))
 	}
 	return err.ErrorOrNil()
 }

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml:     singleInterfaceYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 	})
@@ -115,7 +115,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: singleInterfaceYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: multipleInterfacesYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 	})
@@ -151,7 +151,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: multipleInterfacesYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -188,7 +188,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: bondYAML,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 		})
@@ -208,7 +208,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: bondYAML,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -238,7 +238,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml:     withUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 		})
@@ -254,7 +254,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("vlan without underlying interface - with mapping", func() {
@@ -269,7 +269,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withoutUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -325,7 +325,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withPhysicalInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("at least one mapped interface is required", func() {
@@ -335,7 +335,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml:     withNoMappedInterfaces,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least one interface for host"))
 		})
@@ -351,7 +351,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "agent-installer")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "agent-installer")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("The mac-identifier field is temporarily not supported for flows other than ABI in OCP versions >= MinimalVersionForNmstatectl", func() {
@@ -366,7 +366,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, "")
 			Expect(err).To(HaveOccurred())
 		})
 		It("mac-identifier field is supported in ocp-versions < 4.14", func() {
@@ -381,7 +381,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is temporarily not supported for flows other than ABI in OCP versions >= MinimalVersionForNmstatectl", func() {
@@ -396,7 +396,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, "")
 			Expect(err).To(HaveOccurred())
 		})
 		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is allowed for ABI in OCP versions >= 4.14", func() {
@@ -411,7 +411,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "agent-installer")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "agent-installer")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is supported in ocp-versions < 4.14", func() {
@@ -426,7 +426,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", common.X86CPUArchitecture, "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -478,7 +478,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 			},
 		}
 
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		input = models.MacInterfaceMap{
@@ -492,7 +492,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 				NetworkYaml:     multipleInterfacesYAML,
 			},
 		}
-		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).To(HaveOccurred())
 
 		input = models.MacInterfaceMap{
@@ -506,7 +506,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 				NetworkYaml:     multipleInterfacesYAML,
 			},
 		}
-		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", common.X86CPUArchitecture, "")
+		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/pkg/staticnetworkconfig/mock_generator.go
+++ b/pkg/staticnetworkconfig/mock_generator.go
@@ -81,30 +81,30 @@ func (mr *MockStaticNetworkConfigMockRecorder) GenerateStaticNetworkConfigDataYA
 }
 
 // NMStatectlServiceSupported mocks base method.
-func (m *MockStaticNetworkConfig) NMStatectlServiceSupported(version, arch string) (bool, error) {
+func (m *MockStaticNetworkConfig) NMStatectlServiceSupported(version string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NMStatectlServiceSupported", version, arch)
+	ret := m.ctrl.Call(m, "NMStatectlServiceSupported", version)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NMStatectlServiceSupported indicates an expected call of NMStatectlServiceSupported.
-func (mr *MockStaticNetworkConfigMockRecorder) NMStatectlServiceSupported(version, arch interface{}) *gomock.Call {
+func (mr *MockStaticNetworkConfigMockRecorder) NMStatectlServiceSupported(version interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NMStatectlServiceSupported", reflect.TypeOf((*MockStaticNetworkConfig)(nil).NMStatectlServiceSupported), version, arch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NMStatectlServiceSupported", reflect.TypeOf((*MockStaticNetworkConfig)(nil).NMStatectlServiceSupported), version)
 }
 
 // ValidateStaticConfigParamsYAML mocks base method.
-func (m *MockStaticNetworkConfig) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, arch, installerInvoker string) error {
+func (m *MockStaticNetworkConfig) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, installerInvoker string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateStaticConfigParamsYAML", staticNetworkConfig, ocpVersion, arch, installerInvoker)
+	ret := m.ctrl.Call(m, "ValidateStaticConfigParamsYAML", staticNetworkConfig, ocpVersion, installerInvoker)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateStaticConfigParamsYAML indicates an expected call of ValidateStaticConfigParamsYAML.
-func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParamsYAML(staticNetworkConfig, ocpVersion, arch, installerInvoker interface{}) *gomock.Call {
+func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParamsYAML(staticNetworkConfig, ocpVersion, installerInvoker interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParamsYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParamsYAML), staticNetworkConfig, ocpVersion, arch, installerInvoker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParamsYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParamsYAML), staticNetworkConfig, ocpVersion, installerInvoker)
 }


### PR DESCRIPTION
Since we now fetch nmstatectl binary from the rootfs (https://issues.redhat.com/browse/MGMT-18577) instead of from the assisted- image pod, each architecture uses the appropriate nmstatectl binary for its own arch. Therefore, we can remove the condition checking for x86, which enabling the nmstate flow for all architectures.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
