### PR TITLE
[release-ocm-2.11] MGMT-19834: Add assisted mirror registries to public registries list

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -339,6 +339,15 @@ func main() {
 
 	publicRegistries := map[string]bool{}
 	validations.ParsePublicRegistries(publicRegistries, Options.ValidationsConfig.PublicRegistries)
+	if mirrorRegistriesBuilder.IsMirrorRegistriesConfigured() {
+		var mirrorRegistries []mirrorregistries.RegistriesConf
+		if mirrorRegistries, err = mirrorRegistriesBuilder.ExtractLocationMirrorDataFromRegistries(); err != nil {
+			log.WithError(err).Warnf("failed to parse mirror registries provided to assisted-service, check your mirror registry config map")
+		} else {
+			validations.ParseMirrorRegistries(log, publicRegistries, mirrorRegistries)
+		}
+	}
+
 	pullSecretValidator, err := validations.NewPullSecretValidator(
 		publicRegistries,
 		authHandler,

--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 
 	"github.com/openshift/assisted-service/pkg/auth"
+	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"github.com/openshift/assisted-service/pkg/ocm"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -31,6 +33,13 @@ func ParsePublicRegistries(publicRegistries map[string]bool, publicRegistriesLit
 	}
 
 	for _, registry := range strings.Split(publicRegistriesLiteral, ",") {
+		publicRegistries[registry] = true
+	}
+}
+
+func ParseMirrorRegistries(log logrus.FieldLogger, publicRegistries map[string]bool, mirrorRegistries []mirrorregistries.RegistriesConf) {
+	for _, mirrorRegistry := range mirrorRegistries {
+		registry := ParseBaseRegistry(mirrorRegistry.Location)
 		publicRegistries[registry] = true
 	}
 }

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -138,6 +138,12 @@ func ParseRegistry(image string) (string, error) {
 	return reference.Domain(parsed), nil
 }
 
+// ParseBaseRegistry extracts the base domain for a registry.
+func ParseBaseRegistry(registry string) string {
+	registryParts := strings.Split(strings.TrimSpace(registry), "/")
+	return registryParts[0]
+}
+
 // ValidateVipDHCPAllocationWithIPv6 returns an error in case of VIP DHCP allocation
 // being used with IPv6 machine network
 func ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation bool, machineNetworkCIDR string) error {


### PR DESCRIPTION
Partial backport of https://github.com/openshift/assisted-service/pull/7193
Only the [first commit](https://github.com/openshift/assisted-service/pull/7193/commits/599df3eae02100b636ce8fbf4087d791607a8eef) is backported as the rest of the commits involve a new feature ([MGMT-18013](https://issues.redhat.com/browse/MGMT-18013)) for ACM 2.13 and are not relevant for this release 

---
When a mirror registry configuration is provided to assisted, we will assume that the registry does not require authentication. This will take any mirror registry that assisted is configured with and will add it to the public registries list in the pull secret validator. That way, any pull secret being validated will not be required to have authentication credentials for the registry since it's pulling from the mirror.
This is a better user experience so that the user will not have to provide credentials for a registry if a mirror registry will be used in its place.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 