### PR TITLE
NO-ISSUE: fixing late binding

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -110,7 +110,7 @@ function install_from_catalog_source() {
 
   if [ "${DISCONNECTED}" != "true" ]; then
     # In disconnected mode it should be applied already with a different image
-  tee << EOCR >(oc apply --wait=true -f -)
+  tee << EOCR >(oc apply  -f -)
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -124,7 +124,7 @@ spec:
 EOCR
   fi
 
-  tee << EOCR >(oc apply --wait=true -f -)
+  tee << EOCR >(oc apply  -f -)
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -159,7 +159,7 @@ EOCR
 
   wait_for_crd "agentserviceconfigs.agent-install.openshift.io"
 
-  tee << EOCR >(oc apply --wait=true -f -)
+  tee << EOCR >(oc apply  -f -)
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -174,7 +174,7 @@ EOCR
     deploy_mirror_config_map
   fi
 
-  tee << EOCR >(oc apply --wait=true -f -)
+  tee << EOCR >(oc apply  -f -)
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
@@ -303,7 +303,7 @@ data:
 EOCR
 
   python ${__dir}/set_ca_bundle.py "${WORKING_DIR}/registry/certs/registry.2.crt" "./assisted-mirror-config"
-  tee < ./assisted-mirror-config >(oc apply --wait=true -f -)
+  tee < ./assisted-mirror-config >(oc apply  -f -)
 }
 
 function from_index_image() {


### PR DESCRIPTION
- removing `wait` which cause early failures

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
