### PR TITLE
NO-ISSUE: Recalculate operator dependencies before validations

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -455,7 +455,7 @@ func main() {
 	manifestsGenerator := network.NewManifestsGenerator(manifestsApi, Options.ManifestsGeneratorConfig, db)
 	clusterApi := cluster.NewManager(Options.ClusterConfig, log.WithField("pkg", "cluster-state"), db,
 		notificationStream, eventsHandler, uploadClient, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager,
-		ocmClient, objectHandler, dnsApi, authHandler, manifestsApi, Options.EnableSoftTimeouts)
+		ocmClient, objectHandler, dnsApi, authHandler, manifestsApi, Options.EnableSoftTimeouts, usageManager)
 	infraEnvApi := infraenv.NewManager(log.WithField("pkg", "host-state"), db, objectHandler)
 
 	clusterEventsUploader := thread.New(

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -344,6 +344,18 @@ func mockUsageReports() {
 	mockUsage.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 }
 
+func mockOperatorValidationsSuccess(mock *operators.MockAPI) {
+	mock.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+}
+
+func mockNoChangeInOperatorDependencies(mock *operators.MockAPI) {
+	mock.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ *common.Cluster, previousOperators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
+			return previousOperators, nil
+		},
+	).AnyTimes()
+}
+
 func TestValidator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	common.InitializeDBTest()
