### PR TITLE
MGMT-19733: Enable user-managed load balancer with hosts on different subnets

### DIFF
--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -48,6 +48,7 @@ func (feature *SnoFeature) getIncompatibleFeatures(string) *[]models.FeatureSupp
 		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDVIPAUTOALLOC,
 		models.FeatureSupportLevelIDOPENSHIFTAI,
+		models.FeatureSupportLevelIDUSERMANAGEDLOADBALANCER,
 	}
 }
 

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -507,6 +507,7 @@ func (feature *UserManagedLoadBalancerFeature) getIncompatibleFeatures(string) *
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDDUALSTACK,
 		models.FeatureSupportLevelIDDUALSTACKVIPS,
+		models.FeatureSupportLevelIDSNO,
 	}
 }
 

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/metrics"
+	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/provider/registry"
@@ -2703,262 +2704,781 @@ var _ = Describe("Validations test", func() {
 			}, nil)
 		})
 
-		Context("with cluster-managed load balancer", func() {
-			It("should return validation success when all machine networks exist in the majority group", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
-					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
-					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.127.0/24": {*host.ID},
-				}
+		It("should return validation success when all machine networks exist in the majority group", func() {
+			machineNetworks := []*models.MachineNetwork{
+				{
+					ClusterID: clusterID,
+					Cidr:      "192.168.127.0/24",
+				},
+			}
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:              &clusterID,
+					MachineNetworks: machineNetworks,
+					LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+				},
+			}
+			majorityGroups := map[string][]strfmt.UUID{
+				"192.168.127.0/24": {*host.ID},
+			}
 
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
+			vc, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationSuccess))
-			})
-
-			It("should return validation failure when machine network is not in the majority groups", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
-					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
-					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.128.0/24": {*host.ID},
-				}
-
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationFailure))
-			})
-
-			It("should return validation failure when one of the machine networs is not in the majority groups", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
-					},
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.128.0/24",
-					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
-					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.127.0/24": {*host.ID},
-				}
-
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationFailure))
-			})
+			status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+			Expect(status).To(Equal(ValidationSuccess))
 		})
 
