### PR TITLE
MGMT-19490: Day 2 clusters /install-config endpoint is broken

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -12228,6 +12228,19 @@ var _ = Describe("GetClusterInstallConfig", func() {
 		_, ok := response.(*installer.V2GetClusterInstallConfigOK)
 		Expect(ok).To(BeTrue())
 	})
+
+	It("fail to get install config for Day2 cluster", func() {
+		c.Kind = swag.String(models.ClusterKindAddHostsCluster)
+		db.Save(&c)
+
+		params := installer.V2GetClusterInstallConfigParams{ClusterID: clusterID}
+		response := bm.V2GetClusterInstallConfig(ctx, params)
+
+		errorResponse, ok := response.(*common.ApiErrorResponse)
+		Expect(ok).To(BeTrue(), "Expected response to be ApiErrorResponse but got %T", response)
+		Expect(int(errorResponse.StatusCode())).To(Equal(http.StatusBadRequest))
+	})
+
 })
 
 var _ = Describe("UpdateClusterInstallConfig", func() {

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -130,6 +130,13 @@ func (b *bareMetalInventory) V2GetClusterInstallConfig(ctx context.Context, para
 		return common.GenerateErrorResponder(fmt.Errorf("Failed to get cluster %s: %w", params.ClusterID, err))
 	}
 
+	if common.IsDay2Cluster(cluster) {
+		return common.GenerateErrorResponderWithDefault(
+			fmt.Errorf("The install config is not available because this cluster resource is used only for adding additional hosts to an existing cluster"),
+			http.StatusBadRequest,
+		)
+	}
+
 	clusterInfraenvs, err := b.getClusterInfraenvs(cluster)
 	if err != nil {
 		return common.GenerateErrorResponder(fmt.Errorf("Failed to get cluster %s infraenvs: %w", params.ClusterID, err))


### PR DESCRIPTION
This PR ensures that GET /v2/clusters/{cluster_id}/install-config correctly handles Day2 clusters. Since install-config is not required for Day2, the request now returns a 400 Bad Request instead of a 500 Internal Server Error.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 @eliorerz