@@ -1956,7 +1968,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("happy flow", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockStream, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, mockStream, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -1974,7 +1986,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, release version is lower than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7"
 			clusterParams.OpenshiftVersion = swag.String(insufficientOpenShiftVersionForNoneHA)
@@ -1986,7 +1998,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, release version is pre-release and lower than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7.0-fc.1"
 			clusterParams.OpenshiftVersion = swag.String(insufficientOpenShiftVersionForNoneHA)
@@ -1998,7 +2010,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2016,7 +2028,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is pre-release and greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2035,7 +2047,7 @@ var _ = Describe("cluster", func() {
 		It("create non ha cluster fail, explicitly disabled UserManagedNetworking", func() {
 			errStr := "Can't set none platform with user-managed-networking disabled"
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams.OpenshiftVersion = swag.String(openShiftVersionForNoneHA)
@@ -2048,7 +2060,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, explicitly enabled VipDhcpAllocation", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams.OpenshiftVersion = swag.String(openShiftVersionForNoneHA)
@@ -2063,7 +2075,7 @@ var _ = Describe("cluster", func() {
 	})
 	It("create non ha cluster success, release version is ci-release and greater than minimal", func() {
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 
 		mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 		noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2190,7 +2202,8 @@ var _ = Describe("cluster", func() {
 
 		It("update cluster day1 with APIVipDNSName failed", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+			mockNoChangeInOperatorDependencies(mockOperators)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccess(true)
 
@@ -2219,7 +2232,8 @@ var _ = Describe("cluster", func() {
 			func(openshiftVersion, networkType string) {
 				cpuArchitecture := "irrelevant"
 				mockOperators := operators.NewMockAPI(ctrl)
-				bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+				mockNoChangeInOperatorDependencies(mockOperators)
+				bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 				mockClusterRegisterSuccessWithVersion(cpuArchitecture, openshiftVersion)
 
@@ -2267,7 +2281,8 @@ var _ = Describe("cluster", func() {
 			func(openshiftVersion, networkType string) {
 				cpuArchitecture := "irrelevant"
 				mockOperators := operators.NewMockAPI(ctrl)
-				bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+				mockNoChangeInOperatorDependencies(mockOperators)
+				bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 				mockClusterRegisterSuccessWithVersion(cpuArchitecture, openshiftVersion)
 				clusterCreateParams := &models.ClusterCreateParams{
@@ -2362,7 +2377,7 @@ var _ = Describe("cluster", func() {
 				BeforeEach(func() {
 					openshiftVersion = "4.12.0"
 					bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-						db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+						db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 				})
 				Context("RegisterCluster - Multiple-VIPs Support", func() {
 
@@ -11294,8 +11309,9 @@ var _ = Describe("V2UploadClusterIngressCert test", func() {
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
+		mockNoChangeInOperatorDependencies(mockOperators)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), nil, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+			db, commontesting.GetDummyNotificationStream(ctrl), nil, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:               &clusterID,
 			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
@@ -13113,7 +13129,7 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 		mockUsageReports()
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
@@ -13750,7 +13766,7 @@ var _ = Describe("RegisterCluster", func() {
 		Expect(cfg.DiskEncryptionSupport).Should(BeTrue())
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil, false)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil, false, nil)
 		mockUsageReports()
 	})
 
@@ -15076,7 +15092,7 @@ var _ = Describe("RegisterCluster", func() {
 			var c *models.Cluster
 			diskEncryptionBm := createInventory(db, cfg)
 			diskEncryptionBm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil, false, nil)
 
 			By("Register cluster", func() {
 
@@ -15095,6 +15111,7 @@ var _ = Describe("RegisterCluster", func() {
 
 			By("Update cluster with full object", func() {
 
+				mockNoChangeInOperatorDependencies(mockOperatorManager)
 				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
 				mockEvents.EXPECT().SendClusterEvent(ctx, gomock.Any())
 
@@ -15115,6 +15132,7 @@ var _ = Describe("RegisterCluster", func() {
 
 			By("Update cluster with partial object", func() {
 
+				mockNoChangeInOperatorDependencies(mockOperatorManager)
 				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
 
 				reply := diskEncryptionBm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -15133,6 +15151,7 @@ var _ = Describe("RegisterCluster", func() {
 
 			By("Update cluster with emtpy object", func() {
 
+				mockNoChangeInOperatorDependencies(mockOperatorManager)
 				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
 
 				reply := diskEncryptionBm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -15177,7 +15196,7 @@ var _ = Describe("RegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			mockUsageReports()
 		})
 
@@ -15400,7 +15419,7 @@ var _ = Describe("RegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			mockUsageReports()
 		})
 
@@ -15857,7 +15876,7 @@ var _ = Describe("RegisterCluster", func() {
 			db, dbName = common.PrepareTestDB()
 			bm = createInventory(db, Config{})
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 			cfg := auth.GetConfigRHSSO()
 			cfg.EnableOrgBasedFeatureGates = true
 			mockOcmAuthz = ocm.NewMockOCMAuthorization(ctrl)
@@ -15913,7 +15932,7 @@ var _ = Describe("RegisterCluster", func() {
 			db, dbName = common.PrepareTestDB()
 			bm = createInventory(db, Config{})
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 		})
 
 		Context("with EnableOrgBasedFeatureGates true", func() {
@@ -16261,7 +16280,7 @@ var _ = Describe("RegisterCluster", func() {
 			db, dbName = common.PrepareTestDB()
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 		})
 
 		AfterEach(func() {
@@ -16609,7 +16628,7 @@ var _ = Describe("AMS subscriptions", func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
 		mockUsageReports()
 	})
 
@@ -16670,7 +16689,7 @@ var _ = Describe("AMS subscriptions", func() {
 		It("deregister cluster that don't have 'Reserved' subscriptions", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil, false, nil)
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
 
@@ -16692,10 +16711,12 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name happy flow", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+			mockNoChangeInOperatorDependencies(mockOperators)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
+			mockOperatorValidationsSuccess(mockOperators)
 
 			clusterParams := getDefaultClusterCreateParams()
 			clusterParams.Name = swag.String(clusterName)
@@ -16708,7 +16729,6 @@ var _ = Describe("AMS subscriptions", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			newClusterName := "ams-cluster-new-name"
-			mockOperators.EXPECT().ValidateCluster(ctx, gomock.Any())
 			mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
 				eventstest.WithClusterIdMatcher(c.ID.String())))
@@ -16725,7 +16745,8 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name with same name", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+			mockNoChangeInOperatorDependencies(mockOperators)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -16755,7 +16776,8 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster without name field", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+			mockNoChangeInOperatorDependencies(mockOperators)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -16865,7 +16887,7 @@ var _ = Describe("AMS subscriptions", func() {
 		It("register and deregister cluster happy flow - nil OCM client", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil, false)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil, false, nil)
 			bm.ocmClient = nil
 			mockClusterRegisterSuccess(true)
 
@@ -18911,7 +18933,8 @@ var _ = Describe("Platform tests", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false)
+		mockNoChangeInOperatorDependencies(mockOperators)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil, false, nil)
 		bm.ocmClient = nil
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.Name = swag.String("cluster")

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/stream"
 	"github.com/openshift/assisted-service/internal/uploader"
+	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/commonutils"
@@ -176,7 +177,8 @@ type Manager struct {
 func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, stream stream.Notifier, eventsHandler eventsapi.Handler,
 	uploadClient uploader.Client, hostAPI host.API, metricApi metrics.API, manifestsGeneratorAPI network.ManifestsGeneratorAPI,
 	leaderElector leader.Leader, operatorsApi operators.API, ocmClient *ocm.Client, objectHandler s3wrapper.API,
-	dnsApi dns.DNSApi, authHandler auth.Authenticator, manifestApi manifestsapi.ManifestsAPI, softTimeoutsEnabled bool) *Manager {
+	dnsApi dns.DNSApi, authHandler auth.Authenticator, manifestApi manifestsapi.ManifestsAPI, softTimeoutsEnabled bool,
+	usageApi usage.API) *Manager {
 	th := &transitionHandler{
 		log:                 log,
 		db:                  db,
@@ -198,7 +200,7 @@ func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, stream stream.N
 		sm:                    NewClusterStateMachine(th),
 		metricAPI:             metricApi,
 		manifestsGeneratorAPI: manifestsGeneratorAPI,
-		rp:                    newRefreshPreprocessor(log, hostAPI, operatorsApi),
+		rp:                    newRefreshPreprocessor(log, hostAPI, operatorsApi, usageApi, eventsHandler),
 		hostAPI:               hostAPI,
 		leaderElector:         leaderElector,
 		prevMonitorInvokedAt:  time.Now(),

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -50,7 +50,13 @@ var _ = Describe("Progress bar test", func() {
 		mockOperatorApi = operators.NewMockAPI(ctrl)
 		mockDnsApi = dns.NewMockDNSApi(ctrl)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil, nil, false, nil)
+
+		mockOperatorApi.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ *common.Cluster, previousOperators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
+				return previousOperators, nil
+			},
+		).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/internal/cluster/refresh_status_preprocessor.go
+++ b/internal/cluster/refresh_status_preprocessor.go
@@ -2,15 +2,21 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
+	"github.com/dustin/go-humanize/english"
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
+	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/operators/api"
+	operatorcommon "github.com/openshift/assisted-service/internal/operators/common"
+	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,23 +36,28 @@ type stringer interface {
 }
 
 type refreshPreprocessor struct {
-	log          logrus.FieldLogger
-	validations  []validation
-	conditions   []condition
-	operatorsAPI operators.API
+	log           logrus.FieldLogger
+	validations   []validation
+	conditions    []condition
+	operatorsAPI  operators.API
+	usageAPI      usage.API
+	eventsHandler eventsapi.Handler
 }
 
-func newRefreshPreprocessor(log logrus.FieldLogger, hostAPI host.API, operatorsAPI operators.API) *refreshPreprocessor {
+func newRefreshPreprocessor(log logrus.FieldLogger, hostAPI host.API, operatorsAPI operators.API, usageAPI usage.API,
+	eventsHandler eventsapi.Handler) *refreshPreprocessor {
 	v := clusterValidator{
 		log:     log,
 		hostAPI: hostAPI,
 	}
 
 	return &refreshPreprocessor{
-		log:          log,
-		validations:  newValidations(&v),
-		conditions:   newConditions(&v),
-		operatorsAPI: operatorsAPI,
+		log:           log,
+		validations:   newValidations(&v),
+		conditions:    newConditions(&v),
+		operatorsAPI:  operatorsAPI,
+		usageAPI:      usageAPI,
+		eventsHandler: eventsHandler,
 	}
 }
 
@@ -84,6 +95,17 @@ func (r *refreshPreprocessor) preprocess(ctx context.Context, c *clusterPreproce
 			Message: message,
 		})
 	}
+
+	// Before validating the operators we need to recalculate the dependencies because changes in the hosts may
+	// imply changes in the dependencies between operators. For example, if the OpenShift AI operator is enabled and
+	// a new host with an NVIDIA GPU has been discovered, then the NVIDIA GPU operator will need to be added as a
+	// dependency, and then we will need to validate that secure boot is disabled.
+	err = r.recalculateOperatorDependencies(ctx, c)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to recalculate operator dependencies for cluster '%s'", c.clusterId)
+		return nil, nil, err
+	}
+
 	// Validate operators
 	results, err := r.operatorsAPI.ValidateCluster(ctx, c.cluster)
 	if err != nil {
@@ -122,6 +144,167 @@ func (r *refreshPreprocessor) preprocess(ctx context.Context, c *clusterPreproce
 		}
 	}
 	return stateMachineInput, validationsOutput, nil
+}
+
+// recalculateOperatorDependencies calculates the operator dependencies and updates the database and the passed cluster
+// accordingly.
+func (r *refreshPreprocessor) recalculateOperatorDependencies(ctx context.Context, c *clusterPreprocessContext) error {
+	// Calculate and save the operators that have been added, updated or deleted:
+	operatorsBeforeResolve := c.cluster.MonitoredOperators
+	operatorsAfterResolve, err := r.operatorsAPI.ResolveDependencies(c.cluster, c.cluster.MonitoredOperators)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"failed to resolve operator dependencies for cluster '%s'",
+			c.clusterId,
+		)
+	}
+	var addedOperators, updatedOperators, deletedOperators []*models.MonitoredOperator
+	for _, operatorAfterResolve := range operatorsAfterResolve {
+		if operatorAfterResolve.ClusterID == "" {
+			operatorAfterResolve.ClusterID = c.clusterId
+		}
+		operatorBeforeREsolve := operatorcommon.GetOperator(operatorsBeforeResolve, operatorAfterResolve.Name)
+		if operatorBeforeREsolve != nil {
+			if !reflect.DeepEqual(operatorAfterResolve, operatorBeforeREsolve) {
+				updatedOperators = append(updatedOperators, operatorAfterResolve)
+			}
+		} else {
+			addedOperators = append(addedOperators, operatorAfterResolve)
+		}
+	}
+	for _, operatorBeforeResolve := range operatorsBeforeResolve {
+		if !operatorcommon.HasOperator(operatorsAfterResolve, operatorBeforeResolve.Name) {
+			deletedOperators = append(deletedOperators, operatorBeforeResolve)
+		}
+	}
+	for _, addedOperator := range addedOperators {
+		err = c.db.Save(addedOperator).Error
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"failed to add operator '%s' to cluster '%s'",
+				addedOperator.Name, *c.cluster.ID,
+			)
+		}
+	}
+	for _, updatedOperator := range updatedOperators {
+		err = c.db.Save(updatedOperator).Error
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"failed to update operator '%s' for cluster '%s'",
+				updatedOperator.Name, *c.cluster.ID,
+			)
+		}
+	}
+	for _, deletedOperator := range deletedOperators {
+		err = c.db.Delete(deletedOperator).Error
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"failed to delete operator '%s' from cluster '%s'",
+				deletedOperator.Name,
+				c.clusterId,
+			)
+		}
+	}
+	c.cluster.MonitoredOperators = operatorsAfterResolve
+
+	// If any operator has been added or deleted then we need to update the corresponding feature usage:
+	if len(addedOperators) > 0 || len(deletedOperators) > 0 {
+		err = r.recalculateOperatorFeatureUsage(c, addedOperators, deletedOperators)
+		if err != nil {
+			return err
+		}
+		err = r.notifyOperatorFeatureUsageChange(ctx, c, addedOperators, deletedOperators)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *refreshPreprocessor) recalculateOperatorFeatureUsage(c *clusterPreprocessContext,
+	addedOperators, deletedOperators []*models.MonitoredOperator) error {
+	if r.usageAPI == nil {
+		return nil
+	}
+	usages, err := usage.Unmarshal(c.cluster.FeatureUsage)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"failed to read feature usage from cluster '%s'",
+			c.clusterId,
+		)
+	}
+	for _, addedOperator := range addedOperators {
+		featureName := strings.ToUpper(addedOperator.Name)
+		r.usageAPI.Add(usages, featureName, nil)
+	}
+	for _, deletedOperator := range deletedOperators {
+		featureName := strings.ToUpper(deletedOperator.Name)
+		r.usageAPI.Remove(usages, featureName)
+	}
+	data, err := json.Marshal(usages)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"failed to write feature usage to cluster '%s'",
+			c.clusterId,
+		)
+	}
+	c.cluster.FeatureUsage = string(data)
+	r.usageAPI.Save(c.db, c.clusterId, usages)
+	return nil
+}
+
+func (r refreshPreprocessor) notifyOperatorFeatureUsageChange(ctx context.Context, c *clusterPreprocessContext,
+	addedOperators, deletedOperators []*models.MonitoredOperator) error {
+	if r.eventsHandler == nil {
+		return nil
+	}
+	if len(addedOperators) > 0 {
+		r.notifyAddedOperatorFeatures(ctx, c, addedOperators)
+	}
+	if len(deletedOperators) > 0 {
+		r.notifyDeletedOperatorFeatures(ctx, c, deletedOperators)
+	}
+	return nil
+}
+
+func (r *refreshPreprocessor) notifyAddedOperatorFeatures(ctx context.Context, c *clusterPreprocessContext,
+	operators []*models.MonitoredOperator) {
+	featureList := r.calculateOperatorFeatureList(operators)
+	var message string
+	if len(operators) == 1 {
+		message = fmt.Sprintf("Cluster %s: added operator feature %s", c.clusterId, featureList)
+	} else {
+		message = fmt.Sprintf("Cluster %s: added operator features %s", c.clusterId, featureList)
+	}
+	r.eventsHandler.NotifyInternalEvent(ctx, &c.clusterId, nil, nil, message)
+}
+
+func (r *refreshPreprocessor) notifyDeletedOperatorFeatures(ctx context.Context, c *clusterPreprocessContext,
+	operators []*models.MonitoredOperator) {
+	featureList := r.calculateOperatorFeatureList(operators)
+	var message string
+	if len(operators) == 1 {
+		message = fmt.Sprintf("Cluster %s: deleted operator feature %s", c.clusterId, featureList)
+	} else {
+		message = fmt.Sprintf("Cluster %s: deleted operator features %s", c.clusterId, featureList)
+	}
+	r.eventsHandler.NotifyInternalEvent(ctx, &c.clusterId, nil, nil, message)
+}
+
+func (r *refreshPreprocessor) calculateOperatorFeatureList(operators []*models.MonitoredOperator) string {
+	featureNames := make([]string, len(operators))
+	for i, operator := range operators {
+		featureNames[i] = strings.ToUpper(operator.Name)
+	}
+	sort.Strings(featureNames)
+	return english.WordSeries(featureNames, "and")
 }
 
 // sortByValidationResultID sorts results by models.ClusterValidationID

--- a/internal/cluster/refresh_status_preprocessor_test.go
+++ b/internal/cluster/refresh_status_preprocessor_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/golang/mock/gomock"
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
@@ -25,6 +27,7 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		ctrl                *gomock.Controller
 		mockHostApi         *host.MockAPI
 		mockOperatorManager *operators.MockAPI
+		mockUsageApi        *usage.MockAPI
 		db                  *gorm.DB
 		dbName              string
 		cluster             *common.Cluster
@@ -37,16 +40,19 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockHostApi = host.NewMockAPI(ctrl)
 		mockOperatorManager = operators.NewMockAPI(ctrl)
-		mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+		mockUsageApi = usage.NewMockAPI(ctrl)
 		db, dbName = common.PrepareTestDB()
 		preprocessor = newRefreshPreprocessor(
 			logrus.New(),
 			mockHostApi,
 			mockOperatorManager,
+			mockUsageApi,
+			nil,
 		)
 	})
 
 	AfterEach(func() {
+		ctrl.Finish()
 		common.DeleteTestDB(db, dbName)
 	})
 
@@ -87,6 +93,31 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		}
 	}
 
+	mockNoChangeInOperatorDependencies := func() {
+		mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ *common.Cluster, previousOperators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
+				return previousOperators, nil
+			},
+		).AnyTimes()
+	}
+
+	mockAddedOperatorDependencies := func(addedOperators ...*models.MonitoredOperator) {
+		mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ *common.Cluster, previousOperators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
+				currentOperators := append(previousOperators, addedOperators...)
+				return currentOperators, nil
+			},
+		).Times(1)
+		for _, addedOperator := range addedOperators {
+			mockUsageApi.EXPECT().Add(gomock.Any(), strings.ToUpper(addedOperator.Name), gomock.Any()).Times(1)
+		}
+		mockUsageApi.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	}
+
+	mockOperatorValidationsSuccess := func() {
+		mockOperatorManager.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	}
+
 	Context("Skipping Validations", func() {
 
 		cantBeIgnored := common.NonIgnorableClusterValidations
@@ -122,6 +153,8 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		})
 
 		It("Should allow permitted ignorable validations to be ignored", func() {
+			mockNoChangeInOperatorDependencies()
+			mockOperatorValidationsSuccess()
 			validationContext.cluster.IgnoredClusterValidations = "[\"network-type-valid\", \"ingress-vips-valid\", \"ingress-vips-defined\"]"
 			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
 			Expect(conditions).ToNot(BeEmpty())
@@ -136,6 +169,8 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		})
 
 		It("Should allow all permitted ignorable validations to be ignored", func() {
+			mockNoChangeInOperatorDependencies()
+			mockOperatorValidationsSuccess()
 			validationContext.cluster.IgnoredClusterValidations = "[\"all\"]"
 			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
 			Expect(conditions).ToNot(BeEmpty())
@@ -148,6 +183,8 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 		})
 
 		It("Should never allow a specific mandatory validation to be ignored", func() {
+			mockNoChangeInOperatorDependencies()
+			mockOperatorValidationsSuccess()
 			validationContext.cluster.IgnoredClusterValidations = "[\"all\"]"
 			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
 			for _, unskippableHostValidation := range cantBeIgnored {
@@ -155,6 +192,47 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 				Expect(unskippableHostValidationPresent).To(BeTrue(), unskippableHostValidation+" was not present as expected")
 				Expect(unskippableHostValidationSkipped).To(BeFalse(), unskippableHostValidation+" was ignored when this should not be possible")
 			}
+		})
+	})
+
+	Context("Recalculate operator dependencies", func() {
+		var validationContext *clusterPreprocessContext
+
+		BeforeEach(func() {
+			createCluster()
+			validationContext = newClusterValidationContext(cluster, db)
+		})
+
+		AfterEach(func() {
+			deleteCluster()
+		})
+
+		It("Adds new dependency", func() {
+			// Prepare the operators API so that it will add a new operator dependency:
+			mockAddedOperatorDependencies(
+				&models.MonitoredOperator{
+					Name: "myoperator",
+				},
+			)
+			mockOperatorValidationsSuccess()
+			_, _, err := preprocessor.preprocess(ctx, validationContext)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the new dependency has been added to the cluster in memory:
+			var operator *models.MonitoredOperator
+			for _, current := range cluster.MonitoredOperators {
+				if current.Name == "myoperator" {
+					operator = current
+				}
+			}
+			Expect(operator).ToNot(BeNil())
+
+			// Check that the new dependency has been saved to the database:
+			err = db.Where(&models.MonitoredOperator{
+				ClusterID: clusterID,
+				Name:      "myoperator",
+			}).First(&models.MonitoredOperator{}).Error
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Transition tests", func() {
 
 	Context("cancel_installation", func() {
 		BeforeEach(func() {
-			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 		})
 
 		It("cancel_installation", func() {
@@ -368,7 +368,7 @@ var _ = Describe("Transition tests", func() {
 					mockMetric.EXPECT().ClusterInstallationFinished(gomock.Any(), models.ClusterStatusInstalled, models.ClusterStatusFinalizing, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				}
 
-				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil, false)
+				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil, false, nil)
 
 				// Test
 				clusterAfterRefresh, err := capi.RefreshStatus(ctx, &c, db)
@@ -416,7 +416,7 @@ var _ = Describe("Cancel cluster installation", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		uploadClient = uploader.NewClient(&uploader.Config{EnableDataCollection: false}, nil, logrus.New(), nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 	})
 
 	AfterEach(func() {
@@ -493,7 +493,7 @@ var _ = Describe("Reset cluster", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = eventsapi.NewMockHandler(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEventsHandler, nil, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEventsHandler, nil, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 	})
 
 	AfterEach(func() {
@@ -711,7 +711,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1608,7 +1608,7 @@ var _ = Describe("Refresh Cluster - Same networks", func() {
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1875,7 +1875,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil, false, nil)
 
 		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		hid1 = strfmt.UUID(uuid.New().String())
@@ -2118,7 +2118,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3150,7 +3150,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3876,7 +3876,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -4247,7 +4247,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					mockAccountsMgmt = ocm.NewMockOCMAccountsMgmt(ctrl)
 					ocmClient := &ocm.Client{AccountsMgmt: mockAccountsMgmt, Config: &ocm.Config{}}
 					clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-						mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil, false)
+						mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil, false, nil)
 					if !t.requiresAMSUpdate {
 						cluster.IsAmsSubscriptionConsoleUrlSet = true
 					}
@@ -4351,7 +4351,7 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		clusterApi = NewManager(logTimeoutConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 
@@ -4493,7 +4493,7 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -4797,7 +4797,7 @@ var _ = Describe("Single node", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil, false, nil)
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
 		hid3 = strfmt.UUID(uuid.New().String())
@@ -5103,7 +5103,7 @@ var _ = Describe("installation timeout", func() {
 		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, true)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, true, nil)
 	})
 	createCluster := func(status, statusInfo string, installStartedAt time.Time) *common.Cluster {
 		id := strfmt.UUID(uuid.NewString())
@@ -5221,7 +5221,7 @@ var _ = Describe("finalizing timeouts", func() {
 	Context("soft timeouts disabled", func() {
 		BeforeEach(func() {
 			clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-				mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false)
+				mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, false, nil)
 		})
 		for _, st := range finalizingStages {
 			stage := st
@@ -5259,7 +5259,7 @@ var _ = Describe("finalizing timeouts", func() {
 	Context("soft timeouts enabled", func() {
 		BeforeEach(func() {
 			clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-				mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, true)
+				mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil, true, nil)
 
 		})
 		It("finalizing status timeout not active", func() {

--- a/internal/operators/common/common.go
+++ b/internal/operators/common/common.go
@@ -41,3 +41,12 @@ func HasOperator(operators []*models.MonitoredOperator, operatorName string) boo
 	}
 	return false
 }
+
+func GetOperator(operators []*models.MonitoredOperator, operatorName string) *models.MonitoredOperator {
+	for _, o := range operators {
+		if o.Name == operatorName {
+			return o
+		}
+	}
+	return nil
+}

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -381,13 +381,13 @@ func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models
 		if op.OperatorType != models.OperatorTypeOlm {
 			continue
 		}
-		mgr.log.Infof("Attempting to resolve %s operator dependencies", op.Name)
+		mgr.log.Debugf("Attempting to resolve %s operator dependencies", op.Name)
 		deps, err := mgr.olmOperators[op.Name].GetDependencies(cluster)
 		if err != nil {
 			return map[string]bool{}, err
 		}
 		visited[op.Name] = true
-		mgr.log.Infof("Dependencies found for %s operator: %+v ", op.Name, deps)
+		mgr.log.Debugf("Dependencies found for %s operator: %+v ", op.Name, deps)
 		for _, dep := range deps {
 			fifo.PushBack(dep)
 		}

--- a/internal/operators/odf/validation_test.go
+++ b/internal/operators/odf/validation_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		var cfg clust.Config
 		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		clusterApi = clust.NewManager(cfg, common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil, false, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -123,6 +123,10 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		hid5 = strfmt.UUID(uuid.New().String())
 		hid6 = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+
+		mockEvents.EXPECT().NotifyInternalEvent(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		).AnyTimes()
 	})
 
 	tests := []struct {

--- a/vendor/github.com/dustin/go-humanize/english/words.go
+++ b/vendor/github.com/dustin/go-humanize/english/words.go
@@ -1,0 +1,98 @@
+// Package english provides utilities to generate more user-friendly English output.
+package english
+
+import (
+	"fmt"
+	"strings"
+
+	humanize "github.com/dustin/go-humanize"
+)
+
+// These are included because they are common technical terms.
+var specialPlurals = map[string]string{
+	"index":  "indices",
+	"matrix": "matrices",
+	"vertex": "vertices",
+}
+
+var sibilantEndings = []string{"s", "sh", "tch", "x"}
+
+var isVowel = map[byte]bool{
+	'A': true, 'E': true, 'I': true, 'O': true, 'U': true,
+	'a': true, 'e': true, 'i': true, 'o': true, 'u': true,
+}
+
+// PluralWord builds the plural form of an English word.
+// The simple English rules of regular pluralization will be used
+// if the plural form is an empty string (i.e. not explicitly given).
+// The special cases are not guaranteed to work for strings outside ASCII.
+func PluralWord(quantity int, singular, plural string) string {
+	if quantity == 1 {
+		return singular
+	}
+	if plural != "" {
+		return plural
+	}
+	if plural = specialPlurals[singular]; plural != "" {
+		return plural
+	}
+
+	// We need to guess what the English plural might be.  Keep this
+	// function simple!  It doesn't need to know about every possiblity;
+	// only regular rules and the most common special cases.
+	//
+	// Reference: http://en.wikipedia.org/wiki/English_plural
+
+	for _, ending := range sibilantEndings {
+		if strings.HasSuffix(singular, ending) {
+			return singular + "es"
+		}
+	}
+	l := len(singular)
+	if l >= 2 && singular[l-1] == 'o' && !isVowel[singular[l-2]] {
+		return singular + "es"
+	}
+	if l >= 2 && singular[l-1] == 'y' && !isVowel[singular[l-2]] {
+		return singular[:l-1] + "ies"
+	}
+
+	return singular + "s"
+}
+
+// Plural formats an integer and a string into a single pluralized string.
+// The simple English rules of regular pluralization will be used
+// if the plural form is an empty string (i.e. not explicitly given).
+func Plural(quantity int, singular, plural string) string {
+	return fmt.Sprintf("%s %s", humanize.Comma(int64(quantity)), PluralWord(quantity, singular, plural))
+}
+
+// WordSeries converts a list of words into a word series in English.
+// It returns a string containing all the given words separated by commas,
+// the coordinating conjunction, and a serial comma, as appropriate.
+func WordSeries(words []string, conjunction string) string {
+	switch len(words) {
+	case 0:
+		return ""
+	case 1:
+		return words[0]
+	default:
+		return fmt.Sprintf("%s %s %s", strings.Join(words[:len(words)-1], ", "), conjunction, words[len(words)-1])
+	}
+}
+
+// OxfordWordSeries converts a list of words into a word series in English,
+// using an Oxford comma (https://en.wikipedia.org/wiki/Serial_comma). It
+// returns a string containing all the given words separated by commas, the
+// coordinating conjunction, and a serial comma, as appropriate.
+func OxfordWordSeries(words []string, conjunction string) string {
+	switch len(words) {
+	case 0:
+		return ""
+	case 1:
+		return words[0]
+	case 2:
+		return strings.Join(words, fmt.Sprintf(" %s ", conjunction))
+	default:
+		return fmt.Sprintf("%s, %s %s", strings.Join(words[:len(words)-1], ", "), conjunction, words[len(words)-1])
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -245,6 +245,7 @@ github.com/docker/go-units
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
+github.com/dustin/go-humanize/english
 # github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab
 ## explicit; go 1.11
 github.com/elliotwutingfeng/asciiset


### PR DESCRIPTION
Currently operator dependencies are only calculated when a cluster is created or updated. But certain dependencies are dynamic, and may change when new hosts are added. For example, if a cluster has the OpenShift AI operator installed, it will also require the NVIDIA GPU operator only if there are hosts that have NVIDIA GPUs. To support those dynamic dependencies this patch modifies the cluster monitor so that it recalculates the operator dependencies before checking validations.

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
