### PR TITLE
MGMT-19792: Add discovery ignition URL to the infraenv status

### DIFF
--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -202,6 +202,9 @@ type BootArtifacts struct {
 	// IpxeScriptURL specifies an HTTP/S URL that contains the iPXE script
 	// +optional
 	IpxeScriptURL string `json:"ipxeScript"`
+	// DiscoveryIgnitionURL specifies an HTTP/S URL that contains the discovery ignition
+	// +optional
+	DiscoveryIgnitionURL string `json:"discoveryIgnitionURL"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -294,6 +294,10 @@ spec:
               bootArtifacts:
                 description: BootArtifacts specifies the URLs for each boot artifact
                 properties:
+                  discoveryIgnitionURL:
+                    description: DiscoveryIgnitionURL specifies an HTTP/S URL that
+                      contains the discovery ignition
+                    type: string
                   initrd:
                     description: InitrdURL specifies an HTTP/S URL that contains the
                       initrd

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -3213,6 +3213,10 @@ spec:
               bootArtifacts:
                 description: BootArtifacts specifies the URLs for each boot artifact
                 properties:
+                  discoveryIgnitionURL:
+                    description: DiscoveryIgnitionURL specifies an HTTP/S URL that
+                      contains the discovery ignition
+                    type: string
                   initrd:
                     description: InitrdURL specifies an HTTP/S URL that contains the
                       initrd

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
@@ -304,6 +304,10 @@ spec:
               bootArtifacts:
                 description: BootArtifacts specifies the URLs for each boot artifact
                 properties:
+                  discoveryIgnitionURL:
+                    description: DiscoveryIgnitionURL specifies an HTTP/S URL that
+                      contains the discovery ignition
+                    type: string
                   initrd:
                     description: InitrdURL specifies an HTTP/S URL that contains the
                       initrd

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -202,6 +202,9 @@ type BootArtifacts struct {
 	// IpxeScriptURL specifies an HTTP/S URL that contains the iPXE script
 	// +optional
 	IpxeScriptURL string `json:"ipxeScript"`
+	// DiscoveryIgnitionURL specifies an HTTP/S URL that contains the discovery ignition
+	// +optional
+	DiscoveryIgnitionURL string `json:"discoveryIgnitionURL"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
This will mainly be used with integrations that provide the discovery ignition as metadata to hosts that boot with a generic disk image rather than the discovery ISO, but can also be used for debugging.

Resolves https://issues.redhat.com/browse/MGMT-19792

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed assisted service with this change, created an infraenv, downloaded and checked the discovery ignition using the URL in new API

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
