### PR TITLE
MGMT-19590: Enable user managed load balancer with hosts in the same subnet but load balancer outside this subnet on baremetal

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -426,6 +426,13 @@ func (m *Manager) tryAssignMachineCidrDHCPMode(cluster *common.Cluster) error {
 }
 
 func (m *Manager) tryAssignMachineCidrNonDHCPMode(cluster *common.Cluster) error {
+	// With user-managed load balancer we can't calculate the
+	// machine network as the vips might be outside the hosts subnets.
+	// It should be set by the user manually.
+	if network.IsLoadBalancerUserManaged(cluster) {
+		return nil
+	}
+
 	primaryMachineNetwork, err := network.CalculateMachineNetworkCIDR(
 		network.GetApiVipById(cluster, 0), network.GetIngressVipById(cluster, 0), cluster.Hosts, false)
 	if err != nil {

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -173,12 +173,15 @@ func (feature *DualStackFeature) getFeatureActiveLevel(cluster *common.Cluster, 
 }
 
 func (feature *DualStackFeature) getIncompatibleFeatures(openshiftVersion string) *[]models.FeatureSupportLevelID {
-	if isNotSupported, err := common.BaseVersionLessThan("4.13", openshiftVersion); isNotSupported || err != nil {
-		return &[]models.FeatureSupportLevelID{
-			models.FeatureSupportLevelIDVSPHEREINTEGRATION,
-		}
+	unsupportedFeatures := []models.FeatureSupportLevelID{
+		models.FeatureSupportLevelIDUSERMANAGEDLOADBALANCER,
 	}
-	return nil
+
+	if isNotSupported, err := common.BaseVersionLessThan("4.13", openshiftVersion); isNotSupported || err != nil {
+		unsupportedFeatures = append(unsupportedFeatures, models.FeatureSupportLevelIDVSPHEREINTEGRATION)
+	}
+
+	return &unsupportedFeatures
 }
 
 func (feature *DualStackFeature) getIncompatibleArchitectures(_ *string) *[]models.ArchitectureSupportLevelID {
@@ -231,6 +234,7 @@ func (feature *DualStackVipsFeature) getFeatureActiveLevel(cluster *common.Clust
 func (feature *DualStackVipsFeature) getIncompatibleFeatures(string) *[]models.FeatureSupportLevelID {
 	return &[]models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDEXTERNALPLATFORMOCI,
+		models.FeatureSupportLevelIDUSERMANAGEDLOADBALANCER,
 	}
 }
 
@@ -501,6 +505,8 @@ func (feature *UserManagedLoadBalancerFeature) getIncompatibleFeatures(string) *
 		models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDVIPAUTOALLOC,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+		models.FeatureSupportLevelIDDUALSTACK,
+		models.FeatureSupportLevelIDDUALSTACKVIPS,
 	}
 }
 

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
+	"github.com/openshift/assisted-service/pkg/s3wrapper"
 	"github.com/samber/lo"
 	"github.com/vincent-petithory/dataurl"
 	"gorm.io/gorm"
@@ -2671,5 +2672,674 @@ var _ = Describe("Validations test", func() {
 			}, ValidationFailure, true, false),
 			Entry("Day 2 cluster - the validation should be skipped", []*models.MtuReport{}, ValidationSuccess, false, true),
 		)
+	})
+
+	Context("belongsToL2MajorityGroup", func() {
+		var (
+			ctx                                  = context.Background()
+			kubeApiEnabled                       = false
+			softTimeoutsEnabled                  = false
+			infraenv            *common.InfraEnv = nil
+			s3wrapper           s3wrapper.API    = nil
+			validator                            = &validator{log: common.GetTestLog()}
+			inventoryCache                       = InventoryCache{}
+		)
+
+		BeforeEach(func() {
+			mockHwValidator.EXPECT().GetInfraEnvHostRequirements(gomock.Any(), gomock.Any()).Return(&models.ClusterHostRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetPreflightInfraEnvHardwareRequirements(gomock.Any(), gomock.Any()).Return(&models.PreflightHardwareRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
+				Total: &models.ClusterHostRequirementsDetails{},
+			}, nil)
+			mockHwValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+				Ocp: &models.HostTypeHardwareRequirementsWrapper{
+					Worker: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
+					},
+					Master: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
+					},
+				},
+			}, nil)
+		})
+
+		Context("with cluster-managed load balancer", func() {
+			It("should return validation success when all machine networks exist in the majority group", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.127.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationSuccess))
+			})
+
+			It("should return validation failure when machine network is not in the majority groups", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.128.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationFailure))
+			})
+
+			It("should return validation failure when one of the machine networs is not in the majority groups", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.128.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.127.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationFailure))
+			})
+		})
+
+		Context("with user-managed load balancer", func() {
+			It("should return validation success when all machine networks exist in the majority group", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.127.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationSuccess))
+			})
+
+			It("should return validation failure when machine network is not in the majority groups", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.128.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationFailure))
+			})
+
+			It("should return validation success when one of the machine networs is not in the majority groups", func() {
+				machineNetworks := []*models.MachineNetwork{
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.127.0/24",
+					},
+					{
+						ClusterID: clusterID,
+						Cidr:      "192.168.128.0/24",
+					},
+				}
+				host := &models.Host{
+					ID:        &hostID,
+					ClusterID: &clusterID,
+					Role:      models.HostRoleMaster,
+				}
+				cluster := &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: machineNetworks,
+						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					},
+				}
+				majorityGroups := map[string][]strfmt.UUID{
+					"192.168.127.0/24": {*host.ID},
+				}
+
+				vc, err := newValidationContext(
+					ctx,
+					host,
+					cluster,
+					infraenv,
+					db,
+					inventoryCache,
+					mockHwValidator,
+					kubeApiEnabled,
+					s3wrapper,
+					softTimeoutsEnabled,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+				Expect(status).To(Equal(ValidationSuccess))
+			})
+		})
+	})
+
+	Context("belongsToMachineCidr", func() {
+		var (
+			ctx                                  = context.Background()
+			kubeApiEnabled                       = false
+			softTimeoutsEnabled                  = false
+			infraenv            *common.InfraEnv = nil
+			s3wrapper           s3wrapper.API    = nil
+			validator                            = &validator{log: common.GetTestLog()}
+			inventoryCache                       = InventoryCache{}
+		)
+
+		BeforeEach(func() {
+			mockHwValidator.EXPECT().GetInfraEnvHostRequirements(gomock.Any(), gomock.Any()).Return(&models.ClusterHostRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetPreflightInfraEnvHardwareRequirements(gomock.Any(), gomock.Any()).Return(&models.PreflightHardwareRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
+				Total: &models.ClusterHostRequirementsDetails{},
+			}, nil)
+			mockHwValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+				Ocp: &models.HostTypeHardwareRequirementsWrapper{
+					Worker: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
+					},
+					Master: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
+					},
+				},
+			}, nil)
+		})
+
+		It("with user-managed networking, SNO, host is not bootstrap, there are machine networks", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					UserManagedNetworking: swag.Bool(true),
+					MachineNetworks: []*models.MachineNetwork{
+						{ClusterID: clusterID, Cidr: "192.168.127.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("No machine network CIDR validation needed: User Managed Networking"))
+		})
+
+		It("with user-managed networking, SNO, host is bootstrap, no machine networks", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Bootstrap: true,
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					UserManagedNetworking: swag.Bool(true),
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("No machine network CIDR validation needed: User Managed Networking"))
+		})
+
+		It("with day2 cluster", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					Kind: swag.String(models.ClusterKindAddHostsCluster),
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("No machine network CIDR validation needed: Day2 cluster"))
+		})
+
+		It("with host misses inventory", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationPending))
+			Expect(msg).To(Equal("Missing inventory or machine network CIDR"))
+		})
+
+		It("with host misses machine network", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventory(),
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationPending))
+			Expect(msg).To(Equal("Missing inventory or machine network CIDR"))
+		})
+
+		It("with cluster-managed load balancer, host belongs to all machine networks", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{"1.2.3.5/24"},
+				}),
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					MachineNetworks: []*models.MachineNetwork{
+						{ClusterID: clusterID, Cidr: "1.2.3.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host belongs to all machine network CIDRs"))
+		})
+
+		It("with cluster-managed load balancer, host doesn't belongs to all machine networks", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{"1.2.3.5/24"},
+				}),
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					MachineNetworks: []*models.MachineNetwork{
+						{ClusterID: clusterID, Cidr: "1.2.4.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(Equal("Host does not belong to machine network CIDRs. Verify that the host belongs to every CIDR listed under machine networks"))
+		})
+
+		It("with user-managed load balancer, host belongs to some of the machine networks", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{"1.2.4.5/24"},
+				}),
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					MachineNetworks: []*models.MachineNetwork{
+						{ClusterID: clusterID, Cidr: "1.2.3.0/24"},
+						{ClusterID: clusterID, Cidr: "1.2.4.0/24"},
+					},
+					LoadBalancer: &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host belongs to at least one machine network CIDR"))
+		})
+
+		It("with user-managed load balancer, host doesn't belongs to any machine network", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{"1.2.5.5/24"},
+				}),
+			}
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+					Hosts: []*models.Host{
+						host,
+					},
+					MachineNetworks: []*models.MachineNetwork{
+						{ClusterID: clusterID, Cidr: "1.2.3.0/24"},
+						{ClusterID: clusterID, Cidr: "1.2.4.0/24"},
+					},
+					LoadBalancer: &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status, msg := validator.belongsToMachineCidr(validationContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(Equal("Host does not belong to any machine network CIDR. Verify that the host belongs to at least one CIDR listed under machine networks"))
+		})
 	})
 })

