### PR TITLE
MGMT-19573: Track release stats in installercache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -476,7 +476,7 @@ func main() {
 	failOnError(err, "failed to create valid bm config S3 endpoint URL from %s", Options.BMConfig.S3EndpointURL)
 	Options.BMConfig.S3EndpointURL = newUrl
 
-	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry, manifestsApi)
+	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry, manifestsApi, eventsHandler)
 	var crdUtils bminventory.CRDUtils
 	if ctrlMgr != nil {
 		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient(), hostApi)

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -1,24 +1,70 @@
 package installercache
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 )
 
+var _ = Describe("release event", func() {
+
+	var (
+		ctx           context.Context
+		ctrl          *gomock.Controller
+		eventsHandler *eventsapi.MockHandler
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		ctrl = gomock.NewController(GinkgoT())
+		eventsHandler = eventsapi.NewMockHandler(ctrl)
+	})
+
+	It("should send correct fields when release event is sent", func() {
+		startTime, err := time.Parse(time.RFC3339, "2025-01-07T16:51:10Z")
+		Expect(err).ToNot(HaveOccurred())
+		clusterID := strfmt.UUID(uuid.NewString())
+		releaseID := "quay.io/openshift-release-dev/ocp-release:4.16.28-x86_64"
+		r := &Release{
+			eventsHandler:   eventsHandler,
+			startTime:       startTime,
+			clusterID:       clusterID,
+			releaseID:       releaseID,
+			cached:          false,
+			extractDuration: 19.5,
+		}
+		eventsHandler.EXPECT().V2AddMetricsEvent(
+			ctx, &clusterID, nil, nil, "", models.EventSeverityInfo, metricEventInstallerCacheRelease, gomock.Any(),
+			"release_id", r.releaseID,
+			"start_time", "2025-01-07T16:51:10Z",
+			"end_time", gomock.Any(),
+			"cached", r.cached,
+			"extract_duration", r.extractDuration,
+		).Times(1)
+		r.Cleanup(ctx)
+	})
+})
+
 var _ = Describe("installer cache", func() {
 	var (
-		ctrl        *gomock.Controller
-		mockRelease *oc.MockRelease
-		manager     *Installers
-		cacheDir    string
+		ctrl          *gomock.Controller
+		mockRelease   *oc.MockRelease
+		manager       *Installers
+		cacheDir      string
+		eventsHandler *eventsapi.MockHandler
+		ctx           context.Context
 	)
 
 	BeforeEach(func() {
@@ -26,20 +72,29 @@ var _ = Describe("installer cache", func() {
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
+		eventsHandler = eventsapi.NewMockHandler(ctrl)
 
 		var err error
 		cacheDir, err = os.MkdirTemp("/tmp", "cacheDir")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Mkdir(filepath.Join(cacheDir, "quay.io"), 0755)).To(Succeed())
 		Expect(os.Mkdir(filepath.Join(filepath.Join(cacheDir, "quay.io"), "release-dev"), 0755)).To(Succeed())
-		manager = New(cacheDir, 12, logrus.New())
+		manager = New(cacheDir, 12, eventsHandler, logrus.New())
+		ctx = context.TODO()
 	})
 
 	AfterEach(func() {
 		os.RemoveAll(cacheDir)
 	})
 
-	testGet := func(releaseID, version string) (string, string) {
+	expectEventSent := func() {
+		eventsHandler.EXPECT().V2AddMetricsEvent(
+			ctx, gomock.Any(), nil, nil, "", models.EventSeverityInfo, metricEventInstallerCacheRelease, gomock.Any(),
+			gomock.Any(),
+		).Times(1)
+	}
+
+	testGet := func(releaseID, version string, clusterID strfmt.UUID, expectCached bool) (string, string) {
 		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
 		fname := filepath.Join(workdir, releaseID)
 
@@ -52,16 +107,27 @@ var _ = Describe("installer cache", func() {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		l, err := manager.Get(releaseID, "mirror", "pull-secret", mockRelease, version)
+		l, err := manager.Get(ctx, releaseID, "mirror", "pull-secret", mockRelease, version, clusterID)
 		Expect(err).ShouldNot(HaveOccurred())
+		Expect(l.releaseID).To(Equal(releaseID))
+		Expect(l.clusterID).To(Equal(clusterID))
+		Expect(l.startTime).ShouldNot(BeZero())
+		Expect(l.cached).To(Equal(expectCached))
+		Expect(l.eventsHandler).To(Equal(eventsHandler))
+		if !expectCached {
+			Expect(l.extractDuration).ShouldNot(BeZero())
+		}
+		Expect(l.Path).ShouldNot(BeEmpty())
 
 		time.Sleep(1 * time.Second)
+		Expect(l.startTime.Before(time.Now())).To(BeTrue())
 		return fname, l.Path
 	}
 	It("evicts the oldest file", func() {
-		r1, l1 := testGet("4.8", "4.8.0")
-		r2, l2 := testGet("4.9", "4.9.0")
-		r3, l3 := testGet("4.10", "4.10.0")
+		clusterId := strfmt.UUID(uuid.New().String())
+		r1, l1 := testGet("4.8", "4.8.0", clusterId, false)
+		r2, l2 := testGet("4.9", "4.9.0", clusterId, false)
+		r3, l3 := testGet("4.10", "4.10.0", clusterId, false)
 
 		By("verify that the oldest file was deleted")
 		_, err := os.Stat(r1)
@@ -82,10 +148,11 @@ var _ = Describe("installer cache", func() {
 	})
 
 	It("exising files access time is updated", func() {
-		_, _ = testGet("4.8", "4.8.0")
-		r2, _ := testGet("4.9", "4.9.0")
-		r1, _ := testGet("4.8", "4.8.0")
-		r3, _ := testGet("4.10", "4.10.0")
+		clusterId := strfmt.UUID(uuid.New().String())
+		_, _ = testGet("4.8", "4.8.0", clusterId, false)
+		r2, _ := testGet("4.9", "4.9.0", clusterId, false)
+		r1, _ := testGet("4.8", "4.8.0", clusterId, true)
+		r3, _ := testGet("4.10", "4.10.0", clusterId, false)
 
 		By("verify that the oldest file was deleted")
 		_, err := os.Stat(r1)
@@ -98,10 +165,10 @@ var _ = Describe("installer cache", func() {
 
 	It("when cache limit is not set eviction is skipped", func() {
 		manager.storageCapacity = 0
-
-		r1, _ := testGet("4.8", "4.8.0")
-		r2, _ := testGet("4.9", "4.9.0")
-		r3, _ := testGet("4.10", "4.10.0")
+		clusterId := strfmt.UUID(uuid.New().String())
+		r1, _ := testGet("4.8", "4.8.0", clusterId, false)
+		r2, _ := testGet("4.9", "4.9.0", clusterId, false)
+		r3, _ := testGet("4.10", "4.10.0", clusterId, false)
 
 		By("verify that the no file was deleted")
 		_, err := os.Stat(r1)
@@ -116,6 +183,7 @@ var _ = Describe("installer cache", func() {
 	It("extracts from the mirror", func() {
 		releaseID := "4.10-orig"
 		releaseMirrorID := "4.10-mirror"
+		clusterID := strfmt.UUID(uuid.New().String())
 		version := "4.10.0"
 		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
 		fname := filepath.Join(workdir, releaseID)
@@ -129,14 +197,23 @@ var _ = Describe("installer cache", func() {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, version)
+		l, err := manager.Get(ctx, releaseID, releaseMirrorID, "pull-secret", mockRelease, version, clusterID)
 		Expect(err).ShouldNot(HaveOccurred())
+		Expect(l.releaseID).To(Equal(releaseID))
+		Expect(l.clusterID).To(Equal(clusterID))
+		Expect(l.startTime).ShouldNot(BeZero())
+		Expect(l.cached).To(BeFalse())
+		Expect(l.extractDuration).ShouldNot(BeZero())
+		Expect(l.Path).ShouldNot(BeEmpty())
+		expectEventSent()
+		l.Cleanup(ctx)
 	})
 
 	It("extracts without a mirror", func() {
 		releaseID := "4.10-orig"
 		releaseMirrorID := ""
 		version := "4.10.0"
+		clusterID := strfmt.UUID(uuid.NewString())
 		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
 		fname := filepath.Join(workdir, releaseID)
 
@@ -149,8 +226,16 @@ var _ = Describe("installer cache", func() {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, version)
+		l, err := manager.Get(ctx, releaseID, releaseMirrorID, "pull-secret", mockRelease, version, clusterID)
 		Expect(err).ShouldNot(HaveOccurred())
+		Expect(l.releaseID).To(Equal(releaseID))
+		Expect(l.clusterID).To(Equal(clusterID))
+		Expect(l.startTime).ShouldNot(BeZero())
+		Expect(l.cached).To(BeFalse())
+		Expect(l.extractDuration).ShouldNot(BeZero())
+		Expect(l.Path).ShouldNot(BeEmpty())
+		expectEventSent()
+		l.Cleanup(ctx)
 	})
 })
 


### PR DESCRIPTION
To support Ephemeral storage improvement efforts in [MGMT-13917](https://issues.redhat.com//browse/MGMT-13917) It is desirable to have some statistics from the installer cache

	ReleaseId                 The release being downloaded
	Cached                    Was the release found in the cache (true) or did it need to be downloaded/extracted? (false)
	StartTime                 The start time of the install cache request
	EndTime                   The time at which the caller finished using the request
	ExtractDuration           The time taken to extract the file in seconds (zero if no extraction took place)

This wil be sent in a single metrics event, the event time of the event represents the time that the release was no longer needed by callers. All of the above should be sufficient to give visibility on the lifespan and concurrency of intstaller cache entries.

In addition, it was requested that we are able to enable/disable the recording of metrics for this feature so I have implemented this. Implemented through the metricsManager as a list of metrics that we would like to block.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
