### PR TITLE
[release-ocm-2.9] NO-ISSUE: Remove default release images testing for OCM branches

### DIFF
--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -100,63 +100,8 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 		return osi
 	}
 
-	readDefaultReleaseImages := func(osImages OSImages) *handler {
-		bytes, err := os.ReadFile("../../data/default_release_images.json")
-		Expect(err).ShouldNot(HaveOccurred())
-
-		releaseImages := &models.ReleaseImages{}
-		err = json.Unmarshal(bytes, releaseImages)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		versionsHandler, err := NewHandler(logger, mockRelease, *releaseImages, nil, "", nil)
-		Expect(err).ShouldNot(HaveOccurred())
-		return versionsHandler
-	}
-
-	It("get_defaults from data directory", func() {
-		osImages := readDefaultOsImages()
-		versionsHandler := readDefaultReleaseImages(osImages)
-
-		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
-		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-		defaultExists := false
-
-		for _, releaseImage := range versionsHandler.releaseImages {
-			key := *releaseImage.OpenshiftVersion
-			version := val.Payload[key]
-			architecture := *releaseImage.CPUArchitecture
-			architectures := releaseImage.CPUArchitectures
-			defaultExists = defaultExists || releaseImage.Default
-			if len(architectures) < 2 {
-				// For single-arch release we require in the test that there is a matching
-				// OS image for the provided release image. Otherwise the whole release image
-				// is not usable and indicates a mistake.
-				if architecture == "" {
-					architecture = common.CPUArchitecture
-				}
-				if architecture == common.CPUArchitecture {
-					Expect(version.Default).Should(Equal(releaseImage.Default))
-				}
-				Expect(version.CPUArchitectures).Should(ContainElement(architecture))
-				Expect(version.DisplayName).Should(Equal(releaseImage.Version))
-				Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
-			} else {
-				// For multi-arch release we don't require a strict matching for every
-				// architecture supported by this image. As long as we have at least one OS
-				// image that matches, we are okay. This is to allow setups where release
-				// image supports more architectures than we have available RHCOS images.
-				Expect(len(version.CPUArchitectures)).ShouldNot(Equal(0))
-				Expect(*version.DisplayName).Should(ContainSubstring(*releaseImage.Version))
-				Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
-			}
-		}
-
-		// We want to make sure after parsing the default file, there is always a release
-		// image marked as default. It is not desired to have a service without anything
-		// to default to.
-		Expect(defaultExists).Should(Equal(true))
+	It("validate default OS images in the data directory", func() {
+		_ = readDefaultOsImages()
 	})
 
 	It("getSupportLevel", func() {


### PR DESCRIPTION
As release images are not used in k8s API flow, testing the default ones from data directory is redundant. This PR changes this unit-test to validate only the default OS images by reading and parsing them.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
