### PR TITLE
MGMT-19672: Add NTP sources to discovery environment - ACM 2.10

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1792,6 +1792,13 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		return "", err
 	}
 
+	// If the list of additional NTP sources is empty then we want to pass an empty list to the
+	// template, but the Split method returns a slice with one empty element in that case.
+	additionalNtpSources := strings.Split(infraEnv.AdditionalNtpSources, ",")
+	if len(additionalNtpSources) == 1 && additionalNtpSources[0] == "" {
+		additionalNtpSources = []string{}
+	}
+
 	var ignitionParams = map[string]interface{}{
 		"userSshKey":           userSshKey,
 		"AgentDockerImg":       cfg.AgentDockerImg,
@@ -1812,6 +1819,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"SELINUX_POLICY":       base64.StdEncoding.EncodeToString([]byte(selinuxPolicy)),
 		"EnableAgentService":   infraEnv.InternalIgnitionConfigOverride == "",
 		"ProfileProxyExports":  dataurl.EncodeBytes([]byte(GetProfileProxyEntries(httpProxy, httpsProxy, noProxy))),
+		"AdditionalNtpSources": additionalNtpSources,
 	}
 	if safeForLogs {
 		for _, key := range []string{"userSshKey", "PullSecretToken", "PULL_SECRET", "RH_ROOT_CA"} {

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -9,10 +9,12 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	config_31 "github.com/coreos/ignition/v2/config/v3_1"
+	types_31 "github.com/coreos/ignition/v2/config/v3_1/types"
 	config_32 "github.com/coreos/ignition/v2/config/v3_2"
 	config_32_types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-openapi/strfmt"
@@ -1679,6 +1681,219 @@ var _ = Describe("IgnitionBuilder", func() {
 			}
 			Expect(count).Should(Equal(2))
 		})
+	})
+
+	It("Adds NTP sources script and systemd service when one additional NTP source is given", func() {
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+
+		// Generate a ignition config adding one additional NTP source:
+		infraEnv.AdditionalNtpSources = "ntp1.example.com"
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Parse the generated configuration:
+		config, report, err := config_31.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+
+		// Check the script:
+		var scriptFile *types_31.File
+		for _, file := range config.Storage.Files {
+			if file.Path == "/usr/local/bin/add-ntp-sources.sh" {
+				scriptFile = new(types_31.File)
+				*scriptFile = file
+				break
+			}
+		}
+		Expect(scriptFile).ToNot(BeNil())
+		Expect(scriptFile.Mode).ToNot(BeNil())
+		Expect(*scriptFile.Mode).To(Equal(0755))
+		Expect(scriptFile.User.Name).ToNot(BeNil())
+		Expect(*scriptFile.User.Name).To(Equal("root"))
+		Expect(scriptFile.Contents.Source).ToNot(BeNil())
+		Expect(*scriptFile.Contents.Source).ToNot(BeEmpty())
+
+		// Check that the script contains the line that will be added to the chrony configuration file:
+		scriptData, err := dataurl.DecodeString(*scriptFile.Contents.Source)
+		Expect(err).ToNot(HaveOccurred())
+		scriptText := string(scriptData.Data)
+		Expect(scriptText).To(MatchRegexp(`(?m)^server ntp1.example.com iburst$`))
+
+		// Check the systemd service:
+		var serviceUnit *types_31.Unit
+		for _, unit := range config.Systemd.Units {
+			if unit.Name == "add-ntp-sources.service" {
+				serviceUnit = new(types_31.Unit)
+				*serviceUnit = unit
+				break
+			}
+		}
+		Expect(serviceUnit).ToNot(BeNil())
+		Expect(serviceUnit.Enabled).ToNot(BeNil())
+		Expect(*serviceUnit.Enabled).To(BeTrue())
+		Expect(serviceUnit.Contents).ToNot(BeNil())
+		Expect(*serviceUnit.Contents).ToNot(BeEmpty())
+	})
+
+	It("Adds NTP sources script and systemd service when two additional NTP sources are given", func() {
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+
+		// Generate a ignition config adding one additional NTP source:
+		infraEnv.AdditionalNtpSources = "ntp1.example.com,ntp2.example.com"
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Parse the generated configuration:
+		config, report, err := config_31.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+
+		// Check the script:
+		var scriptFile *types_31.File
+		for _, file := range config.Storage.Files {
+			if file.Path == "/usr/local/bin/add-ntp-sources.sh" {
+				scriptFile = new(types_31.File)
+				*scriptFile = file
+				break
+			}
+		}
+		Expect(scriptFile).ToNot(BeNil())
+		Expect(scriptFile.Mode).ToNot(BeNil())
+		Expect(*scriptFile.Mode).To(Equal(0755))
+		Expect(scriptFile.User.Name).ToNot(BeNil())
+		Expect(*scriptFile.User.Name).To(Equal("root"))
+		Expect(scriptFile.Contents.Source).ToNot(BeNil())
+		Expect(*scriptFile.Contents.Source).ToNot(BeEmpty())
+
+		// Check that the script contains the line that will be added to the chrony configuration file:
+		scriptData, err := dataurl.DecodeString(*scriptFile.Contents.Source)
+		Expect(err).ToNot(HaveOccurred())
+		scriptText := string(scriptData.Data)
+		Expect(scriptText).To(MatchRegexp(`(?m)^server ntp1.example.com iburst$`))
+		Expect(scriptText).To(MatchRegexp(`(?m)^server ntp2.example.com iburst$`))
+
+		// Check the systemd service:
+		var serviceUnit *types_31.Unit
+		for _, unit := range config.Systemd.Units {
+			if unit.Name == "add-ntp-sources.service" {
+				serviceUnit = new(types_31.Unit)
+				*serviceUnit = unit
+				break
+			}
+		}
+		Expect(serviceUnit).ToNot(BeNil())
+		Expect(serviceUnit.Enabled).ToNot(BeNil())
+		Expect(*serviceUnit.Enabled).To(BeTrue())
+		Expect(serviceUnit.Contents).ToNot(BeNil())
+		Expect(*serviceUnit.Contents).ToNot(BeEmpty())
+	})
+
+	It("Doesn't add NTP sources script and systemd service when no additional NTP sources are given", func() {
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+
+		// Generate a ignition config without additional NTP sources
+		infraEnv.AdditionalNtpSources = ""
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Parse the generated configuration:
+		config, report, err := config_31.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+
+		// Check that there is no script:
+		var scriptFile *types_31.File
+		for _, file := range config.Storage.Files {
+			if file.Path == "/usr/local/bin/add-ntp-sources.sh" {
+				scriptFile = new(types_31.File)
+				*scriptFile = file
+				break
+			}
+		}
+		Expect(scriptFile).To(BeNil())
+
+		// Check that there is no systemd service:
+		var serviceUnit *types_31.Unit
+		for _, unit := range config.Systemd.Units {
+			if unit.Name == "add-ntp-sources.service" {
+				serviceUnit = new(types_31.Unit)
+				*serviceUnit = unit
+				break
+			}
+		}
+		Expect(serviceUnit).To(BeNil())
+	})
+
+	It("NTP sources script adds entries to existing 'chrony.conf' configuration file", func() {
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+
+		// Generate a ignition config with two additional NTP sources:
+		infraEnv.AdditionalNtpSources = "ntp1.example.com,ntp2.example.com"
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Parse the generated configuration:
+		config, report, err := config_31.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+
+		// Find the script:
+		var scriptFile *types_31.File
+		for _, file := range config.Storage.Files {
+			if file.Path == "/usr/local/bin/add-ntp-sources.sh" {
+				scriptFile = new(types_31.File)
+				*scriptFile = file
+				break
+			}
+		}
+		scriptData, err := dataurl.DecodeString(*scriptFile.Contents.Source)
+		Expect(err).ToNot(HaveOccurred())
+		scriptText := string(scriptData.Data)
+
+		// Create a temporary directory for the script and for the configuration file that
+		// it will modify:
+		tmpDir, err := os.MkdirTemp("", "*.test")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		// Create the configuration file that will be modified by the script:
+		configPath := filepath.Join(tmpDir, "chrony.conf")
+		configFile, err := os.OpenFile(configPath, os.O_CREATE|os.O_WRONLY, 0600)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = fmt.Fprintf(configFile, "makestep 1.0 3\n")
+		Expect(err).ToNot(HaveOccurred())
+		err = configFile.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Modify the script so that it will write to the configuration file that we
+		// created, and write it to the temporary directory.
+		scriptText = strings.ReplaceAll(scriptText, "/etc/chrony.conf", configPath)
+		scriptPath := filepath.Join(tmpDir, "add-ntp-sources.sh")
+		err = os.WriteFile(scriptPath, []byte(scriptText), 0700) // #nosec G306
+		Expect(err).ToNot(HaveOccurred())
+
+		// Execute the script:
+		scriptCmd := exec.Command(scriptPath)
+		scriptCmd.Stdout = GinkgoWriter
+		scriptCmd.Stderr = GinkgoWriter
+		err = scriptCmd.Run()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Read the modified configuration file:
+		configData, err := os.ReadFile(configPath)
+		Expect(err).ToNot(HaveOccurred())
+		configText := string(configData)
+
+		// Check that the additional NTP servers have been added:
+		Expect(configText).To(MatchRegexp(`(?m)^server ntp1.example.com iburst$`))
+		Expect(configText).To(MatchRegexp(`(?m)^server ntp2.example.com iburst$`))
+
+		// Check that the original config has been preserved:
+		Expect(configText).To(MatchRegexp("(?m)^makestep 1.0 3$"))
 	})
 })
 

