### PR TITLE
MGMT-16808: Ensure that spoke BMH is marked as PoweredOn

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1330,6 +1330,15 @@ func (r *BMACReconciler) ensureSpokeBMH(ctx context.Context, log logrus.FieldLog
 	} else if result != controllerutil.OperationResultNone {
 		log.Info("Spoke BareMetalHost created")
 	}
+	if bmhSpoke != nil && !bmhSpoke.Status.PoweredOn {
+		// Ensure that any Day 2 BMH is marked as online when copied to spoke.
+		// Metal3 is not connected at this point and will not do this for us.
+		bmhSpoke.Status.PoweredOn = true
+		err := r.spokeClient.Status().Update(ctx, bmhSpoke)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return bmhSpoke, nil
 }
 


### PR DESCRIPTION
When a new node is added to a Day 2 cluster via a BMH, the resulting BMH is copied to the spoke cluster. Presently, the spoke cluster will always show this with a status of 'poweredOn: false' when the BMH should have a status of 'poweredOn: true'.

This PR changes that by forcing a status update in the `ensureSpokeBMH` As the SpokeBMH is not managed (or even reconciled in any way) by Metal3 then it is acceptable for us to manage the status when copying the BMH to the node.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
