### PR TITLE
MGMT-19100: Allow install to the existing root filesystem

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -38,6 +38,9 @@ type InstallCmdRequest struct {
 	// Pattern: ^(([a-zA-Z0-9\-\.]+)(:[0-9]+)?\/)?[a-z0-9\._\-\/@]+[?::a-zA-Z0-9_\-.]+$
 	ControllerImage *string `json:"controller_image"`
 
+	// CoreOS container image to use if installing to the local device
+	CoreosImage string `json:"coreos_image,omitempty"`
+
 	// List of disks to format
 	DisksToFormat []string `json:"disks_to_format"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -38,6 +38,9 @@ type InstallCmdRequest struct {
 	// Pattern: ^(([a-zA-Z0-9\-\.]+)(:[0-9]+)?\/)?[a-z0-9\._\-\/@]+[?::a-zA-Z0-9_\-.]+$
 	ControllerImage *string `json:"controller_image"`
 
+	// CoreOS container image to use if installing to the local device
+	CoreosImage string `json:"coreos_image,omitempty"`
+
 	// List of disks to format
 	DisksToFormat []string `json:"disks_to_format"`
 

--- a/internal/host/conditions.go
+++ b/internal/host/conditions.go
@@ -41,6 +41,11 @@ func (v *validator) isInstallationDiskSpeedCheckSuccessful(c *validationContext)
 		return true
 	}
 
+	// Disk speed check is skipped when installing to the local disk
+	if v.installToExistingRoot {
+		return true
+	}
+
 	info, err := v.getBootDeviceInfo(c.host)
 	return err == nil && info != nil && info.DiskSpeed != nil && info.DiskSpeed.Tested && info.DiskSpeed.ExitCode == 0
 }

--- a/internal/host/conditions_test.go
+++ b/internal/host/conditions_test.go
@@ -1,0 +1,51 @@
+package host
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/hardware"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("isInstallationDiskSpeedCheckSuccessful", func() {
+	var (
+		validationCtx *validationContext
+		v             *validator
+	)
+
+	BeforeEach(func() {
+		validationCtx = &validationContext{
+			host: &models.Host{},
+		}
+		v = &validator{
+			log:         common.GetTestLog(),
+			hwValidator: hardware.NewValidator(common.GetTestLog(), hardware.ValidatorCfg{}, nil, nil),
+		}
+	})
+
+	It("returns false when the infraenv is set", func() {
+		validationCtx.infraEnv = &common.InfraEnv{}
+		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeFalse())
+	})
+
+	It("returns true when disk partitions are being saved", func() {
+		validationCtx.host.InstallerArgs = "--save-partindex 1"
+		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeTrue())
+	})
+
+	It("returns true when installToExistingRoot is set", func() {
+		v.installToExistingRoot = true
+		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeTrue())
+	})
+
+	It("fails when install disk path can't be found", func() {
+		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeFalse())
+	})
+
+	It("succeeds when disk speed has been checked", func() {
+		validationCtx.host.InstallationDiskPath = "/dev/sda"
+		validationCtx.host.DisksInfo = "{\"/dev/sda\": {\"disk_speed\": {\"tested\": true, \"exit_code\": 0}, \"path\": \"/dev/sda\"}}"
+		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeTrue())
+	})
+})

--- a/internal/host/config.go
+++ b/internal/host/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	BootstrapHostMAC         string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
 	MaxHostDisconnectionTime time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
 	EnableVirtualInterfaces  bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
+	InstallToExistingRoot    bool                    `envconfig:"INSTALL_TO_EXISTING_ROOT" default:"false"`
 
 	// hostStageTimeouts contains the values of the host stage timeouts. Don't use this
 	// directly, use the HostStageTimeout method instead.

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -167,7 +167,7 @@ func NewManager(log logrus.FieldLogger, db *gorm.DB, notificationStream stream.N
 		hwValidator:         hwValidator,
 		eventsHandler:       eventsHandler,
 		sm:                  sm,
-		rp:                  newRefreshPreprocessor(log, hwValidatorCfg, hwValidator, operatorsApi, config.DisabledHostvalidations, providerRegistry, versionHandler),
+		rp:                  newRefreshPreprocessor(log, hwValidatorCfg, hwValidator, operatorsApi, config.DisabledHostvalidations, providerRegistry, versionHandler, config.InstallToExistingRoot),
 		metricApi:           metricApi,
 		Config:              *config,
 		leaderElector:       leaderElector,

--- a/internal/host/hostcommands/disk_performance_cmd.go
+++ b/internal/host/hostcommands/disk_performance_cmd.go
@@ -15,21 +15,26 @@ import (
 
 type diskPerfCheckCmd struct {
 	baseCmd
-	hwValidator        hardware.Validator
-	diskPerfCheckImage string
-	timeoutSeconds     float64
+	hwValidator           hardware.Validator
+	diskPerfCheckImage    string
+	timeoutSeconds        float64
+	installToExistingRoot bool
 }
 
-func NewDiskPerfCheckCmd(log logrus.FieldLogger, diskPerfCheckImage string, hwValidator hardware.Validator, timeoutSeconds float64) *diskPerfCheckCmd {
+func NewDiskPerfCheckCmd(log logrus.FieldLogger, diskPerfCheckImage string, hwValidator hardware.Validator, timeoutSeconds float64, installToExistingRoot bool) *diskPerfCheckCmd {
 	return &diskPerfCheckCmd{
-		baseCmd:            baseCmd{log: log},
-		diskPerfCheckImage: diskPerfCheckImage,
-		hwValidator:        hwValidator,
-		timeoutSeconds:     timeoutSeconds,
+		baseCmd:               baseCmd{log: log},
+		diskPerfCheckImage:    diskPerfCheckImage,
+		hwValidator:           hwValidator,
+		timeoutSeconds:        timeoutSeconds,
+		installToExistingRoot: installToExistingRoot,
 	}
 }
 
 func (c *diskPerfCheckCmd) GetSteps(_ context.Context, host *models.Host) ([]*models.Step, error) {
+	if c.installToExistingRoot {
+		return nil, nil
+	}
 	bootDevice, err := hardware.GetBootDevice(c.hwValidator, host)
 	if err != nil {
 		return nil, err

--- a/internal/host/hostcommands/disk_performance_cmd_test.go
+++ b/internal/host/hostcommands/disk_performance_cmd_test.go
@@ -32,7 +32,7 @@ var _ = Describe("disk_performance", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockValidator = hardware.NewMockValidator(ctrl)
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
-		dCmd = NewDiskPerfCheckCmd(common.GetTestLog(), "quay.io/example/agent:latest", mockValidator, 600)
+		dCmd = NewDiskPerfCheckCmd(common.GetTestLog(), "quay.io/example/agent:latest", mockValidator, 600, false)
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
@@ -54,6 +54,13 @@ var _ = Describe("disk_performance", func() {
 		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
 		Expect(stepErr).ToNot(HaveOccurred())
 		Expect(stepReply).To(BeNil())
+	})
+
+	It("returns no steps when installToExistingRoot is true", func() {
+		dCmd.installToExistingRoot = true
+		steps, err := dCmd.GetSteps(ctx, &host)
+		Expect(steps).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -69,6 +69,7 @@ type InstructionConfig struct {
 	DiskCheckTimeout         time.Duration     `envconfig:"DISK_CHECK_TIMEOUT" default:"8m"`
 	ImageAvailabilityTimeout time.Duration     `envconfig:"IMAGE_AVAILABILITY_TIMEOUT" default:"16m"`
 	DisabledSteps            []models.StepType `envconfig:"DISABLED_STEPS" default:""`
+	InstallToExistingRoot    bool              `envconfig:"INSTALL_TO_EXISTING_ROOT" default:"false"`
 	ReleaseImageMirror       string
 	CheckClusterVersion      bool
 	HostFSMountDir           string
@@ -78,7 +79,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	instructionConfig InstructionConfig, connectivityValidator connectivity.Validator, eventsHandler eventsapi.Handler,
 	versionHandler versions.Handler, osImages versions.OSImages, kubeApiEnabled bool) *InstructionManager {
 	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.AgentImage)
-	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot, !kubeApiEnabled)
+	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot, !kubeApiEnabled, instructionConfig.InstallToExistingRoot)
 	inventoryCmd := NewInventoryCmd(log, instructionConfig.AgentImage)
 	freeAddressesCmd := newFreeAddressesCmd(log, kubeApiEnabled)
 	stopCmd := NewStopInstallationCmd(log)

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -88,7 +88,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.AgentImage)
 	tangConnectivityCmd := NewTangConnectivityCheckCmd(log, db, instructionConfig.AgentImage)
 	ntpSynchronizerCmd := NewNtpSyncCmd(log, instructionConfig.AgentImage, db)
-	diskPerfCheckCmd := NewDiskPerfCheckCmd(log, instructionConfig.AgentImage, hwValidator, instructionConfig.DiskCheckTimeout.Seconds())
+	diskPerfCheckCmd := NewDiskPerfCheckCmd(log, instructionConfig.AgentImage, hwValidator, instructionConfig.DiskCheckTimeout.Seconds(), instructionConfig.InstallToExistingRoot)
 	imageAvailabilityCmd := NewImageAvailabilityCmd(log, db, ocRelease, versionHandler, instructionConfig, instructionConfig.ImageAvailabilityTimeout.Seconds())
 	domainNameResolutionCmd := NewDomainNameResolutionCmd(log, instructionConfig.AgentImage, versionHandler, db)
 	noopCmd := NewNoopCmd()

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -43,14 +43,15 @@ type refreshPreprocessor struct {
 
 func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator,
 	operatorsApi operators.API, disabledHostValidations DisabledHostValidations, providerRegistry registry.ProviderRegistry,
-	versionHandler versions.Handler) *refreshPreprocessor {
+	versionHandler versions.Handler, installToExistingRoot bool) *refreshPreprocessor {
 	v := &validator{
-		log:              log,
-		hwValidatorCfg:   hwValidatorCfg,
-		hwValidator:      hwValidator,
-		operatorsAPI:     operatorsApi,
-		providerRegistry: providerRegistry,
-		versionHandler:   versionHandler,
+		log:                   log,
+		hwValidatorCfg:        hwValidatorCfg,
+		hwValidator:           hwValidator,
+		operatorsAPI:          operatorsApi,
+		providerRegistry:      providerRegistry,
+		versionHandler:        versionHandler,
+		installToExistingRoot: installToExistingRoot,
 	}
 	return &refreshPreprocessor{
 		log:                     log,

--- a/internal/host/refresh_status_preprocessor_test.go
+++ b/internal/host/refresh_status_preprocessor_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 			disabledHostValidations,
 			mockProviderRegistry,
 			mockVersions,
+			false,
 		)
 	})
 

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -284,12 +284,13 @@ func boolValue(b bool) ValidationStatus {
 }
 
 type validator struct {
-	log              logrus.FieldLogger
-	hwValidatorCfg   *hardware.ValidatorCfg
-	hwValidator      hardware.Validator
-	operatorsAPI     operators.API
-	providerRegistry registry.ProviderRegistry
-	versionHandler   versions.Handler
+	log                   logrus.FieldLogger
+	hwValidatorCfg        *hardware.ValidatorCfg
+	hwValidator           hardware.Validator
+	operatorsAPI          operators.API
+	providerRegistry      registry.ProviderRegistry
+	versionHandler        versions.Handler
+	installToExistingRoot bool
 }
 
 func (v *validator) isMediaConnected(c *validationContext) (ValidationStatus, string) {

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -49,6 +49,21 @@ func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion)
 }
 
+// GetCoreOSImage mocks base method.
+func (m *MockRelease) GetCoreOSImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCoreOSImage", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCoreOSImage indicates an expected call of GetCoreOSImage.
+func (mr *MockReleaseMockRecorder) GetCoreOSImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCoreOSImage", reflect.TypeOf((*MockRelease)(nil).GetCoreOSImage), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
 // GetImageArchitecture mocks base method.
 func (m *MockRelease) GetImageArchitecture(log logrus.FieldLogger, image, pullSecret string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -33,6 +33,7 @@ const (
 	ironicAgentImageName           = "ironic-agent"
 	mustGatherImageName            = "must-gather"
 	okdRPMSImageName               = "okd-rpms"
+	coreosImageName                = "rhel-coreos"
 	DefaultTries                   = 5
 	DefaltRetryDelay               = time.Second * 5
 	staticInstallerRequiredVersion = "4.16.0-0.alpha"
@@ -57,6 +58,7 @@ type Release interface {
 	GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
+	GetCoreOSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetReleaseArchitecture(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) ([]string, error)
@@ -120,6 +122,11 @@ func (r *release) GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, r
 // GetMustGatherImage gets must-gather image URL from the release image or releaseImageMirror, if provided.
 func (r *release) GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
 	return r.getImageByName(log, mustGatherImageName, releaseImage, releaseImageMirror, pullSecret)
+}
+
+// GetCoreOSImage gets rhel-coreos image URL from the release image or releaseImageMirror, if provided.
+func (r *release) GetCoreOSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	return r.getImageByName(log, coreosImageName, releaseImage, releaseImageMirror, pullSecret)
 }
 
 func (r *release) getImageByName(log logrus.FieldLogger, imageName, releaseImage, releaseImageMirror, pullSecret string) (string, error) {

--- a/models/install_cmd_request.go
+++ b/models/install_cmd_request.go
@@ -38,6 +38,9 @@ type InstallCmdRequest struct {
 	// Pattern: ^(([a-zA-Z0-9\-\.]+)(:[0-9]+)?\/)?[a-z0-9\._\-\/@]+[?::a-zA-Z0-9_\-.]+$
 	ControllerImage *string `json:"controller_image"`
 
+	// CoreOS container image to use if installing to the local device
+	CoreosImage string `json:"coreos_image,omitempty"`
+
 	// List of disks to format
 	DisksToFormat []string `json:"disks_to_format"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8979,6 +8979,10 @@ func init() {
           "type": "string",
           "pattern": "^(([a-zA-Z0-9\\-\\.]+)(:[0-9]+)?\\/)?[a-z0-9\\._\\-\\/@]+[?::a-zA-Z0-9_\\-.]+$"
         },
+        "coreos_image": {
+          "description": "CoreOS container image to use if installing to the local device",
+          "type": "string"
+        },
         "disks_to_format": {
           "description": "List of disks to format",
           "type": "array",
@@ -19890,6 +19894,10 @@ func init() {
           "description": "Assisted installer controller image",
           "type": "string",
           "pattern": "^(([a-zA-Z0-9\\-\\.]+)(:[0-9]+)?\\/)?[a-z0-9\\._\\-\\/@]+[?::a-zA-Z0-9_\\-.]+$"
+        },
+        "coreos_image": {
+          "description": "CoreOS container image to use if installing to the local device",
+          "type": "string"
         },
         "disks_to_format": {
           "description": "List of disks to format",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6751,6 +6751,9 @@ definitions:
       notify_num_reboots:
         type: boolean
         description: If true, notify number of reboots by assisted controller
+      coreos_image:
+        type: string
+        description: CoreOS container image to use if installing to the local device
 
   ntp_synchronization_request:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -38,6 +38,9 @@ type InstallCmdRequest struct {
 	// Pattern: ^(([a-zA-Z0-9\-\.]+)(:[0-9]+)?\/)?[a-z0-9\._\-\/@]+[?::a-zA-Z0-9_\-.]+$
 	ControllerImage *string `json:"controller_image"`
 
+	// CoreOS container image to use if installing to the local device
+	CoreosImage string `json:"coreos_image,omitempty"`
+
 	// List of disks to format
 	DisksToFormat []string `json:"disks_to_format"`
 


### PR DESCRIPTION
In order to allow for new CAPI install methods this PR enables the installer to write to a new stateroot on the existing root filesystem as opposed to installing to an entire device using `coreos-installer`.

This PR creates an environment variable (`INSTALL_TO_EXISTING_ROOT`) which when set will fetch the coreos image content from the selected release and provide it to the installer. This (along with the changes in https://github.com/openshift/assisted-installer/pull/1003) will trigger the installer to write the image to a new stateroot on the existing disk rather than installing to a target device.

This functionality is disabled by default and should only be used when the host is not running in the live-iso environment.

In order to enable (and succeed when using) the new install flow the following must be done:
1. Set `INSTALL_TO_EXISTING_ROOT` to `true` in the assisted-service deployment
2. Boot a host using a disk image and provide the discovery ignition to that host using a platform metadata service
3. Proceed with installation as normal

In the future (https://issues.redhat.com/browse/MGMT-19102) we will detect if the host is booted using a live-iso or not and use the corresponding install strategy, but this PR is just a first pass to get CAPI integration work unstuck.

This PR can be merged now, but the full functionality also depends on the following PRs:
- https://github.com/openshift/assisted-installer/pull/1003
- [todo] agent PR

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19100

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Manually deployed to a dev-scripts environment and succeeded in an install using a disk image rather than the live-iso.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) - Will follow up with docs
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