-		Context("with user-managed load balancer", func() {
-			It("should return validation success when all machine networks exist in the majority group", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
+		It("should return validation failure when machine network is not in the majority groups", func() {
+			machineNetworks := []*models.MachineNetwork{
+				{
+					ClusterID: clusterID,
+					Cidr:      "192.168.127.0/24",
+				},
+			}
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:              &clusterID,
+					MachineNetworks: machineNetworks,
+					LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+				},
+			}
+			majorityGroups := map[string][]strfmt.UUID{
+				"192.168.128.0/24": {*host.ID},
+			}
+
+			vc, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+			Expect(status).To(Equal(ValidationFailure))
+		})
+
+		It("should return validation failure when one of the machine networs is not in the majority groups", func() {
+			machineNetworks := []*models.MachineNetwork{
+				{
+					ClusterID: clusterID,
+					Cidr:      "192.168.127.0/24",
+				},
+				{
+					ClusterID: clusterID,
+					Cidr:      "192.168.128.0/24",
+				},
+			}
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:              &clusterID,
+					MachineNetworks: machineNetworks,
+					LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+				},
+			}
+			majorityGroups := map[string][]strfmt.UUID{
+				"192.168.127.0/24": {*host.ID},
+			}
+
+			vc, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
+			Expect(status).To(Equal(ValidationFailure))
+		})
+	})
+
+	Context("belongsToMajorityGroup", func() {
+		var (
+			ctx                                  = context.Background()
+			kubeApiEnabled                       = false
+			softTimeoutsEnabled                  = false
+			infraenv            *common.InfraEnv = nil
+			s3wrapper           s3wrapper.API    = nil
+			validator                            = &validator{log: common.GetTestLog()}
+			inventoryCache                       = InventoryCache{}
+		)
+
+		BeforeEach(func() {
+			infraenv = nil
+			mockHwValidator.EXPECT().GetInfraEnvHostRequirements(gomock.Any(), gomock.Any()).Return(&models.ClusterHostRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetPreflightInfraEnvHardwareRequirements(gomock.Any(), gomock.Any()).Return(&models.PreflightHardwareRequirements{}, nil).AnyTimes()
+			mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
+				Total: &models.ClusterHostRequirementsDetails{},
+			}, nil)
+			mockHwValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+				Ocp: &models.HostTypeHardwareRequirementsWrapper{
+					Worker: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
 					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					Master: &models.HostTypeHardwareRequirements{
+						Quantitative: &models.ClusterHostRequirementsDetails{},
 					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.127.0/24": {*host.ID},
-				}
+				},
+			}, nil)
+		})
 
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
+		It("should return success without output when infraenv is not nil", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+				},
+			}
+			infraenv = &common.InfraEnv{
+				InfraEnv: models.InfraEnv{
+					ClusterID: clusterID,
+				},
+			}
 
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationSuccess))
-			})
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-			It("should return validation failure when machine network is not in the majority groups", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccessSuppressOutput))
+			Expect(msg).To(Equal(""))
+		})
+
+		It("should return success when host is day2", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Kind:      swag.String(models.HostKindAddToExistingClusterHost),
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Day2 host is not required to be connected to other hosts in the cluster"))
+		})
+
+		It("should return success when cluster is SNO", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                   &clusterID,
+					HighAvailabilityMode: swag.String(models.ClusterCreateParamsHighAvailabilityModeNone),
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host has connectivity to the majority of hosts in the cluster"))
+		})
+
+		It("should return pending when cluster is missing connectivity majority groups", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &clusterID,
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationPending))
+			Expect(msg).To(Equal("Machine Network CIDR or Connectivity Majority Groups missing"))
+		})
+
+		It("should return error when cluster connectivity majority groups field is not a valid json", func() {
+			host := &models.Host{
+				ID:        &hostID,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+			}
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					ConnectivityMajorityGroups: "non-valid-json",
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationError))
+			Expect(msg).To(Equal("Parse error for connectivity majority group"))
+		})
+
+		It("should return success for L3 connected user-managed networking cluster", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.128.1"
+			host3IP := "192.168.129.1"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				L3ConnectedAddresses: map[strfmt.UUID][]string{
+					hostID1: {host1IP},
+					hostID2: {host2IP},
+					hostID3: {host3IP},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					UserManagedNetworking:      swag.Bool(true),
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
 					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host has connectivity to the majority of hosts in the cluster"))
+		})
+
+		It("should return failure for L3 non-connected user-managed networking cluster", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.128.1"
+			host3IP := "192.168.129.1"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				L3ConnectedAddresses: map[strfmt.UUID][]string{
+					hostID2: {host2IP},
+					hostID3: {host3IP},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					UserManagedNetworking:      swag.Bool(true),
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
 					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.128.0/24": {*host.ID},
-				}
+				},
+			}
 
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationFailure))
-			})
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(Equal("No connectivity to the majority of hosts in the cluster"))
+		})
 
-			It("should return validation success when one of the machine networs is not in the majority groups", func() {
-				machineNetworks := []*models.MachineNetwork{
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.127.0/24",
+		It("should return success for L3 connected user-managed load balancer", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.128.1"
+			host3IP := "192.168.129.1"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				L3ConnectedAddresses: map[strfmt.UUID][]string{
+					hostID1: {host1IP},
+					hostID2: {host2IP},
+					hostID3: {host3IP},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					LoadBalancer:               &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
 					},
-					{
-						ClusterID: clusterID,
-						Cidr:      "192.168.128.0/24",
-					},
-				}
-				host := &models.Host{
-					ID:        &hostID,
-					ClusterID: &clusterID,
-					Role:      models.HostRoleMaster,
-				}
-				cluster := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:              &clusterID,
-						MachineNetworks: machineNetworks,
-						LoadBalancer:    &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
-					},
-				}
-				majorityGroups := map[string][]strfmt.UUID{
-					"192.168.127.0/24": {*host.ID},
-				}
+				},
+			}
 
