### PR TITLE
NO-ISSUE: Simplify spoke client factory

### DIFF
--- a/internal/spoke_k8s_client/factory_test.go
+++ b/internal/spoke_k8s_client/factory_test.go
@@ -1,0 +1,63 @@
+package spoke_k8s_client
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Factory", func() {
+	var logger *logrus.Logger
+
+	BeforeEach(func() {
+		logger = logrus.New()
+		logger.SetOutput(GinkgoWriter)
+	})
+
+	Describe("Create from secret", func() {
+		It("Fails if secret doesn't contain data", func() {
+			factory := NewSpokeK8sClientFactory(logger)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "myns",
+					Name:      "mysecret",
+				},
+				Data: nil,
+			}
+			_, err := factory.CreateFromSecret(secret)
+			Expect(err).To(MatchError("Secret myns/mysecret does not contain any data"))
+		})
+
+		It("Fails if secret doesn't contain a 'kubeconfig' data item", func() {
+			factory := NewSpokeK8sClientFactory(logger)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "myns",
+					Name:      "mysecret",
+				},
+				Data: map[string][]byte{
+					"mydata": []byte("myvalue"),
+				},
+			}
+			_, err := factory.CreateFromSecret(secret)
+			Expect(err).To(MatchError("Secret data for myns/mysecret does not contain kubeconfig"))
+		})
+
+		It("Fails if secret contains a 'kubeconfig' data item with junk", func() {
+			factory := NewSpokeK8sClientFactory(logger)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "myns",
+					Name:      "mysecret",
+				},
+				Data: map[string][]byte{
+					"kubeconfig": []byte("junk"),
+				},
+			}
+			_, err := factory.CreateFromSecret(secret)
+			Expect(err).To(MatchError(ContainSubstring("cannot unmarshal")))
+		})
+	})
+})

--- a/internal/spoke_k8s_client/mock_spoke_k8s_client_factory.go
+++ b/internal/spoke_k8s_client/mock_spoke_k8s_client_factory.go
@@ -51,21 +51,6 @@ func (mr *MockSpokeK8sClientFactoryMockRecorder) ClientAndSetFromSecret(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientAndSetFromSecret", reflect.TypeOf((*MockSpokeK8sClientFactory)(nil).ClientAndSetFromSecret), arg0)
 }
 
-// CreateFromRawKubeconfig mocks base method.
-func (m *MockSpokeK8sClientFactory) CreateFromRawKubeconfig(arg0 []byte) (SpokeK8sClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFromRawKubeconfig", arg0)
-	ret0, _ := ret[0].(SpokeK8sClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateFromRawKubeconfig indicates an expected call of CreateFromRawKubeconfig.
-func (mr *MockSpokeK8sClientFactoryMockRecorder) CreateFromRawKubeconfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromRawKubeconfig", reflect.TypeOf((*MockSpokeK8sClientFactory)(nil).CreateFromRawKubeconfig), arg0)
-}
-
 // CreateFromSecret mocks base method.
 func (m *MockSpokeK8sClientFactory) CreateFromSecret(arg0 *v1.Secret) (SpokeK8sClient, error) {
 	m.ctrl.T.Helper()

--- a/internal/spoke_k8s_client/suite_test.go
+++ b/internal/spoke_k8s_client/suite_test.go
@@ -1,0 +1,13 @@
+package spoke_k8s_client
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSpokeK8SClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Spoke K8S client")
+}


### PR DESCRIPTION
This patch removes the `CreateFromRawKubeconfig` method that is only used in one place, replacing it with the `CreateFromSecret` method. This simplifies the client factory, which is convenient for future refactorings.

The more relevant change is that the spoke client cache now uses the complete data of the secret (serialized using JSON) to calculate the hash that is used to check if the kubeconfig should be re-created. That is to avoid having the logic to extract the kubeconfig from the `kubeconfig` field, as that is already part of the `CreateFromSecret` method of the factory. The tests related to that have also been moved to the `spoke_k8s_client` package.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19120

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [X] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
