### PR TITLE
NO-ISSUE: Ensure that hard links are accounted for when measuring disk usage

### DIFF
--- a/internal/metrics/disk_stats_helper.go
+++ b/internal/metrics/disk_stats_helper.go
@@ -1,8 +1,10 @@
 package metrics
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -22,12 +24,22 @@ func NewOSDiskStatsHelper() *OSDiskStatsHelper {
 
 func (c *OSDiskStatsHelper) getUsedBytesInDirectory(directory string) (uint64, error) {
 	var totalBytes uint64
+	// Maintain a map of inodes we have seen so that we don't double count storage
+	seenInodes := make(map[uint64]bool)
 	err := filepath.Walk(directory, func(path string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if !fileInfo.IsDir() {
+		// We need to ensure that the size check is based on inodes and not just the sizes gleaned from files.
+		// we should ensure that we have not seen a particular inode for a given file before.
+		// this is because there are hard links in use and we need to account for this.
+		stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("unable to determine stat information for path %s", path)
+		}
+		if !fileInfo.IsDir() && !seenInodes[stat.Ino] {
 			totalBytes += uint64(fileInfo.Size())
+			seenInodes[stat.Ino] = true
 		}
 		return nil
 	})

--- a/internal/metrics/os_disk_stats_helper_test.go
+++ b/internal/metrics/os_disk_stats_helper_test.go
@@ -2,7 +2,9 @@ package metrics
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -24,13 +26,14 @@ var _ = Describe("OS disk stats helper", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	var writeDummyFile = func(sizeInBytes int64) {
+	var writeDummyFile = func(sizeInBytes int64) string {
 		file, err := os.CreateTemp(tempDir, "dummy-file")
 		Expect(err).ToNot(HaveOccurred())
 		defer file.Close()
 
 		err = file.Truncate(sizeInBytes)
 		Expect(err).ToNot(HaveOccurred())
+		return file.Name()
 	}
 
 	It("should retrieve correct stats for an empty directory", func() {
@@ -47,6 +50,45 @@ var _ = Describe("OS disk stats helper", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(usageBytes).To(BeEquivalentTo(32768))
 		Expect(freeBytes).To(BeNumerically(">", 0))
+	})
+
+	It("hardlinks should be correctly handled", func() {
+		writeDummyFile(16384)
+
+		// Create a hardlink to a second file
+		path := writeDummyFile(16384)
+		link := filepath.Join(tempDir, "ln_"+uuid.NewString())
+		err := os.Link(path, link)
+		Expect(err).ToNot((HaveOccurred()))
+
+		usageBytes, _, err := diskStatsHelper.GetDiskUsage(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		// We should only be counting the size of the two actual files.
+		Expect(usageBytes).To(BeEquivalentTo(32768))
+
+		// Delete the main file link
+		err = os.Remove(path)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Grab usage again
+		usageBytes, _, err = diskStatsHelper.GetDiskUsage(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		// We expect the same result as the hardlink is still pointing to the old file
+		Expect(usageBytes).To(BeEquivalentTo(32768))
+
+		// Now get rid of the link
+		err = os.Remove(link)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Grab usage again
+		usageBytes, _, err = diskStatsHelper.GetDiskUsage(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		// We expect to use less space as all references to the file inodes have been removed.
+		Expect(usageBytes).To(BeEquivalentTo(16384))
+
 	})
 
 })


### PR DESCRIPTION
When we measure the disk usage for metrics, we need to ensure that hard links are accounted for as these may lead to an inaccurate count. This PR modifies the gathering of filesizes slightly to perform a stat on each file and take into account the unique inode number.

Hard links and actual files share the same inode number as this is a reference to the underlying data.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
