### PR TITLE
OCPBUGS-47627: dnsmasq service on OCP SNO fails to read /etc/resolv.conf file during system startup

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -171,7 +171,7 @@ spec:
             [Unit]
             Description=Run dnsmasq to provide local dns for Single Node OpenShift
             Before=kubelet.service crio.service
-            After=network.target
+            After=network.target ovs-configuration.service
 
             [Service]
             TimeoutStartSec=30


### PR DESCRIPTION
network.target doesn't garantee that interfaces are configured
(https://systemd.io/NETWORK_ONLINE/), so we may have cases were dnsmasq
fails to start because `resolv.conf` is not there yet.

This fix will start dnsmasq after `ovs-configuration` service so we are
sure that the network is configured at this point.
