### PR TITLE
MGMT-19102: Use inventory to determine if install is on the existing root

### DIFF
--- a/internal/host/conditions.go
+++ b/internal/host/conditions.go
@@ -41,8 +41,8 @@ func (v *validator) isInstallationDiskSpeedCheckSuccessful(c *validationContext)
 		return true
 	}
 
-	// Disk speed check is skipped when installing to the local disk
-	if v.installToExistingRoot {
+	// Disk speed check is skipped when installing to the existing root
+	if c.inventory != nil && c.inventory.Boot != nil && c.inventory.Boot.DeviceType == models.BootDeviceTypePersistent {
 		return true
 	}
 

--- a/internal/host/conditions_test.go
+++ b/internal/host/conditions_test.go
@@ -34,8 +34,8 @@ var _ = Describe("isInstallationDiskSpeedCheckSuccessful", func() {
 		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeTrue())
 	})
 
-	It("returns true when installToExistingRoot is set", func() {
-		v.installToExistingRoot = true
+	It("returns true when the boot disk is persistent", func() {
+		validationCtx.inventory = &models.Inventory{Boot: &models.Boot{DeviceType: models.BootDeviceTypePersistent}}
 		Expect(v.isInstallationDiskSpeedCheckSuccessful(validationCtx)).To(BeTrue())
 	})
 

--- a/internal/host/config.go
+++ b/internal/host/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	BootstrapHostMAC         string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
 	MaxHostDisconnectionTime time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
 	EnableVirtualInterfaces  bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
-	InstallToExistingRoot    bool                    `envconfig:"INSTALL_TO_EXISTING_ROOT" default:"false"`
 
 	// hostStageTimeouts contains the values of the host stage timeouts. Don't use this
 	// directly, use the HostStageTimeout method instead.

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -167,7 +167,7 @@ func NewManager(log logrus.FieldLogger, db *gorm.DB, notificationStream stream.N
 		hwValidator:         hwValidator,
 		eventsHandler:       eventsHandler,
 		sm:                  sm,
-		rp:                  newRefreshPreprocessor(log, hwValidatorCfg, hwValidator, operatorsApi, config.DisabledHostvalidations, providerRegistry, versionHandler, config.InstallToExistingRoot),
+		rp:                  newRefreshPreprocessor(log, hwValidatorCfg, hwValidator, operatorsApi, config.DisabledHostvalidations, providerRegistry, versionHandler),
 		metricApi:           metricApi,
 		Config:              *config,
 		leaderElector:       leaderElector,

--- a/internal/host/hostcommands/disk_performance_cmd.go
+++ b/internal/host/hostcommands/disk_performance_cmd.go
@@ -15,24 +15,26 @@ import (
 
 type diskPerfCheckCmd struct {
 	baseCmd
-	hwValidator           hardware.Validator
-	diskPerfCheckImage    string
-	timeoutSeconds        float64
-	installToExistingRoot bool
+	hwValidator        hardware.Validator
+	diskPerfCheckImage string
+	timeoutSeconds     float64
 }
 
-func NewDiskPerfCheckCmd(log logrus.FieldLogger, diskPerfCheckImage string, hwValidator hardware.Validator, timeoutSeconds float64, installToExistingRoot bool) *diskPerfCheckCmd {
+func NewDiskPerfCheckCmd(log logrus.FieldLogger, diskPerfCheckImage string, hwValidator hardware.Validator, timeoutSeconds float64) *diskPerfCheckCmd {
 	return &diskPerfCheckCmd{
-		baseCmd:               baseCmd{log: log},
-		diskPerfCheckImage:    diskPerfCheckImage,
-		hwValidator:           hwValidator,
-		timeoutSeconds:        timeoutSeconds,
-		installToExistingRoot: installToExistingRoot,
+		baseCmd:            baseCmd{log: log},
+		diskPerfCheckImage: diskPerfCheckImage,
+		hwValidator:        hwValidator,
+		timeoutSeconds:     timeoutSeconds,
 	}
 }
 
 func (c *diskPerfCheckCmd) GetSteps(_ context.Context, host *models.Host) ([]*models.Step, error) {
-	if c.installToExistingRoot {
+	inv, err := common.UnmarshalInventory(host.Inventory)
+	if err != nil {
+		return nil, err
+	}
+	if inv.Boot != nil && inv.Boot.DeviceType == models.BootDeviceTypePersistent {
 		return nil, nil
 	}
 	bootDevice, err := hardware.GetBootDevice(c.hwValidator, host)

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -41,31 +41,29 @@ const (
 
 type installCmd struct {
 	baseCmd
-	db                    *gorm.DB
-	hwValidator           hardware.Validator
-	ocRelease             oc.Release
-	instructionConfig     InstructionConfig
-	eventsHandler         eventsapi.Handler
-	versionsHandler       versions.Handler
-	enableSkipMcoReboot   bool
-	notifyNumReboots      bool
-	installToExistingRoot bool
+	db                  *gorm.DB
+	hwValidator         hardware.Validator
+	ocRelease           oc.Release
+	instructionConfig   InstructionConfig
+	eventsHandler       eventsapi.Handler
+	versionsHandler     versions.Handler
+	enableSkipMcoReboot bool
+	notifyNumReboots    bool
 }
 
 func NewInstallCmd(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, ocRelease oc.Release,
 	instructionConfig InstructionConfig, eventsHandler eventsapi.Handler, versionsHandler versions.Handler,
-	enableSkipMcoReboot, notifyNumReboots, installToExistingRoot bool) *installCmd {
+	enableSkipMcoReboot, notifyNumReboots bool) *installCmd {
 	return &installCmd{
-		baseCmd:               baseCmd{log: log},
-		db:                    db,
-		hwValidator:           hwValidator,
-		ocRelease:             ocRelease,
-		instructionConfig:     instructionConfig,
-		eventsHandler:         eventsHandler,
-		versionsHandler:       versionsHandler,
-		enableSkipMcoReboot:   enableSkipMcoReboot,
-		notifyNumReboots:      notifyNumReboots,
-		installToExistingRoot: installToExistingRoot,
+		baseCmd:             baseCmd{log: log},
+		db:                  db,
+		hwValidator:         hwValidator,
+		ocRelease:           ocRelease,
+		instructionConfig:   instructionConfig,
+		eventsHandler:       eventsHandler,
+		versionsHandler:     versionsHandler,
+		enableSkipMcoReboot: enableSkipMcoReboot,
+		notifyNumReboots:    notifyNumReboots,
 	}
 }
 
@@ -153,7 +151,7 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 			return "", err
 		}
 
-		if i.installToExistingRoot {
+		if inventory != nil && inventory.Boot != nil && inventory.Boot.DeviceType == models.BootDeviceTypePersistent {
 			request.CoreosImage, err = i.ocRelease.GetCoreOSImage(i.log, *releaseImage.URL, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
 			if err != nil {
 				return "", err

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -71,7 +71,7 @@ var _ = Describe("installcmd", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
-		installCmd = NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true, false)
+		installCmd = NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true)
 		cluster = createClusterInDb(db, models.ClusterHighAvailabilityModeFull)
 		clusterId = *cluster.ID
 		infraEnv = createInfraEnvInDb(db, clusterId)
@@ -109,7 +109,7 @@ var _ = Describe("installcmd", func() {
 	})
 	DescribeTable("enable MCO reboot values",
 		func(enableMcoReboot bool, version string, architecture string, expected bool) {
-			installCommand := NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, enableMcoReboot, true, false)
+			installCommand := NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, enableMcoReboot, true)
 			mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return(common.TestDiskId).Times(1)
 			mockGetReleaseImage(1)
 			mockImages(1)
@@ -133,7 +133,7 @@ var _ = Describe("installcmd", func() {
 
 	DescribeTable("notify num reboots",
 		func(notifyNumReboots bool) {
-			installCommand := NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, true, notifyNumReboots, false)
+			installCommand := NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions, true, notifyNumReboots)
 			mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return(common.TestDiskId).Times(1)
 			mockGetReleaseImage(1)
 			mockImages(1)
@@ -423,7 +423,7 @@ var _ = Describe("installcmd arguments", func() {
 	Context("configuration_params", func() {
 		It("check_cluster_version_is_false_by_default", func() {
 			config := &InstructionConfig{}
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -435,7 +435,7 @@ var _ = Describe("installcmd arguments", func() {
 			config := &InstructionConfig{
 				CheckClusterVersion: false,
 			}
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -447,7 +447,7 @@ var _ = Describe("installcmd arguments", func() {
 			config := &InstructionConfig{
 				CheckClusterVersion: true,
 			}
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, *config, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -456,7 +456,7 @@ var _ = Describe("installcmd arguments", func() {
 		})
 
 		It("verify high-availability-mode is None", func() {
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -469,7 +469,7 @@ var _ = Describe("installcmd arguments", func() {
 			mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
 
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -479,7 +479,7 @@ var _ = Describe("installcmd arguments", func() {
 
 		It("no must-gather , mco and openshift version in day2 installation", func() {
 			db.Model(&cluster).Update("kind", models.ClusterKindAddHostsCluster)
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true, false)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -489,14 +489,15 @@ var _ = Describe("installcmd arguments", func() {
 			Expect(request.MustGatherImage).To(BeEmpty())
 		})
 
-		It("provides the coreos image when installToExistingRoot is set", func() {
+		It("provides the coreos image when the boot device is persistent", func() {
+			host.Inventory = `{"boot": {"device_type": "persistent"}}`
 			testCoreOSImage := "example.com/coreos/image:latest"
 			mockRelease = oc.NewMockRelease(ctrl)
 			mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
 			mockRelease.EXPECT().GetCoreOSImage(gomock.Any(), *common.TestDefaultConfig.ReleaseImage.URL, gomock.Any(), gomock.Any()).Return(testCoreOSImage, nil).AnyTimes()
 
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true, true)
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions, true, true)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
@@ -513,7 +514,7 @@ var _ = Describe("installcmd arguments", func() {
 
 		BeforeEach(func() {
 			instructionConfig = DefaultInstructionConfig
-			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true, false)
+			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true)
 		})
 
 		It("valid installer args", func() {
@@ -593,7 +594,7 @@ var _ = Describe("installcmd arguments", func() {
 
 		BeforeEach(func() {
 			instructionConfig = DefaultInstructionConfig
-			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true, false)
+			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true)
 		})
 
 		It("single argument with ocp image only", func() {
@@ -625,7 +626,7 @@ var _ = Describe("installcmd arguments", func() {
 
 		BeforeEach(func() {
 			instructionConfig = DefaultInstructionConfig
-			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true, false)
+			installCmd = NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, instructionConfig, mockEvents, mockVersions, true, true)
 		})
 		It("no-proxy without httpProxy", func() {
 			args := installCmd.getProxyArguments("t-cluster", "proxy.org", "", "", "domain.com,192.168.1.0/24")

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -69,7 +69,6 @@ type InstructionConfig struct {
 	DiskCheckTimeout         time.Duration     `envconfig:"DISK_CHECK_TIMEOUT" default:"8m"`
 	ImageAvailabilityTimeout time.Duration     `envconfig:"IMAGE_AVAILABILITY_TIMEOUT" default:"16m"`
 	DisabledSteps            []models.StepType `envconfig:"DISABLED_STEPS" default:""`
-	InstallToExistingRoot    bool              `envconfig:"INSTALL_TO_EXISTING_ROOT" default:"false"`
 	ReleaseImageMirror       string
 	CheckClusterVersion      bool
 	HostFSMountDir           string
@@ -79,7 +78,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	instructionConfig InstructionConfig, connectivityValidator connectivity.Validator, eventsHandler eventsapi.Handler,
 	versionHandler versions.Handler, osImages versions.OSImages, kubeApiEnabled bool) *InstructionManager {
 	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.AgentImage)
-	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot, !kubeApiEnabled, instructionConfig.InstallToExistingRoot)
+	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot, !kubeApiEnabled)
 	inventoryCmd := NewInventoryCmd(log, instructionConfig.AgentImage)
 	freeAddressesCmd := newFreeAddressesCmd(log, kubeApiEnabled)
 	stopCmd := NewStopInstallationCmd(log)
@@ -88,7 +87,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.AgentImage)
 	tangConnectivityCmd := NewTangConnectivityCheckCmd(log, db, instructionConfig.AgentImage)
 	ntpSynchronizerCmd := NewNtpSyncCmd(log, instructionConfig.AgentImage, db)
-	diskPerfCheckCmd := NewDiskPerfCheckCmd(log, instructionConfig.AgentImage, hwValidator, instructionConfig.DiskCheckTimeout.Seconds(), instructionConfig.InstallToExistingRoot)
+	diskPerfCheckCmd := NewDiskPerfCheckCmd(log, instructionConfig.AgentImage, hwValidator, instructionConfig.DiskCheckTimeout.Seconds())
 	imageAvailabilityCmd := NewImageAvailabilityCmd(log, db, ocRelease, versionHandler, instructionConfig, instructionConfig.ImageAvailabilityTimeout.Seconds())
 	domainNameResolutionCmd := NewDomainNameResolutionCmd(log, instructionConfig.AgentImage, versionHandler, db)
 	noopCmd := NewNoopCmd()

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -43,15 +43,14 @@ type refreshPreprocessor struct {
 
 func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator,
 	operatorsApi operators.API, disabledHostValidations DisabledHostValidations, providerRegistry registry.ProviderRegistry,
-	versionHandler versions.Handler, installToExistingRoot bool) *refreshPreprocessor {
+	versionHandler versions.Handler) *refreshPreprocessor {
 	v := &validator{
-		log:                   log,
-		hwValidatorCfg:        hwValidatorCfg,
-		hwValidator:           hwValidator,
-		operatorsAPI:          operatorsApi,
-		providerRegistry:      providerRegistry,
-		versionHandler:        versionHandler,
-		installToExistingRoot: installToExistingRoot,
+		log:              log,
+		hwValidatorCfg:   hwValidatorCfg,
+		hwValidator:      hwValidator,
+		operatorsAPI:     operatorsApi,
+		providerRegistry: providerRegistry,
+		versionHandler:   versionHandler,
 	}
 	return &refreshPreprocessor{
 		log:                     log,

--- a/internal/host/refresh_status_preprocessor_test.go
+++ b/internal/host/refresh_status_preprocessor_test.go
@@ -77,7 +77,6 @@ var _ = Describe("Cluster Refresh Status Preprocessor", func() {
 			disabledHostValidations,
 			mockProviderRegistry,
 			mockVersions,
-			false,
 		)
 	})
 

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -284,13 +284,12 @@ func boolValue(b bool) ValidationStatus {
 }
 
 type validator struct {
-	log                   logrus.FieldLogger
-	hwValidatorCfg        *hardware.ValidatorCfg
-	hwValidator           hardware.Validator
-	operatorsAPI          operators.API
-	providerRegistry      registry.ProviderRegistry
-	versionHandler        versions.Handler
-	installToExistingRoot bool
+	log              logrus.FieldLogger
+	hwValidatorCfg   *hardware.ValidatorCfg
+	hwValidator      hardware.Validator
+	operatorsAPI     operators.API
+	providerRegistry registry.ProviderRegistry
+	versionHandler   versions.Handler
 }
 
 func (v *validator) isMediaConnected(c *validationContext) (ValidationStatus, string) {


### PR DESCRIPTION
When the boot device is persistent the install will write to that device, when the boot device is ephemeral (iso, ipxe, etc), the install will write to a separate disk.

The replaces the environment variable (`INSTALL_TO_EXISTING_ROOT`) which was added to originally expose this behavior.

https://issues.redhat.com/browse/MGMT-19102

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Manually tested that an assisted service deployment with this code would install correctly based on how discovery was started.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc) - I'll create a separate docs PR when this is all in
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