--- a/internal/ignition/templates/add-ntp-sources.service
+++ b/internal/ignition/templates/add-ntp-sources.service
@@ -1,0 +1,9 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/add-ntp-sources.sh
+
+[Unit]
+Before=chronyd.service
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/add-ntp-sources.sh
+++ b/internal/ignition/templates/add-ntp-sources.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >> /etc/chrony.conf <<.
+{{ range .AdditionalNtpSources }}
+server {{ . }} iburst
+{{ end }}
+.

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -42,7 +42,13 @@
         "name": "iscsistart.service",
         "enabled": true,
         "contents": {{ executeTemplate "iscsistart.service" . | toString | toJson }}
-    }{{end}}
+    }{{end}}{{if .AdditionalNtpSources}},
+    {
+        "name": "add-ntp-sources.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "add-ntp-sources.service" . | toString | toJson }}
+    }
+    {{end}}
     ]
   },
   "storage": {
@@ -204,6 +210,14 @@
         "name": "root"
       },
       "contents": { "source": "{{.ProfileProxyExports}}" }
+    }{{end}}{{if .AdditionalNtpSources}},
+    {
+      "path": "/usr/local/bin/add-ntp-sources.sh",
+      "mode": 493,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ executeTemplate "add-ntp-sources.sh" . | toBase64 }}" }
     }{{end}}]
   }
 }


### PR DESCRIPTION
This is a backport of [MGMT-18411](https://issues.redhat.com//browse/MGMT-18411) and #6591 for ACM 2.10.

Currently when the user provides additional NTP sources for the installation they are used by the installed cluster, but not by the discovery environment. That means that the system clock of the discovery environment may be wrong if the default NTP servers can't be reached, and as result it may fail to pull images because the system clock may be before the validity date of the certificates of the registry server. To avoid that this patch changes the ignition of the discovery environment so that it will also use the NTP sources provided by the user.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19672
https://issues.redhat.com/browse/MGMT-18411

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested using the included unit tests.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
