### PR TITLE
OCPBUGS-43578: Log disk info if rootDeviceHint not found

### DIFF
--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -142,6 +142,17 @@ func applyRootDeviceHints(log *log.Logger, host *models.Host, inventory *models.
 		log.Infof("Selecting disk %s for installation", diskID)
 	} else {
 		log.Info("No disk found matching root device hints")
+
+		possibleDisks := []string{}
+		for _, disk := range inventory.Disks {
+			if !disk.InstallationEligibility.Eligible {
+				log.Infof("Disk %s is not eligible due to %s", disk.Path, disk.InstallationEligibility.NotEligibleReasons)
+				continue
+			}
+			diskStr := fmt.Sprintf("Disk - path: %s, by-path: %s, wwn: %s", disk.Path, disk.ByPath, disk.Wwn)
+			possibleDisks = append(possibleDisks, diskStr)
+		}
+		log.Info("Eligible disks: ", possibleDisks)
 	}
 
 	updateParams.DisksSelectedConfig = []*models.DiskConfigParams{


### PR DESCRIPTION
If the rootDeviceHint is not found, log info about eligible disks. This is needed because the disk inventory in the the logs does not always reflect eligible disks.

Note that this is the first part of a change to reflect this info in the agent-based installer wait-for output.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
