### PR TITLE
ACM-6053: Add NTP to machineconfig even if no sync

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -193,18 +193,16 @@ func (m *ManifestsGenerator) createChronyManifestContent(c *common.Cluster, role
 	sources := make([]string, 0)
 
 	for _, host := range c.Hosts {
-		if host.NtpSources == "" {
-			continue
-		}
+		if host.NtpSources != "" {
+			var ntpSources []*models.NtpSource
+			if err := json.Unmarshal([]byte(host.NtpSources), &ntpSources); err != nil {
+				return nil, errors.Wrapf(err, "Failed to unmarshal %s", host.NtpSources)
+			}
 
-		var ntpSources []*models.NtpSource
-		if err := json.Unmarshal([]byte(host.NtpSources), &ntpSources); err != nil {
-			return nil, errors.Wrapf(err, "Failed to unmarshal %s", host.NtpSources)
-		}
-
-		for _, source := range ntpSources {
-			if !lo.Contains(sources, source.SourceName) {
-				sources = append(sources, source.SourceName)
+			for _, source := range ntpSources {
+				if !lo.Contains(sources, source.SourceName) {
+					sources = append(sources, source.SourceName)
+				}
 			}
 		}
 


### PR DESCRIPTION
The server instructs the agent to perform NTP synchronization, and when the results are received it stores the results in the `ntp_sources` column of the `hosts` table. But in the ZTP flow installation may start before that response is received, so that `ntp_sources` column may be empty. The value of this column is used to build the `MachineConfig` that configures NTP for the hosts, and we have a fallback that intends to use the NTP servers provided by the user in the `additionalNTPSources` field of the `InfraEnv` object. But the current code skips that fallback logic when the `ntp_sources` is empty. This patch fixes that.

## List all the issues related to this PR

Related: https://issues.redhat.com/browse/ACM-6053

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested removing the NTP synchronization step, adding the additional NTP sources to the infrastructure environment and trying to install the cluster. Before the patch no NPT sources was added to the generated machine config. After the patch the additional NTP sources are added.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
