### PR TITLE
MGMT-14495: Stop removing the finalizers from BMH

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -348,13 +348,6 @@ func deleteBMHForMachine(ctx context.Context, spokeClient client.Client, machine
 		return errors.Wrapf(err, "failed to delete BMH %s", bmhNSName)
 	}
 
-	// TODO: remove this once OCPBUGS-7581 is fixed
-	patch := client.MergeFrom(bmh.DeepCopy())
-	bmh.ObjectMeta.Finalizers = nil
-	if err = client.IgnoreNotFound(spokeClient.Patch(ctx, bmh, patch)); err != nil {
-		return errors.Wrapf(err, "failed to remove BMH %s finalizers", bmhNSName)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This code was added to handle OCPBUGS-7581, and it was meant to be removed after it was resolved. Its fix has long merged and was backported till OCP 4.12; therefore this code can now be removed.
Removing the BMH finalizer causes the BMH to instantly be deleted, which means that BMO is unable to do any necessary cleanup. In OCPBUGS-25927, BMO encounters an error while attempting to update the status of an already deleted BMH:
2024-11-13T07:28:35.215792213Z {"level":"info","ts":1731482915.2157853,"logger":"controllers.BareMetalHost","msg":"saving host status","baremetalhost":{"name":"gateway-1.workload.fc18.lab","namespace":"openshift-machine-api"},"provisioningState":"unmanaged","operational status":"discovered","provisioning state":"deleting"}
2024-11-13T07:28:35.220351574Z {"level":"error","ts":1731482915.2201939,"msg":"Reconciler error","controller":"baremetalhost","controllerGroup":"metal3.io","controllerKind":"BareMetalHost","BareMetalHost":{"name":"gateway-1.workload.fc18.lab","namespace":"openshift-machine-api"},"namespace":"openshift-machine-api","name":"gateway-1.workload.fc18.lab","reconcileID":"dbda2c02-2b4d-4a5e-ac98-531d4fc46263",
"error":"failed to save host status after \"unmanaged\": Operation cannot be fulfilled on baremetalhosts.metal3.io \"gateway-1.workload.fc18.lab\": StorageError: invalid object, Code: 4, Key: /kubernetes.io/metal3.io/baremetalhosts/openshift-machine-api/gateway-1.workload.fc18.lab, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: c207fd48-3dc4-455a-ae12-b4e44fda2285, UID in object meta: ","errorVerbose":"Operation cannot be fulfilled on baremetalhosts.metal3.io \"gateway-1.workload.fc18.lab\": StorageError: invalid object, Code: 4, Key: /kubernetes.io/metal3.io/baremetalhosts/openshift-machine-api/gateway-1.workload.fc18.lab, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: c207fd48-3dc4-455a-ae12-b4e44fda2285, UID in object meta: \nfailed to save host status after \"unmanaged\"\n

- Should this PR be tested by the reviewer? If possible, it would be helpful
- Is this PR relying on CI for an e2e test run? Yes
- Should this PR be tested in a specific environment? With baremetal-operator running and when assisted issues a delete request for a BareMetalHost.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

This PR should be backported till 4.12