### PR TITLE
MGMT-19413: Add validations info to the Agents annotations

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -75,6 +75,7 @@ const (
 	AgentInventoryAnnotation             = "agent." + aiv1beta1.Group + "/inventory"
 	AgentCurrentStageAnnotation          = "agent." + aiv1beta1.Group + "/current-stage"
 	AgentRoleAnnotation                  = "agent." + aiv1beta1.Group + "/role"
+	AgentValidationsInfoAnnotation       = "agent." + aiv1beta1.Group + "/validations-info"
 	AgentLabelHostManufacturer           = InventoryLabelPrefix + "host-manufacturer"
 	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
 	AgentLabelHostIsVirtual              = InventoryLabelPrefix + "host-isvirtual"
@@ -258,6 +259,7 @@ func updateAnnotations(log logrus.FieldLogger, agent *v1beta1.Agent, h *models.H
 	updated = setAgentAnnotation(log, agent, AgentStateAnnotation, swag.StringValue(h.Status))
 	updated = setAgentAnnotation(log, agent, AgentRoleAnnotation, string(h.Role)) || updated
 	updated = setAgentAnnotation(log, agent, AgentInventoryAnnotation, h.Inventory) || updated
+	updated = setAgentAnnotation(log, agent, AgentValidationsInfoAnnotation, h.ValidationsInfo) || updated
 	if h.Progress != nil {
 		updated = setAgentAnnotation(log, agent, AgentCurrentStageAnnotation, string(h.Progress.CurrentStage))
 	}
@@ -1830,6 +1832,7 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 	hostrole := agent.Annotations[AgentRoleAnnotation]
 	role := models.HostRole(hostrole)
 	inventory := agent.Annotations[AgentInventoryAnnotation]
+	validationsInfo := agent.Annotations[AgentValidationsInfoAnnotation]
 
 	// Fetch State
 	var hostStatus string
@@ -1846,16 +1849,17 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 	// Create Host model
 	hostID := strfmt.UUID(agent.Name)
 	host := &models.Host{
-		ID:            &hostID,
-		Kind:          swag.String(models.HostKindHost),
-		RegisteredAt:  strfmt.DateTime(agent.CreationTimestamp.Time),
-		CheckedInAt:   strfmt.DateTime(agent.CreationTimestamp.Time),
-		Role:          role,
-		SuggestedRole: role,
-		ClusterID:     clusterID,
-		InfraEnvID:    infraEnvID,
-		Status:        &hostStatus,
-		Inventory:     inventory,
+		ID:              &hostID,
+		Kind:            swag.String(models.HostKindHost),
+		RegisteredAt:    strfmt.DateTime(agent.CreationTimestamp.Time),
+		CheckedInAt:     strfmt.DateTime(agent.CreationTimestamp.Time),
+		Role:            role,
+		SuggestedRole:   role,
+		ClusterID:       clusterID,
+		InfraEnvID:      infraEnvID,
+		Status:          &hostStatus,
+		Inventory:       inventory,
+		ValidationsInfo: validationsInfo,
 	}
 
 	// Fetch Current Stage


### PR DESCRIPTION
Primarily affects hosted control planes.
After restoring Agents, the validations status showed up as failing in the AgentMachines. This adds the validations information to the Agent's status so that it is picked up and restored to the host.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @danielerez 
