### PR TITLE
MGMT-14453: Make sure installercache can actually run Mutex correctly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/infraenv"
 	installcfg "github.com/openshift/assisted-service/internal/installcfg/builder"
+	"github.com/openshift/assisted-service/internal/installercache"
 	internaljson "github.com/openshift/assisted-service/internal/json"
 	"github.com/openshift/assisted-service/internal/manifests"
 	"github.com/openshift/assisted-service/internal/metrics"
@@ -476,7 +477,10 @@ func main() {
 	failOnError(err, "failed to create valid bm config S3 endpoint URL from %s", Options.BMConfig.S3EndpointURL)
 	Options.BMConfig.S3EndpointURL = newUrl
 
-	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry, manifestsApi, eventsHandler)
+	installGeneratorWorkDir := filepath.Join(Options.WorkDir, "install-config-generate")
+	installerCacheDir := filepath.Join(installGeneratorWorkDir, "installercache")
+	installerCache := installercache.New(installerCacheDir, 5, eventsHandler, log)
+	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry, manifestsApi, eventsHandler, installGeneratorWorkDir, installerCache)
 	var crdUtils bminventory.CRDUtils
 	if ctrlMgr != nil {
 		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient(), hostApi)

--- a/internal/ignition/installmanifests.go
+++ b/internal/ignition/installmanifests.go
@@ -85,7 +85,6 @@ type installerGenerator struct {
 	cluster                       *common.Cluster
 	releaseImage                  string
 	releaseImageMirror            string
-	installerDir                  string
 	serviceCACert                 string
 	encodedDhcpFileContents       string
 	s3Client                      s3wrapper.API
@@ -110,16 +109,15 @@ var fileNames = [...]string{
 }
 
 // NewGenerator returns a generator that can generate ignition files
-func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, releaseImage string, releaseImageMirror string,
+func NewGenerator(workDir string, cluster *common.Cluster, releaseImage string, releaseImageMirror string,
 	serviceCACert string, installInvoker string, s3Client s3wrapper.API, log logrus.FieldLogger, providerRegistry registry.ProviderRegistry,
-	installerReleaseImageOverride, clusterTLSCertOverrideDir string, storageCapacityLimit int64, manifestApi manifestsapi.ManifestsAPI, eventsHandler eventsapi.Handler) Generator {
+	installerReleaseImageOverride, clusterTLSCertOverrideDir string, manifestApi manifestsapi.ManifestsAPI, eventsHandler eventsapi.Handler, installerCache *installercache.Installers) Generator {
 	return &installerGenerator{
 		cluster:                       cluster,
 		log:                           log,
 		releaseImage:                  releaseImage,
 		releaseImageMirror:            releaseImageMirror,
 		workDir:                       workDir,
-		installerDir:                  installerDir,
 		serviceCACert:                 serviceCACert,
 		s3Client:                      s3Client,
 		enableMetal3Provisioning:      true,
@@ -127,7 +125,7 @@ func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, 
 		providerRegistry:              providerRegistry,
 		installerReleaseImageOverride: installerReleaseImageOverride,
 		clusterTLSCertOverrideDir:     clusterTLSCertOverrideDir,
-		installerCache:                installercache.New(installerDir, storageCapacityLimit, eventsHandler, log),
+		installerCache:                installerCache,
 		manifestApi:                   manifestApi,
 	}
 }

--- a/internal/ignition/installmanifests_test.go
+++ b/internal/ignition/installmanifests_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/assisted-service/internal/constants"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/installercache"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
@@ -78,23 +79,25 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 	  }`
 
 	var (
-		err           error
-		examplePath   string
-		db            *gorm.DB
-		dbName        string
-		bmh           *bmh_v1alpha1.BareMetalHost
-		config        *config_32_types.Config
-		mockS3Client  *s3wrapper.MockAPI
-		workDir       string
-		cluster       *common.Cluster
-		ctrl          *gomock.Controller
-		manifestsAPI  *manifestsapi.MockManifestsAPI
-		eventsHandler eventsapi.Handler
+		err            error
+		examplePath    string
+		db             *gorm.DB
+		dbName         string
+		bmh            *bmh_v1alpha1.BareMetalHost
+		config         *config_32_types.Config
+		mockS3Client   *s3wrapper.MockAPI
+		workDir        string
+		cluster        *common.Cluster
+		ctrl           *gomock.Controller
+		manifestsAPI   *manifestsapi.MockManifestsAPI
+		eventsHandler  eventsapi.Handler
+		installerCache *installercache.Installers
 	)
 
 	BeforeEach(func() {
 		// setup temp workdir
 		workDir, err = os.MkdirTemp("", "bootstrap-ignition-update-test-")
+		installerCache = installercache.New(filepath.Join(workDir, "install-config-generate", "installercache"), 5, eventsHandler, logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 		examplePath = filepath.Join(workDir, "example1.ign")
 		var err1 error
@@ -113,7 +116,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 			},
 		}
 		db, dbName = common.PrepareTestDB()
-		g := NewGenerator(workDir, "", cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+		g := NewGenerator(workDir, cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 		Expect(g.updateBootstrap(context.Background(), examplePath)).To(Succeed())
 
@@ -241,16 +244,17 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 -----END CERTIFICATE-----`
 
 	var (
-		masterPath    string
-		workerPath    string
-		caCertPath    string
-		dbName        string
-		db            *gorm.DB
-		cluster       *common.Cluster
-		workDir       string
-		ctrl          *gomock.Controller
-		manifestsAPI  *manifestsapi.MockManifestsAPI
-		eventsHandler eventsapi.Handler
+		masterPath     string
+		workerPath     string
+		caCertPath     string
+		dbName         string
+		db             *gorm.DB
+		cluster        *common.Cluster
+		workDir        string
+		ctrl           *gomock.Controller
+		manifestsAPI   *manifestsapi.MockManifestsAPI
+		eventsHandler  eventsapi.Handler
+		installerCache *installercache.Installers
 	)
 
 	BeforeEach(func() {
@@ -274,6 +278,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		installerCache = installercache.New(filepath.Join(workDir, "install-config-generate", "installercache"), 5, eventsHandler, logrus.New())
 	})
 
 	AfterEach(func() {
@@ -283,7 +288,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 
 	Describe("update ignitions", func() {
 		It("with ca cert file", func() {
-			g := NewGenerator(workDir, "", cluster, "", "", caCertPath, "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", caCertPath, "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -305,7 +310,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			Expect(file.Path).To(Equal(common.HostCACertPath))
 		})
 		It("with no ca cert file", func() {
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -324,7 +329,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		Context("DHCP generation", func() {
 			It("Definitions only", func() {
-				g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+				g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 				g.encodedDhcpFileContents = "data:,abc"
 				err := g.updateIgnitions()
@@ -342,7 +347,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			})
 		})
 		It("Definitions+leases", func() {
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			g.encodedDhcpFileContents = "data:,abc"
 			cluster.ApiVipLease = "api"
@@ -429,14 +434,15 @@ var _ = Describe("createHostIgnitions", func() {
 		}`
 
 	var (
-		dbName        string
-		db            *gorm.DB
-		mockS3Client  *s3wrapper.MockAPI
-		cluster       *common.Cluster
-		ctrl          *gomock.Controller
-		workDir       string
-		manifestsAPI  *manifestsapi.MockManifestsAPI
-		eventsHandler eventsapi.Handler
+		dbName         string
+		db             *gorm.DB
+		mockS3Client   *s3wrapper.MockAPI
+		cluster        *common.Cluster
+		ctrl           *gomock.Controller
+		workDir        string
+		manifestsAPI   *manifestsapi.MockManifestsAPI
+		eventsHandler  eventsapi.Handler
+		installerCache *installercache.Installers
 	)
 
 	BeforeEach(func() {
@@ -457,6 +463,7 @@ var _ = Describe("createHostIgnitions", func() {
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
 		cluster = testCluster()
+		installerCache = installercache.New(filepath.Join(workDir, "install-config-generate", "installercache"), 5, eventsHandler, logrus.New())
 	})
 
 	AfterEach(func() {
@@ -492,7 +499,7 @@ var _ = Describe("createHostIgnitions", func() {
 				host.ID = &id
 			}
 
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			err := g.createHostIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -546,7 +553,7 @@ var _ = Describe("createHostIgnitions", func() {
 				host.ID = &id
 			}
 
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			err := g.createHostIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -590,7 +597,7 @@ var _ = Describe("createHostIgnitions", func() {
 				host.ID = &id
 			}
 
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 			err := g.createHostIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -638,7 +645,7 @@ var _ = Describe("createHostIgnitions", func() {
 			host.ID = &id
 		}
 
-		g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+		g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 		g.nodeIpAllocations = make(map[strfmt.UUID]*network.NodeIpAllocation)
 		for i, h := range cluster.Hosts {
 			g.nodeIpAllocations[*h.ID] = &network.NodeIpAllocation{
@@ -679,7 +686,7 @@ var _ = Describe("createHostIgnitions", func() {
 			IgnitionConfigOverrides: `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`,
 		}}
 
-		g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+		g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 		err := g.createHostIgnitions()
 		Expect(err).NotTo(HaveOccurred())
@@ -750,7 +757,7 @@ spec:
 				MachineConfigPoolName: "infra",
 			}}
 
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 			mockS3Client.EXPECT().ListObjectsByPrefixWithMetadata(gomock.Any(), filepath.Join(clusterID.String(), constants.ManifestFolder, models.ManifestFolderOpenshift)).Return([]s3wrapper.ObjectInfo{{Path: "mcp.yaml"}}, nil).Times(1)
 			mockS3Client.EXPECT().ListObjectsByPrefixWithMetadata(gomock.Any(), filepath.Join(clusterID.String(), constants.ManifestFolder, models.ManifestFolderManifests)).Times(1)
 			mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader(mcp)), int64(0), nil)
@@ -776,7 +783,7 @@ spec:
 				MachineConfigPoolName: "infra",
 			}}
 
-			g := NewGenerator(workDir, "", cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", 5, manifestsAPI, eventsHandler).(*installerGenerator)
+			g := NewGenerator(workDir, cluster, "", "", "", "", mockS3Client, logrus.New(), nil, "", "", manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 			mockS3Client.EXPECT().ListObjectsByPrefixWithMetadata(gomock.Any(), filepath.Join(clusterID.String(), constants.ManifestFolder, models.ManifestFolderOpenshift)).Return([]s3wrapper.ObjectInfo{{Path: "mcp.yaml"}}, nil).Times(1)
 			mockS3Client.EXPECT().ListObjectsByPrefixWithMetadata(gomock.Any(), filepath.Join(clusterID.String(), constants.ManifestFolder, models.ManifestFolderManifests)).Times(1)
 			mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader(mc)), int64(0), nil)
@@ -1582,10 +1589,11 @@ var _ = Describe("Set kubelet node ip", func() {
 
 var _ = Describe("Bare metal host generation", func() {
 	var (
-		workDir       string
-		ctrl          *gomock.Controller
-		manifestsAPI  *manifestsapi.MockManifestsAPI
-		eventsHandler eventsapi.Handler
+		workDir        string
+		ctrl           *gomock.Controller
+		manifestsAPI   *manifestsapi.MockManifestsAPI
+		eventsHandler  eventsapi.Handler
+		installerCache *installercache.Installers
 	)
 
 	BeforeEach(func() {
@@ -1595,6 +1603,7 @@ var _ = Describe("Bare metal host generation", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		installerCache = installercache.New(filepath.Join(workDir, "install-config-generate", "installercache"), 5, eventsHandler, logrus.New())
 	})
 
 	AfterEach(func() {
@@ -1607,7 +1616,6 @@ var _ = Describe("Bare metal host generation", func() {
 			// Create the generator:
 			generator := NewGenerator(
 				workDir,
-				"",
 				testCluster(),
 				"",
 				"",
@@ -1618,9 +1626,9 @@ var _ = Describe("Bare metal host generation", func() {
 				nil,
 				"",
 				"",
-				5,
 				manifestsAPI,
 				eventsHandler,
+				installerCache,
 			).(*installerGenerator)
 
 			// The default host inventory used by these tests has two NICs, each with
@@ -1680,14 +1688,15 @@ var _ = Describe("Bare metal host generation", func() {
 
 var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 	var (
-		certDir       string
-		dbName        string
-		db            *gorm.DB
-		cluster       *common.Cluster
-		workDir       string
-		ctrl          *gomock.Controller
-		manifestsAPI  *manifestsapi.MockManifestsAPI
-		eventsHandler eventsapi.Handler
+		certDir        string
+		dbName         string
+		db             *gorm.DB
+		cluster        *common.Cluster
+		workDir        string
+		ctrl           *gomock.Controller
+		manifestsAPI   *manifestsapi.MockManifestsAPI
+		eventsHandler  eventsapi.Handler
+		installerCache *installercache.Installers
 	)
 
 	certFiles := []string{"test-cert.crt", "test-cert.key"}
@@ -1718,6 +1727,7 @@ var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		installerCache = installercache.New(filepath.Join(workDir, "install-config-generate", "installercache"), 5, eventsHandler, logrus.New())
 	})
 
 	AfterEach(func() {
@@ -1726,7 +1736,7 @@ var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 	})
 
 	It("copies the tls cert files", func() {
-		g := NewGenerator(workDir, "", cluster, "", "", "", "", nil, logrus.New(), nil, "", certDir, 5, manifestsAPI, eventsHandler).(*installerGenerator)
+		g := NewGenerator(workDir, cluster, "", "", "", "", nil, logrus.New(), nil, "", certDir, manifestsAPI, eventsHandler, installerCache).(*installerGenerator)
 
 		err := g.importClusterTLSCerts(context.Background())
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/google/uuid"
 )
 
 var (
@@ -135,8 +136,7 @@ func (i *Installers) Get(ctx context.Context, releaseID, releaseIDMirror, pullSe
 	// return a new hard link to the binary file
 	// the caller should delete the hard link when
 	// it finishes working with the file
-	link := filepath.Join(workdir, "ln_"+fmt.Sprint(time.Now().Unix())+
-		"_"+binary)
+	link := filepath.Join(workdir, fmt.Sprintf("ln_%d_%s_%s", time.Now().Unix(), uuid.NewString(), binary))
 	err = os.Link(path, link)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Failed to create hard link to binary %s", path))

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -3,11 +3,11 @@ package generator
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/openshift/assisted-service/internal/common"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/ignition"
+	"github.com/openshift/assisted-service/internal/installercache"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/provider/registry"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -39,18 +39,20 @@ type installGenerator struct {
 	providerRegistry registry.ProviderRegistry
 	manifestApi      manifestsapi.ManifestsAPI
 	eventsHandler    eventsapi.Handler
+	installerCache   *installercache.Installers
 }
 
 func New(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config, workDir string,
-	providerRegistry registry.ProviderRegistry, manifestApi manifestsapi.ManifestsAPI, eventsHandler eventsapi.Handler) *installGenerator {
+	providerRegistry registry.ProviderRegistry, manifestApi manifestsapi.ManifestsAPI, eventsHandler eventsapi.Handler, installGeneratorWorkdir string, installerCache *installercache.Installers) *installGenerator {
 	return &installGenerator{
 		Config:           cfg,
 		log:              log,
 		s3Client:         s3Client,
-		workDir:          filepath.Join(workDir, "install-config-generate"),
+		workDir:          installGeneratorWorkdir,
 		providerRegistry: providerRegistry,
 		manifestApi:      manifestApi,
 		eventsHandler:    eventsHandler,
+		installerCache:   installerCache,
 	}
 }
 
@@ -71,15 +73,13 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 		}
 	}()
 
-	installerCacheDir := filepath.Join(k.workDir, "installercache")
-
 	// runs openshift-install to generate ignition files, then modifies them as necessary
 	var generator ignition.Generator
 	if k.Config.DummyIgnition {
 		generator = ignition.NewDummyGenerator(clusterWorkDir, &cluster, k.s3Client, log)
 	} else {
-		generator = ignition.NewGenerator(clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror,
-			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.providerRegistry, installerReleaseImageOverride, k.Config.ClusterTLSCertOverrideDir, k.InstallerCacheCapacity, k.manifestApi, k.eventsHandler)
+		generator = ignition.NewGenerator(clusterWorkDir, &cluster, releaseImage, k.Config.ReleaseImageMirror,
+			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.providerRegistry, installerReleaseImageOverride, k.Config.ClusterTLSCertOverrideDir, k.manifestApi, k.eventsHandler, k.installerCache)
 	}
 	err = generator.Generate(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
Presently we instantiate a new `installercache.Installers` instance per execution of the code generator. This renders any mutex handling pointless as we will never have any mutex conflict over a single request.

This PR moves the instantiation into the main and effectively makes it a singleton so that mutexes will function as intended.

This is the root cause behind a couple of reported issues

https://issues.redhat.com/browse/MGMT-14452 - Installer cache removes in-used cached image when out of space https://issues.redhat.com/browse/MGMT-14453 - INSTALLER_CACHE_CAPACITY small value cause to assisted-service crash

Both of these issues are reproducible on master and do not reproduce when running on code based on this PR.

If the cache size is set to a low value such as 1 then the current release will be deleted once the caller has finished with the release.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
