### PR TITLE
MGMT-18891: Use old static network flow when MAC identifier exists

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -8784,7 +8784,7 @@ var _ = Describe("infraEnvs", func() {
 			mockInfraEnvRegisterSuccess()
 			mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.InfraEnvRegisteredEventName))).Times(1)
-			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "")
+			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any())
 			mockUsage.EXPECT().Add(gomock.Any(), gomock.Not(usage.StaticNetworkConfigUsage), gomock.Any()).AnyTimes()
 			mockUsage.EXPECT().Remove(gomock.Any(), usage.StaticNetworkConfigUsage).Times(1)
 			mockUsage.EXPECT().Remove(gomock.Any(), gomock.Not(usage.StaticNetworkConfigUsage)).AnyTimes()
@@ -8815,7 +8815,7 @@ var _ = Describe("infraEnvs", func() {
 				eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
 			mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.InfraEnvRegisteredEventName))).Times(1)
-			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any(), "4.8.0-fc.0", "")
+			mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(gomock.Any())
 
 			mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("static network format result", nil).Times(1)
 			mockUsage.EXPECT().Add(gomock.Any(), usage.StaticNetworkConfigUsage, nil)
@@ -9496,7 +9496,7 @@ location = "%s"
 					common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 					common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 				}
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig).Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 					InfraEnvID: *i.ID,
@@ -9533,7 +9533,7 @@ location = "%s"
 					common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 					common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 				}
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig).Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 					InfraEnvID: *i.ID,
@@ -9563,7 +9563,7 @@ location = "%s"
 				}
 
 				mockInfraEnvUpdateSuccess()
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig).Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				mockUsage.EXPECT().Add(gomock.Any(), usage.StaticNetworkConfigUsage, nil).Times(1)
 				mockUsage.EXPECT().Save(gomock.Any(), *cluster.ID, gomock.Any()).Times(1)
@@ -9590,7 +9590,7 @@ location = "%s"
 				staticNetworkConfig := []*models.HostStaticNetworkConfig{}
 
 				mockInfraEnvUpdateSuccess()
-				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(1)
+				mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig).Return(nil).Times(1)
 				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(1)
 				mockUsage.EXPECT().Remove(gomock.Any(), usage.StaticNetworkConfigUsage).Times(1)
 				mockUsage.EXPECT().Save(gomock.Any(), *cluster.ID, gomock.Any()).Times(1)
@@ -9997,7 +9997,7 @@ location = "%s"
 						common.FormatStaticConfigHostYAML("0200003ef73c", "02000048ba38", "192.168.126.40", "192.168.141.40", "192.168.126.1", map2),
 						common.FormatStaticConfigHostYAML("0200003ef75c", "02000048ba58", "192.168.126.42", "192.168.141.42", "192.168.126.1", map3),
 					}
-					mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.6", "").Return(nil).Times(2)
+					mockStaticNetworkConfig.EXPECT().ValidateStaticConfigParamsYAML(staticNetworkConfig).Return(nil).Times(2)
 					mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(staticNetworkConfig).Return(staticNetworkFormatRes, nil).Times(2)
 					params.StaticNetworkConfig = staticNetworkConfig
 					newURL = updateInfraEnv(params)

