### PR TITLE
ACM-17555: Save version of imported clusters - ACM 2.10

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -951,6 +951,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		Kind:               swag.String(models.ClusterKindAddHostsCluster),
 		Name:               clusterName,
 		OpenshiftClusterID: common.StrFmtUUIDVal(params.NewImportClusterParams.OpenshiftClusterID),
+		OpenshiftVersion:   params.NewImportClusterParams.OpenshiftVersion,
 		UserName:           ocm.UserNameFromContext(ctx),
 		OrgID:              ocm.OrgIDFromContext(ctx),
 		EmailDomain:        ocm.EmailDomainFromContext(ctx),

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -12669,7 +12669,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
-		Expect(actual.Payload.OpenshiftVersion).To(BeEmpty())
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))
@@ -12696,7 +12696,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
-		Expect(actual.Payload.OpenshiftVersion).To(BeEmpty())
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(BeEmpty())
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Day2 v2 cluster tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(swag.StringValue(cluster.GetPayload().Status)).Should(Equal("adding-hosts"))
 		Expect(swag.StringValue(cluster.GetPayload().StatusInfo)).Should(Equal(statusInfoAddingHosts))
-		Expect(swag.StringValue(&cluster.GetPayload().OpenshiftVersion)).Should(BeEmpty())
+		Expect(swag.StringValue(&cluster.GetPayload().OpenshiftVersion)).Should(Equal(openshiftVersion))
 		Expect(swag.StringValue(&cluster.GetPayload().OcpReleaseImage)).Should(BeEmpty())
 		Expect(cluster.GetPayload().StatusUpdatedAt).ShouldNot(Equal(strfmt.DateTime(time.Time{})))
 


### PR DESCRIPTION
This is a backport of OCPBUGS-42059 and #7249 for ACM 2.10.

Currently when a cluster is imported the `openshift_version` column of the database is not populated. As a result that version will not be available for validations, in particular for the validation that checks if dual-stack VIPs are supported. A side effect of that is that adding a node to a cluster with dual-stack VIPs will always fail with an error message like this, regardless of the version:

```
"dual-stack VIPs are not supported in OpenShift "
```

That error happens because we are trying to see if the version is less than 4.12, but the result is always true because the version is empty.

To avoid that this patch changes the cluster import code so that it populates the `openshift_version` database column.

## List all the issues related to this PR

https://issues.redhat.com/browse/ACM-17555
https://issues.redhat.com/browse/OCPBUGS-42059

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
