### PR TITLE
NO-ISSUE: Remove unused method from spoke client factory

### DIFF
--- a/internal/spoke_k8s_client/mock_spoke_k8s_client_factory.go
+++ b/internal/spoke_k8s_client/mock_spoke_k8s_client_factory.go
@@ -5,12 +5,9 @@
 package spoke_k8s_client
 
 import (
-	context "context"
 	reflect "reflect"
 
-	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
-	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
 	v1 "k8s.io/api/core/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
 )
@@ -82,19 +79,4 @@ func (m *MockSpokeK8sClientFactory) CreateFromSecret(arg0 *v1.Secret) (SpokeK8sC
 func (mr *MockSpokeK8sClientFactoryMockRecorder) CreateFromSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromSecret", reflect.TypeOf((*MockSpokeK8sClientFactory)(nil).CreateFromSecret), arg0)
-}
-
-// CreateFromStorageKubeconfig mocks base method.
-func (m *MockSpokeK8sClientFactory) CreateFromStorageKubeconfig(arg0 context.Context, arg1 *strfmt.UUID, arg2 s3wrapper.API) (SpokeK8sClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFromStorageKubeconfig", arg0, arg1, arg2)
-	ret0, _ := ret[0].(SpokeK8sClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateFromStorageKubeconfig indicates an expected call of CreateFromStorageKubeconfig.
-func (mr *MockSpokeK8sClientFactoryMockRecorder) CreateFromStorageKubeconfig(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromStorageKubeconfig", reflect.TypeOf((*MockSpokeK8sClientFactory)(nil).CreateFromStorageKubeconfig), arg0, arg1, arg2)
 }


### PR DESCRIPTION
This patch removes the `CreateFromStorageKubeconfig` method, as it isn't used and complicates changes to that client factory.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19120

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [X] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [X] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