--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -336,15 +336,12 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 	if infraEnv.StaticNetworkConfig != "" && models.ImageType(isoType) == models.ImageTypeFullIso {
 		var filesList []staticnetworkconfig.StaticNetworkConfigData
 		var newErr error
-
-		// backward compatibility - nmstate.service has been available on RHCOS since version 4.14+, therefore, we should maintain both flows
-		var ok bool
-		ok, err = ib.staticNetworkConfig.NMStatectlServiceSupported(infraEnv.OpenshiftVersion)
+		var shouldUseNmstateService bool
+		shouldUseNmstateService, err = ib.staticNetworkConfig.ShouldUseNmstateService(infraEnv.StaticNetworkConfig, infraEnv.OpenshiftVersion)
 		if err != nil {
 			return "", err
 		}
-
-		if ok {
+		if shouldUseNmstateService {
 			ib.log.Info("Static network configuration using the nmstatectl service")
 			filesList, newErr = ib.prepareStaticNetworkConfigYAMLForIgnition(infraEnv)
 			ignitionParams["StaticNetworkConfigWithNmstatectl"] = filesList

--- a/internal/ignition/discovery_test.go
+++ b/internal/ignition/discovery_test.go
@@ -540,7 +540,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -562,7 +562,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -585,7 +585,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
@@ -626,7 +626,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = ocpVersionInvolvingGenerateKeyfiles
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -649,7 +649,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.X86CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(true, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())
@@ -672,7 +672,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			infraEnv.OpenshiftVersion = common.MinimalVersionForNmstatectl
 			infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
-			mockStaticNetworkConfig.EXPECT().NMStatectlServiceSupported(infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
+			mockStaticNetworkConfig.EXPECT().ShouldUseNmstateService(formattedInput, infraEnv.OpenshiftVersion).Return(false, nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, string(models.ImageTypeFullIso))
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/staticnetworkconfig/backward_compatibility.go
+++ b/pkg/staticnetworkconfig/backward_compatibility.go
@@ -3,6 +3,7 @@ package staticnetworkconfig
 import (
 	"github.com/openshift/assisted-service/internal/common"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
@@ -22,4 +23,67 @@ func (s *StaticNetworkConfigGenerator) NMStatectlServiceSupported(version string
 		return false, err
 	}
 	return versionOK, nil
+}
+
+// CheckConfigForMACIdentifier TODO: This is a temporary workaround and should be removed once the mac-identifier bug in nmstate is fixed - RHEL-72440.
+func (s *StaticNetworkConfigGenerator) CheckConfigForMACIdentifier(staticNetworkConfigStr string) (bool, error) {
+	staticNetworkConfig, err := s.decodeStaticNetworkConfig(staticNetworkConfigStr)
+	if err != nil {
+		s.log.WithError(err).Errorf("Failed to decode static network config")
+		return false, err
+	}
+
+	for _, hostConfig := range staticNetworkConfig {
+		isIncludeMacIdentifier, err := s.hasMACIdentifier(hostConfig.NetworkYaml)
+		if err != nil {
+			return false, err
+		}
+		if isIncludeMacIdentifier {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *StaticNetworkConfigGenerator) hasMACIdentifier(networksYaml string) (bool, error) {
+	var config map[string]interface{}
+
+	// Unmarshal the YAML string into the config struct
+	err := yaml.Unmarshal([]byte(networksYaml), &config)
+	if err != nil {
+		s.log.WithError(err).Errorf("Error unmarshalling yaml")
+		return false, err
+	}
+
+	interfaces, exists := config["interfaces"]
+	if !exists || interfaces == nil {
+		return false, nil
+	}
+	interfacesSlice, ok := interfaces.([]interface{})
+	if !ok {
+		return false, nil
+	}
+
+	for _, iface := range interfacesSlice {
+		nic := iface.(map[interface{}]interface{})
+		identifier, exists := nic["identifier"]
+		if exists && identifier == "mac-address" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ShouldUseNmstatectlService - Both static networking flows should be maintained: one without nmstate.service and one with it, since nmstate.service isn't available in all RHCOS versions.
+func (s *StaticNetworkConfigGenerator) ShouldUseNmstateService(staticNetworkConfigStr, openshiftVersion string) (bool, error) {
+	includesMACIdentifier, err := s.CheckConfigForMACIdentifier(staticNetworkConfigStr)
+	if err != nil {
+		return false, err
+	}
+
+	isNmstateServiceSupported, err := s.NMStatectlServiceSupported(openshiftVersion)
+	if err != nil {
+		return false, err
+	}
+	return isNmstateServiceSupported && !includesMACIdentifier, nil
 }

--- a/pkg/staticnetworkconfig/backward_compatibility_test.go
+++ b/pkg/staticnetworkconfig/backward_compatibility_test.go
@@ -1,0 +1,51 @@
+package staticnetworkconfig_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	snc "github.com/openshift/assisted-service/pkg/staticnetworkconfig"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("ShouldUseNmstateService", func() {
+	var (
+		staticNetworkGenerator = snc.New(logrus.New(), snc.Config{MinVersionForNmstateService: common.MinimalVersionForNmstatectl})
+		hostsYAML              = `[{ "network_yaml": "%s" }]`
+		withMacIdentifier      = `interfaces:
+- name: eth0
+  type: ethernet
+  state: up
+  identifier: mac-address
+  mac-address: 02:00:00:80:12:14
+  ipv4:
+    enabled: true
+    address:
+      - ip: 192.0.2.1
+        prefix-length: 24`
+		withoutMacIdentifier = `interfaces:
+- name: eth0
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: true
+    address:
+      - ip: 192.0.2.1
+        prefix-length: 24`
+	)
+	table.DescribeTable("different scenarios", func(YAML, version string, expectedResult bool) {
+		escapedYamlContent, err := escapeYAMLForJSON(YAML)
+		Expect(err).NotTo(HaveOccurred())
+
+		shouldUseNmstateService, err := staticNetworkGenerator.ShouldUseNmstateService(fmt.Sprintf(hostsYAML, escapedYamlContent), version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shouldUseNmstateService).To(Equal(expectedResult))
+	},
+		table.Entry("If the YAML contains a mac-identifier, and the version is >= MinimalVersionForNmstatectl,  we shouldn't use the nmstate service flow", withMacIdentifier, common.MinimalVersionForNmstatectl, false),
+		table.Entry("If the YAML contains a mac-identifier, and the version is < MinimalVersionForNmstatectl,  we shouldn't use the nmstate service flow", withMacIdentifier, "4.12", false),
+		table.Entry("If the YAML doesn't contain a mac-identifier and the version is >= MinimalVersionForNmstatectl, we should use the nmstate service flow", withoutMacIdentifier, common.MinimalVersionForNmstatectl, true),
+		table.Entry("If the YAML doesn't contain a mac-identifier, and the version < MinimalVersionForNmstatectl we shouldn't use the nmstate service flow.", withoutMacIdentifier, "4.12", false))
+})

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml:     singleInterfaceYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 	})
@@ -115,7 +115,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: singleInterfaceYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: multipleInterfacesYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 	})
@@ -151,7 +151,7 @@ var _ = Describe("validate mac interface mapping", func() {
 				NetworkYaml: multipleInterfacesYAML,
 			},
 		}
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -188,7 +188,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: bondYAML,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 		})
@@ -208,7 +208,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: bondYAML,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -238,7 +238,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml:     withUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mac-interface mapping for interface"))
 		})
