### PR TITLE
MGMT-19102: Add boot device type

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -155,6 +155,7 @@ type HostDisk struct {
 type HostBoot struct {
 	CurrentBootMode string `json:"currentBootMode,omitempty"`
 	PxeInterface    string `json:"pxeInterface,omitempty"`
+	DeviceType      string `json:"deviceType,omitempty"`
 }
 
 type HostSystemVendor struct {

--- a/api/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -7,10 +7,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Boot boot
@@ -24,6 +26,10 @@ type Boot struct {
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 
+	// device type
+	// Enum: [persistent ephemeral]
+	DeviceType string `json:"device_type,omitempty"`
+
 	// pxe interface
 	PxeInterface string `json:"pxe_interface,omitempty"`
 
@@ -35,6 +41,10 @@ type Boot struct {
 func (m *Boot) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDeviceType(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSecureBootState(formats); err != nil {
 		res = append(res, err)
 	}
@@ -42,6 +52,48 @@ func (m *Boot) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var bootTypeDeviceTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["persistent","ephemeral"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		bootTypeDeviceTypePropEnum = append(bootTypeDeviceTypePropEnum, v)
+	}
+}
+
+const (
+
+	// BootDeviceTypePersistent captures enum value "persistent"
+	BootDeviceTypePersistent string = "persistent"
+
+	// BootDeviceTypeEphemeral captures enum value "ephemeral"
+	BootDeviceTypeEphemeral string = "ephemeral"
+)
+
+// prop value enum
+func (m *Boot) validateDeviceTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, bootTypeDeviceTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Boot) validateDeviceType(formats strfmt.Registry) error {
+	if swag.IsZero(m.DeviceType) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateDeviceTypeEnum("device_type", "body", m.DeviceType); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/client/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -7,10 +7,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Boot boot
@@ -24,6 +26,10 @@ type Boot struct {
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 
+	// device type
+	// Enum: [persistent ephemeral]
+	DeviceType string `json:"device_type,omitempty"`
+
 	// pxe interface
 	PxeInterface string `json:"pxe_interface,omitempty"`
 
@@ -35,6 +41,10 @@ type Boot struct {
 func (m *Boot) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDeviceType(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSecureBootState(formats); err != nil {
 		res = append(res, err)
 	}
@@ -42,6 +52,48 @@ func (m *Boot) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var bootTypeDeviceTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["persistent","ephemeral"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		bootTypeDeviceTypePropEnum = append(bootTypeDeviceTypePropEnum, v)
+	}
+}
+
+const (
+
+	// BootDeviceTypePersistent captures enum value "persistent"
+	BootDeviceTypePersistent string = "persistent"
+
+	// BootDeviceTypeEphemeral captures enum value "ephemeral"
+	BootDeviceTypeEphemeral string = "ephemeral"
+)
+
+// prop value enum
+func (m *Boot) validateDeviceTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, bootTypeDeviceTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Boot) validateDeviceType(formats strfmt.Registry) error {
+	if swag.IsZero(m.DeviceType) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateDeviceTypeEnum("device_type", "body", m.DeviceType); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -216,6 +216,8 @@ spec:
                     properties:
                       currentBootMode:
                         type: string
+                      deviceType:
+                        type: string
                       pxeInterface:
                         type: string
                     type: object

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -1013,6 +1013,8 @@ spec:
                     properties:
                       currentBootMode:
                         type: string
+                      deviceType:
+                        type: string
                       pxeInterface:
                         type: string
                     type: object

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -226,6 +226,8 @@ spec:
                     properties:
                       currentBootMode:
                         type: string
+                      deviceType:
+                        type: string
                       pxeInterface:
                         type: string
                     type: object

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -1383,6 +1383,7 @@ func (r *AgentReconciler) updateInventoryAndLabels(log logrus.FieldLogger, ctx c
 		agent.Status.Inventory.Boot = aiv1beta1.HostBoot{
 			CurrentBootMode: inventory.Boot.CurrentBootMode,
 			PxeInterface:    inventory.Boot.PxeInterface,
+			DeviceType:      inventory.Boot.DeviceType,
 		}
 	}
 	if inventory.SystemVendor != nil {

--- a/models/boot.go
+++ b/models/boot.go
@@ -7,10 +7,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Boot boot
@@ -24,6 +26,10 @@ type Boot struct {
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 
+	// device type
+	// Enum: [persistent ephemeral]
+	DeviceType string `json:"device_type,omitempty"`
+
 	// pxe interface
 	PxeInterface string `json:"pxe_interface,omitempty"`
 
@@ -35,6 +41,10 @@ type Boot struct {
 func (m *Boot) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDeviceType(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSecureBootState(formats); err != nil {
 		res = append(res, err)
 	}
@@ -42,6 +52,48 @@ func (m *Boot) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var bootTypeDeviceTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["persistent","ephemeral"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		bootTypeDeviceTypePropEnum = append(bootTypeDeviceTypePropEnum, v)
+	}
+}
+
+const (
+
+	// BootDeviceTypePersistent captures enum value "persistent"
+	BootDeviceTypePersistent string = "persistent"
+
+	// BootDeviceTypeEphemeral captures enum value "ephemeral"
+	BootDeviceTypeEphemeral string = "ephemeral"
+)
+
+// prop value enum
+func (m *Boot) validateDeviceTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, bootTypeDeviceTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Boot) validateDeviceType(formats strfmt.Registry) error {
+	if swag.IsZero(m.DeviceType) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateDeviceTypeEnum("device_type", "body", m.DeviceType); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6204,6 +6204,13 @@ func init() {
         "current_boot_mode": {
           "type": "string"
         },
+        "device_type": {
+          "type": "string",
+          "enum": [
+            "persistent",
+            "ephemeral"
+          ]
+        },
         "pxe_interface": {
           "type": "string"
         },
@@ -17249,6 +17256,13 @@ func init() {
         },
         "current_boot_mode": {
           "type": "string"
+        },
+        "device_type": {
+          "type": "string",
+          "enum": [
+            "persistent",
+            "ephemeral"
+          ]
         },
         "pxe_interface": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6099,6 +6099,9 @@ definitions:
         type: string
       secure_boot_state:
         $ref: '#/definitions/secure-boot-state'
+      device_type:
+        type: string
+        enum: [persistent, ephemeral]
 
   system_vendor:
     type: object

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -155,6 +155,7 @@ type HostDisk struct {
 type HostBoot struct {
 	CurrentBootMode string `json:"currentBootMode,omitempty"`
 	PxeInterface    string `json:"pxeInterface,omitempty"`
+	DeviceType      string `json:"deviceType,omitempty"`
 }
 
 type HostSystemVendor struct {

--- a/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -7,10 +7,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Boot boot
@@ -24,6 +26,10 @@ type Boot struct {
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 
+	// device type
+	// Enum: [persistent ephemeral]
+	DeviceType string `json:"device_type,omitempty"`
+
 	// pxe interface
 	PxeInterface string `json:"pxe_interface,omitempty"`
 
@@ -35,6 +41,10 @@ type Boot struct {
 func (m *Boot) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDeviceType(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSecureBootState(formats); err != nil {
 		res = append(res, err)
 	}
@@ -42,6 +52,48 @@ func (m *Boot) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var bootTypeDeviceTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["persistent","ephemeral"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		bootTypeDeviceTypePropEnum = append(bootTypeDeviceTypePropEnum, v)
+	}
+}
+
+const (
+
+	// BootDeviceTypePersistent captures enum value "persistent"
+	BootDeviceTypePersistent string = "persistent"
+
+	// BootDeviceTypeEphemeral captures enum value "ephemeral"
+	BootDeviceTypeEphemeral string = "ephemeral"
+)
+
+// prop value enum
+func (m *Boot) validateDeviceTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, bootTypeDeviceTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Boot) validateDeviceType(formats strfmt.Registry) error {
+	if swag.IsZero(m.DeviceType) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateDeviceTypeEnum("device_type", "body", m.DeviceType); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR creates an API in the agent inventory and in the agent CR for storing the boot device type. The options for this type are ephemeral when an ISO or ipxe is being used for discovery, or persistent when discovery is being done from the same device we're installing to.

In a follow up PR (after the agent changes are merged to populate this field) this field will be used to determine if install should target the existing root filesystem or a separate device.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed assisted manually and installed a cluster to a host using the existing root filesystem and also using the ISO from the same assisted deployment. This test included the changes from https://github.com/openshift/assisted-service/pull/7220 as well as the agent changes to populate the new inventory field.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
