### PR TITLE
MGMT-19521: Add the supported OLM operators names in the swagger file

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5932,7 +5932,23 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "lso",
+                  "mtv",
+                  "openshift_ai",
+                  "osc",
+                  "servicemesh",
+                  "authorino",
+                  "cnv",
+                  "nvidia_gpu",
+                  "pipelines",
+                  "odf",
+                  "lvm",
+                  "mce",
+                  "node_feature_discovery",
+                  "serverless"
+                ]
               }
             }
           },
@@ -16757,7 +16773,23 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "lso",
+                  "mtv",
+                  "openshift_ai",
+                  "osc",
+                  "servicemesh",
+                  "authorino",
+                  "cnv",
+                  "nvidia_gpu",
+                  "pipelines",
+                  "odf",
+                  "lvm",
+                  "mce",
+                  "node_feature_discovery",
+                  "serverless"
+                ]
               }
             }
           },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2703,6 +2703,21 @@ paths:
             type: array
             items:
               type: string
+              enum:
+              - 'lso'
+              - 'mtv'
+              - 'openshift_ai'
+              - 'osc'
+              - 'servicemesh'
+              - 'authorino'
+              - 'cnv'
+              - 'nvidia_gpu'
+              - 'pipelines'
+              - 'odf'
+              - 'lvm'
+              - 'mce'
+              - 'node_feature_discovery'
+              - 'serverless'
         "401":
           description: Unauthorized.
           schema:


### PR DESCRIPTION
This PR addresses the need to update the Swagger file with the supported OLM operators' names, improving the clarity of API documentation.

Since this change modifies only the `swagger.yaml` file, no automated tests are necessary.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 @eliorerz 
