### PR TITLE
MGMT-19414: Add default requeue time when Hosts are created from Agents

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -81,6 +81,8 @@ const (
 	AgentLabelHostIsVirtual              = InventoryLabelPrefix + "host-isvirtual"
 	AgentLabelClusterDeploymentNamespace = BaseLabelPrefix + "clusterdeployment-namespace"
 	AgentDeprovisionMessage              = "Waiting for host to unbind to do spoke cleanup"
+
+	defaultRequeue = 1 * time.Minute
 )
 
 // AgentReconciler reconciles a Agent object
@@ -158,7 +160,7 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 			}
 			// Requeuing as the associated Host should exist now
 			log.Infof("Restored a Host for agent %s", agent.Name)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}, nil
 		} else {
 			log.WithError(err).Errorf("failed to retrieve Host %s from backend", agent.Name)
 			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4362,7 +4362,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4403,7 +4403,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4448,7 +4448,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4516,7 +4516,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4644,7 +4644,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			// Reconcile Agent
 			result, err := hr.Reconcile(ctx, newHostRequest(agent))
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 			// Ensure the Agent exists
 			key := types.NamespacedName{
@@ -4700,7 +4700,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			// Reconcile Agent
 			result, err := hr.Reconcile(ctx, newHostRequest(agent))
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 			// Ensure the Agent exists
 			key := types.NamespacedName{


### PR DESCRIPTION
Observed in an environment when restoring Hosts from Agents that the Agents aren't requeued and their statuses are never updated. This adds a requeue timer so that they actually get requeued.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @danielerez 