### PR TITLE
OCPBUGS-42059: Save version of imported clusters

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -987,6 +987,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		Kind:               swag.String(models.ClusterKindAddHostsCluster),
 		Name:               clusterName,
 		OpenshiftClusterID: common.StrFmtUUIDVal(params.NewImportClusterParams.OpenshiftClusterID),
+		OpenshiftVersion:   params.NewImportClusterParams.OpenshiftVersion,
 		UserName:           ocm.UserNameFromContext(ctx),
 		OrgID:              ocm.OrgIDFromContext(ctx),
 		EmailDomain:        ocm.EmailDomainFromContext(ctx),

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13396,7 +13396,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
-		Expect(actual.Payload.OpenshiftVersion).To(BeEmpty())
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))
@@ -13423,7 +13423,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
-		Expect(actual.Payload.OpenshiftVersion).To(BeEmpty())
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -233,7 +233,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 			return r.createNewCluster(ctx, log, req.NamespacedName, pullSecret, releaseImage, clusterDeployment, clusterInstall, mirrorRegistryConfiguration)
 		}
 
-		return r.createNewDay2Cluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
+		return r.createNewDay2Cluster(ctx, log, req.NamespacedName, releaseImage, clusterDeployment, clusterInstall)
 	}
 	if err != nil {
 		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
@@ -1514,6 +1514,7 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	key types.NamespacedName,
+	releaseImage *models.ReleaseImage,
 	clusterDeployment *hivev1.ClusterDeployment,
 	clusterInstall *hiveext.AgentClusterInstall) (ctrl.Result, error) {
 
@@ -1525,6 +1526,9 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 	clusterParams := &models.ImportClusterParams{
 		APIVipDnsname: swag.String(apiVipDnsname),
 		Name:          swag.String(spec.ClusterName),
+	}
+	if releaseImage != nil && releaseImage.OpenshiftVersion != nil {
+		clusterParams.OpenshiftVersion = *releaseImage.OpenshiftVersion
 	}
 
 	// add optional parameter

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -4167,6 +4167,7 @@ var _ = Describe("cluster reconcile", func() {
 			V2ImportClusterInternal := func(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID,
 				params installer.V2ImportClusterParams) (*common.Cluster, error) {
 				Expect(string(*params.NewImportClusterParams.OpenshiftClusterID)).To(Equal(cid))
+				Expect(params.NewImportClusterParams.OpenshiftVersion).To(Equal(ocpVersion))
 				return clusterReply, nil
 			}
 			mockInstallerInternal.EXPECT().

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Day2 v2 cluster tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(swag.StringValue(cluster.GetPayload().Status)).Should(Equal("adding-hosts"))
 		Expect(swag.StringValue(cluster.GetPayload().StatusInfo)).Should(Equal(statusInfoAddingHosts))
-		Expect(swag.StringValue(&cluster.GetPayload().OpenshiftVersion)).Should(BeEmpty())
+		Expect(swag.StringValue(&cluster.GetPayload().OpenshiftVersion)).Should(Equal(openshiftVersion))
 		Expect(swag.StringValue(&cluster.GetPayload().OcpReleaseImage)).Should(BeEmpty())
 		Expect(cluster.GetPayload().StatusUpdatedAt).ShouldNot(Equal(strfmt.DateTime(time.Time{})))
 


### PR DESCRIPTION
Currently when a cluster is imported the `openshift_version` column of the database is not populated. As a result that version will not be available for validations, in particular for the validation that checks if dual-stack VIPs are supported. A side effect of that is that adding a node to a cluster with dual-stack VIPs will always fail with an error message like this, regardless of the version:

```
"dual-stack VIPs are not supported in OpenShift "
```

That error happens because we are trying to see if the version is less than 4.12, but the result is always true because the version is empty.

To avoid that this patch changes the cluster import code so that it populates the `openshift_version` database column.

## List all the issues related to this PR

https://issues.redhat.com/browse/OCPBUGS-42059

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