--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -14,6 +14,9 @@ const MinMaskDelta = 7
 // Minimum mask size for Machine CIDR to allow at least 16 addresses
 const MinMachineMaskDelta = 4
 
+// Minimum mask size for Machine CIDR to allow at least 4 addresses
+const MinUserManagedLoadBalancerMachineMaskDelta = 2
+
 // Minimum mask size for Machine CIDR to allow at least 2 addresses
 const MinSNOMachineMaskDelta = 1
 
@@ -78,10 +81,12 @@ func VerifyClusterOrServiceCIDR(cidrStr string) error {
 	return verifySubnetCIDR(cidrStr, MinMaskDelta)
 }
 
-func VerifyMachineCIDR(cidrStr string, isSNO bool) error {
+func VerifyMachineCIDR(cidrStr string, isSNO bool, isUserManagedLoadBalancer bool) error {
 	maskDelta := MinMachineMaskDelta
 	if isSNO {
 		maskDelta = MinSNOMachineMaskDelta
+	} else if isUserManagedLoadBalancer {
+		maskDelta = MinUserManagedLoadBalancerMachineMaskDelta
 	}
 	return verifySubnetCIDR(cidrStr, maskDelta)
 }

--- a/internal/network/cidr_validations_test.go
+++ b/internal/network/cidr_validations_test.go
@@ -34,24 +34,32 @@ var _ = Describe("CIDR validations", func() {
 	})
 	Context("Verify CIDRs", func() {
 		It("Machine CIDR 24 OK", func() {
-			Expect(VerifyMachineCIDR("1.2.3.0/24", false)).ToNot(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.0/24", false, false)).ToNot(HaveOccurred())
 		})
 		It("Machine CIDR 26 OK", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/26", false)).ToNot(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.128/26", false, false)).ToNot(HaveOccurred())
 		})
 		It("Machine CIDR 29 Fail", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/29", false)).To(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.128/29", false, false)).To(HaveOccurred())
 		})
 		It("Machine CIDR 27 OK", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/27", false)).ToNot(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.128/27", false, false)).ToNot(HaveOccurred())
 		})
 
 		It("Machine CIDR 31 Ok for SNO", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/31", true)).ToNot(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.128/31", true, false)).ToNot(HaveOccurred())
 		})
 
 		It("Machine CIDR 32 Fail for SNO", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/32", true)).To(HaveOccurred())
+			Expect(VerifyMachineCIDR("1.2.3.128/32", true, false)).To(HaveOccurred())
+		})
+
+		It("Machine CIDR 30 Ok for user managed load balancer", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/30", false, true)).ToNot(HaveOccurred())
+		})
+
+		It("Machine CIDR 31 Fail for user managed load balancer", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/31", false, true)).To(HaveOccurred())
 		})
 
 		It("Service CIDR 26 Fail", func() {

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -208,6 +208,15 @@ func DerefClusterNetworks(obj interface{}) []*models.ClusterNetwork {
 	}
 }
 
+func DerefClusterLoadBalancer(obj interface{}) *models.LoadBalancer {
+	switch v := obj.(type) {
+	case *models.LoadBalancer:
+		return v
+	default:
+		return nil
+	}
+}
+
 func GetMachineNetworkCidrs(cluster *common.Cluster) (ret []string) {
 	for _, n := range cluster.MachineNetworks {
 		ret = append(ret, string(n.Cidr))


### PR DESCRIPTION
This PR continues - https://github.com/openshift/assisted-service/pull/7096 by expanding user-managed load balancer support to support load balancers IP which could be outside the hosts subnet as well.

**Note** - OpenShift network operator requires each VIP to be part of at least one machine network. Therefore, we require from the user to provide the necessary machine networks for both the hosts and VIPs when using user-managd load balancer, and enable using more than one. 

Two e2e tests were configured to test this flow:

- `edge-e2e-metal-assisted-umlb-4-18` (REST API)
- `edge-e2e-metal-assisted-kube-api-umlb-4-18` (k8s AI)

This PR also disables `dual-stack` features with this one, as they seem to be incompatible at the moment. It could be enabled in the future in case they will be compatible.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