-				vc, err := newValidationContext(
-					ctx,
-					host,
-					cluster,
-					infraenv,
-					db,
-					inventoryCache,
-					mockHwValidator,
-					kubeApiEnabled,
-					s3wrapper,
-					softTimeoutsEnabled,
-				)
-				Expect(err).ToNot(HaveOccurred())
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-				status := validator.belongsToL2MajorityGroup(vc, majorityGroups)
-				Expect(status).To(Equal(ValidationSuccess))
-			})
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host has connectivity to the majority of hosts in the cluster"))
+		})
+
+		It("should return failure for L3 non-connected user-managed load balancer cluster", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.128.1"
+			host3IP := "192.168.129.1"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				L3ConnectedAddresses: map[strfmt.UUID][]string{
+					hostID2: {host2IP},
+					hostID3: {host3IP},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					LoadBalancer:               &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged},
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(Equal("No connectivity to the majority of hosts in the cluster"))
+		})
+
+		It("should return success for L2 connected cluster-managed load balancer cluster", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.127.2"
+			host3IP := "192.168.127.3"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				MajorityGroups: map[string][]strfmt.UUID{
+					"192.168.127.0/24": {hostID1, hostID2, hostID3},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					LoadBalancer:               &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("Host has connectivity to the majority of hosts in the cluster"))
+		})
+
+		It("should return failure for L2 non-connected cluster-managed load balancer cluster", func() {
+			hostID1 := strfmt.UUID(uuid.New().String())
+			hostID2 := strfmt.UUID(uuid.New().String())
+			hostID3 := strfmt.UUID(uuid.New().String())
+
+			host1IP := "192.168.127.1"
+			host2IP := "192.168.127.2"
+			host3IP := "192.168.127.3"
+
+			host1 := &models.Host{
+				ID:        &hostID1,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host1IP},
+				}),
+			}
+
+			host2 := &models.Host{
+				ID:        &hostID2,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host2IP},
+				}),
+			}
+
+			host3 := &models.Host{
+				ID:        &hostID3,
+				ClusterID: &clusterID,
+				Role:      models.HostRoleMaster,
+				Inventory: common.GenerateTestInventoryWithNetwork(common.NetAddress{
+					IPv4Address: []string{host3IP},
+				}),
+			}
+
+			connectivity := network.Connectivity{
+				MajorityGroups: map[string][]strfmt.UUID{
+					"192.168.127.0/24": {hostID2, hostID3},
+				},
+			}
+			bytes, err := json.Marshal(connectivity)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:                         &clusterID,
+					LoadBalancer:               &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged},
+					ConnectivityMajorityGroups: string(bytes),
+					Hosts:                      []*models.Host{host1, host2, host3},
+					MachineNetworks: []*models.MachineNetwork{
+						{Cidr: "192.168.127.0/24"},
+					},
+				},
+			}
+
+			validationContext, err := newValidationContext(
+				ctx,
+				host1,
+				cluster,
+				infraenv,
+				db,
+				inventoryCache,
+				mockHwValidator,
+				kubeApiEnabled,
+				s3wrapper,
+				softTimeoutsEnabled,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			status, msg := validator.belongsToMajorityGroup(validationContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(Equal("No connectivity to the majority of hosts in the cluster"))
 		})
 	})
 

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			cluster.Platform = createBaremetalPlatformParams()
 			err := providerRegistry.AddPlatformToInstallConfig(&cfg, &cluster, nil)
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("Failed to find a network interface matching machine network"))
+			Expect(err.Error()).Should(ContainSubstring("Failed to find a network interface matching any machine network"))
 		})
 		It("fails for cluster without machine networks", func() {
 			cfg := getInstallerConfigBaremetal()


### PR DESCRIPTION
This PR continues - https://github.com/openshift/assisted-service/pull/7187 by expanding user-managed load balancer support to support hosts on different subnets as well.

**Note** - OpenShift network operator requires each VIP to be part of at least one machine network. Therefore, we require from the user to provide the necessary machine networks for both the hosts and VIPs when using user-managd load balancer, and enable using more than one. 

Two e2e tests were configured to test this flow:

- `edge-e2e-metal-assisted-umlb-4-18` (REST API)
- `edge-e2e-metal-assisted-kube-api-umlb-4-18` (k8s AI)

This PR also disables `SNO` feature with this one, as SNO requires `user-managed networking` which is incompatible with this one.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