@@ -254,7 +254,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("vlan without underlying interface - with mapping", func() {
@@ -269,7 +269,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withoutUnderlyingInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -325,7 +325,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withPhysicalInterface,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("at least one mapped interface is required", func() {
@@ -335,11 +335,11 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml:     withNoMappedInterfaces,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least one interface for host"))
 		})
-		It("mac-identifier field is allowed for ABI in ocp-version >= 4.14", func() {
+		It("mac-identifier field is supported", func() {
 			staticNetworkConfig := []*models.HostStaticNetworkConfig{
 				{
 					MacInterfaceMap: []*models.MacInterfaceMapItems0{
@@ -351,82 +351,7 @@ var _ = Describe("validate mac interface mapping", func() {
 					NetworkYaml: withMacIdentifier,
 				},
 			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "agent-installer")
-			Expect(err).ToNot(HaveOccurred())
-		})
-		It("The mac-identifier field is temporarily not supported for flows other than ABI in OCP versions >= MinimalVersionForNmstatectl", func() {
-			staticNetworkConfig := []*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: []*models.MacInterfaceMapItems0{
-						{
-							LogicalNicName: "eth0",
-							MacAddress:     "f8:75:a4:a4:00:fe",
-						},
-					},
-					NetworkYaml: withMacIdentifier,
-				},
-			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, "")
-			Expect(err).To(HaveOccurred())
-		})
-		It("mac-identifier field is supported in ocp-versions < 4.14", func() {
-			staticNetworkConfig := []*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: []*models.MacInterfaceMapItems0{
-						{
-							LogicalNicName: "eth0",
-							MacAddress:     "f8:75:a4:a4:00:fe",
-						},
-					},
-					NetworkYaml: withMacIdentifier,
-				},
-			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", "")
-			Expect(err).ToNot(HaveOccurred())
-		})
-		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is temporarily not supported for flows other than ABI in OCP versions >= MinimalVersionForNmstatectl", func() {
-			staticNetworkConfig := []*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: []*models.MacInterfaceMapItems0{
-						{
-							LogicalNicName: "eth1",
-							MacAddress:     "f8:75:a4:a4:00:14",
-						},
-					},
-					NetworkYaml: withMacIdentifier,
-				},
-			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, common.MinimalVersionForNmstatectl, "")
-			Expect(err).To(HaveOccurred())
-		})
-		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is allowed for ABI in OCP versions >= 4.14", func() {
-			staticNetworkConfig := []*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: []*models.MacInterfaceMapItems0{
-						{
-							LogicalNicName: "eth1",
-							MacAddress:     "f8:75:a4:a4:00:14",
-						},
-					},
-					NetworkYaml: withMacIdentifier,
-				},
-			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "agent-installer")
-			Expect(err).ToNot(HaveOccurred())
-		})
-		It("mac-identifier field in the YAML, along with a differing MAC in the mac-map, is supported in ocp-versions < 4.14", func() {
-			staticNetworkConfig := []*models.HostStaticNetworkConfig{
-				{
-					MacInterfaceMap: []*models.MacInterfaceMapItems0{
-						{
-							LogicalNicName: "eth1",
-							MacAddress:     "f8:75:a4:a4:00:14",
-						},
-					},
-					NetworkYaml: withMacIdentifier,
-				},
-			}
-			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.13", "")
+			err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -478,7 +403,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 			},
 		}
 
