### PR TITLE
WIP: NO-JIRA: Validate the CPU architectures set by users in the CRs

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -37,6 +37,7 @@ type OSImage struct {
 	// Deprecated: this field is ignored (will be removed in a future release).
 	RootFSUrl string `json:"rootFSUrl"`
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// +kubebuilder:validation:Enum=arm64;ppc64le;x86_64;s390x
 	// +optional
 	CPUArchitecture string `json:"cpuArchitecture"`
 }

--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -88,6 +88,7 @@ type InfraEnvSpec struct {
 
 	// CpuArchitecture specifies the target CPU architecture. Default is x86_64
 	// +kubebuilder:default=x86_64
+	// +kubebuilder:validation:Enum=arm64;ppc64le;x86_64;s390x
 	// +optional
 	CpuArchitecture string `json:"cpuArchitecture,omitempty"`
 

--- a/config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml
@@ -751,6 +751,11 @@ spec:
                   properties:
                     cpuArchitecture:
                       description: The CPU architecture of the image (x86_64/arm64/etc).
+                      enum:
+                      - arm64
+                      - ppc64le
+                      - x86_64
+                      - s390x
                       type: string
                     openshiftVersion:
                       description: |-

--- a/config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
@@ -766,6 +766,11 @@ spec:
                   properties:
                     cpuArchitecture:
                       description: The CPU architecture of the image (x86_64/arm64/etc).
+                      enum:
+                      - arm64
+                      - ppc64le
+                      - x86_64
+                      - s390x
                       type: string
                     openshiftVersion:
                       description: |-

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -88,6 +88,11 @@ spec:
                 default: x86_64
                 description: CpuArchitecture specifies the target CPU architecture.
                   Default is x86_64
+                enum:
+                - arm64
+                - ppc64le
+                - x86_64
+                - s390x
                 type: string
               ignitionConfigOverride:
                 description: Json formatted string containing the user overrides for


### PR DESCRIPTION
There is an inconsistency about the name of the architecture to use in the InfraEnv and other CRDs using the OSImage object. Users can easily provide a "wrong" value for the CPUArchitecture fields in such CRs and no error would arise at creation time as they are not validated, making it harder for the user to debug and understand how to proceed with their deployment.

This commit adds validation for the architecture field among the values in the set {arm64, ppc64le, s390x, x86_64}

Related to openshift/assisted-service#4441 openshift/release#60815
