### PR TITLE
AGENT-1074: Add support for ABI to install OLM operators

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -42,8 +42,8 @@ import (
 const failureOutputPath = "/var/run/agent-installer/host-config-failures"
 
 var Options struct {
-	ServiceBaseUrl   string `envconfig:"SERVICE_BASE_URL" default:""`
-	UserAuthToken    string `envconfig:"USER_AUTH_TOKEN" default:""`
+	ServiceBaseUrl string `envconfig:"SERVICE_BASE_URL" default:""`
+	UserAuthToken  string `envconfig:"USER_AUTH_TOKEN" default:""`
 }
 
 var RegisterOptions struct {
@@ -56,6 +56,7 @@ var RegisterOptions struct {
 	ImageTypeISO            string `envconfig:"IMAGE_TYPE_ISO" default:"full-iso"`
 	ReleaseImageMirror      string `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
 	ExtraManifests          string `envconfig:"EXTRA_MANIFESTS_PATH" default:"/extra-manifests"`
+	OperatorInstallFile     string `envconfig:"OPERATOR_INSTALL_FILE" default:"/manifests/operators.yaml"`
 }
 
 var ConfigureOptions struct {
@@ -132,7 +133,7 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 	}
 
 	modelsCluster, err := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
-		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
+		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror, RegisterOptions.OperatorInstallFile)
 	if err != nil {
 		log.Fatal("Failed to register cluster with assisted-service: ", err)
 	}
@@ -168,7 +169,7 @@ func registerCluster(ctx context.Context, log *log.Logger, bmInventory *client.A
 	}
 
 	modelsCluster, err := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
-		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
+		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror, RegisterOptions.OperatorInstallFile)
 	if err != nil {
 		log.Fatal("Failed to register cluster with assisted-service: ", err)
 	}

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1278,7 +1278,7 @@ var _ = Describe("cluster reconcile", func() {
 			cpuArch := "x86_64"
 			openshiftVersion := "4.10.0-rc1"
 
-			params := CreateClusterParams(cluster, aci, pullSecretString, openshiftVersion, cpuArch, nil)
+			params := CreateClusterParams(cluster, aci, pullSecretString, openshiftVersion, cpuArch, nil, nil)
 			Expect(params.Name).To(Equal(&cluster.Spec.ClusterName))
 			Expect(params.BaseDNSDomain).To(Equal(cluster.Spec.BaseDomain))
 			Expect(params.PullSecret).To(Equal(&pullSecretString))

--- a/subsystem/agent_based_installer_client_test.go
+++ b/subsystem/agent_based_installer_client_test.go
@@ -23,7 +23,7 @@ var _ = Describe("RegisterClusterAndInfraEnv", func() {
 		modelCluster, registerClusterErr := agentbasedinstaller.RegisterCluster(ctx, log, utils_test.TestContext.UserBMClient, pullSecret,
 			"../docs/hive-integration/crds/clusterDeployment.yaml",
 			"../docs/hive-integration/crds/agentClusterInstall.yaml",
-			"../docs/hive-integration/crds/clusterImageSet.yaml", "")
+			"../docs/hive-integration/crds/clusterImageSet.yaml", "", "")
 		Expect(registerClusterErr).NotTo(HaveOccurred())
 		Expect(network.GetApiVipById(&common.Cluster{Cluster: *modelCluster}, 0)).To(Equal("1.2.3.8"))
 		Expect(network.GetIngressVipById(&common.Cluster{Cluster: *modelCluster}, 0)).To(Equal("1.2.3.9"))
@@ -45,7 +45,7 @@ var _ = Describe("RegisterClusterAndInfraEnv", func() {
 		modelCluster, registerClusterErr := agentbasedinstaller.RegisterCluster(ctx, log, utils_test.TestContext.UserBMClient, pullSecret,
 			"../docs/hive-integration/crds/clusterDeployment.yaml",
 			"../docs/hive-integration/crds/agentClusterInstall-with-installconfig-overrides.yaml",
-			"../docs/hive-integration/crds/clusterImageSet.yaml", "")
+			"../docs/hive-integration/crds/clusterImageSet.yaml", "", "")
 		Expect(registerClusterErr).NotTo(HaveOccurred())
 		Expect(network.GetApiVipById(&common.Cluster{Cluster: *modelCluster}, 0)).To(Equal("1.2.3.8"))
 		Expect(network.GetIngressVipById(&common.Cluster{Cluster: *modelCluster}, 0)).To(Equal("1.2.3.9"))
@@ -68,7 +68,7 @@ var _ = Describe("RegisterClusterAndInfraEnv", func() {
 		modelCluster, registerClusterErr := agentbasedinstaller.RegisterCluster(ctx, log, utils_test.TestContext.UserBMClient, pullSecret,
 			"file-does-not-exist",
 			"../docs/hive-integration/crds/agentClusterInstall.yaml",
-			"../docs/hive-integration/crds/clusterImageSet.yaml", "")
+			"../docs/hive-integration/crds/clusterImageSet.yaml", "", "")
 		Expect(registerClusterErr).To(HaveOccurred())
 		Expect(modelCluster).To(BeNil())
 	})


### PR DESCRIPTION
Add the ability for the agent-based installer to pass in a file containing a list of operators to be installed. The operators will be added to the cluster create params and adding when registering the cluster.

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