-		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err := staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).ToNot(HaveOccurred())
 
 		input = models.MacInterfaceMap{
@@ -492,7 +417,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 				NetworkYaml:     multipleInterfacesYAML,
 			},
 		}
-		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).To(HaveOccurred())
 
 		input = models.MacInterfaceMap{
@@ -506,7 +431,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 				NetworkYaml:     multipleInterfacesYAML,
 			},
 		}
-		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig, "4.14", "")
+		err = staticNetworkGenerator.ValidateStaticConfigParamsYAML(staticNetworkConfig)
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/pkg/staticnetworkconfig/mock_generator.go
+++ b/pkg/staticnetworkconfig/mock_generator.go
@@ -80,31 +80,31 @@ func (mr *MockStaticNetworkConfigMockRecorder) GenerateStaticNetworkConfigDataYA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateStaticNetworkConfigDataYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).GenerateStaticNetworkConfigDataYAML), staticNetworkConfigStr)
 }
 
-// NMStatectlServiceSupported mocks base method.
-func (m *MockStaticNetworkConfig) NMStatectlServiceSupported(version string) (bool, error) {
+// ShouldUseNmstateService mocks base method.
+func (m *MockStaticNetworkConfig) ShouldUseNmstateService(staticNetworkConfigStr, openshiftVersion string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NMStatectlServiceSupported", version)
+	ret := m.ctrl.Call(m, "ShouldUseNmstateService", staticNetworkConfigStr, openshiftVersion)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// NMStatectlServiceSupported indicates an expected call of NMStatectlServiceSupported.
-func (mr *MockStaticNetworkConfigMockRecorder) NMStatectlServiceSupported(version interface{}) *gomock.Call {
+// ShouldUseNmstateService indicates an expected call of ShouldUseNmstateService.
+func (mr *MockStaticNetworkConfigMockRecorder) ShouldUseNmstateService(staticNetworkConfigStr, openshiftVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NMStatectlServiceSupported", reflect.TypeOf((*MockStaticNetworkConfig)(nil).NMStatectlServiceSupported), version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldUseNmstateService", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ShouldUseNmstateService), staticNetworkConfigStr, openshiftVersion)
 }
 
 // ValidateStaticConfigParamsYAML mocks base method.
-func (m *MockStaticNetworkConfig) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig, ocpVersion, installerInvoker string) error {
+func (m *MockStaticNetworkConfig) ValidateStaticConfigParamsYAML(staticNetworkConfig []*models.HostStaticNetworkConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateStaticConfigParamsYAML", staticNetworkConfig, ocpVersion, installerInvoker)
+	ret := m.ctrl.Call(m, "ValidateStaticConfigParamsYAML", staticNetworkConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateStaticConfigParamsYAML indicates an expected call of ValidateStaticConfigParamsYAML.
-func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParamsYAML(staticNetworkConfig, ocpVersion, installerInvoker interface{}) *gomock.Call {
+func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParamsYAML(staticNetworkConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParamsYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParamsYAML), staticNetworkConfig, ocpVersion, installerInvoker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParamsYAML", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParamsYAML), staticNetworkConfig)
 }


### PR DESCRIPTION
As a temporary workaround, until the nmstate team resolves the issue with the MAC identifier, we will use the old static networking flow when the MAC identifier is present in the nmstate YAML.

/cc @danielerez
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
