### PR TITLE
MGMT-19844: Validate the internal ignition override

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4984,7 +4984,7 @@ func (b *bareMetalInventory) validateInfraEnvCreateParams(ctx context.Context, p
 		}
 	}
 
-	if err = b.validateInfraEnvIgnitionParams(ctx, params.InfraenvCreateParams.IgnitionConfigOverride); err != nil {
+	if err = b.validateInfraEnvIgnitionParams(ctx, params.InfraenvCreateParams.IgnitionConfigOverride, nil); err != nil {
 		return err
 	}
 
@@ -5161,7 +5161,7 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 			}
 		}
 
-		if err = b.validateInfraEnvIgnitionParams(ctx, params.InfraEnvUpdateParams.IgnitionConfigOverride); err != nil {
+		if err = b.validateInfraEnvIgnitionParams(ctx, params.InfraEnvUpdateParams.IgnitionConfigOverride, internalIgnitionConfig); err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 
@@ -5375,7 +5375,7 @@ func (b *bareMetalInventory) validateAndUpdateInfraEnvParams(ctx context.Context
 	return *params, nil
 }
 
-func (b *bareMetalInventory) validateInfraEnvIgnitionParams(ctx context.Context, ignitionConfigOverride string) error {
+func (b *bareMetalInventory) validateInfraEnvIgnitionParams(ctx context.Context, ignitionConfigOverride string, internalIgnitionOverride *string) error {
 
 	log := logutil.FromContext(ctx, b.log)
 
@@ -5383,6 +5383,14 @@ func (b *bareMetalInventory) validateInfraEnvIgnitionParams(ctx context.Context,
 		_, err := ignition.ParseToLatest([]byte(ignitionConfigOverride))
 		if err != nil {
 			log.WithError(err).Errorf("Failed to parse ignition config patch %s", ignitionConfigOverride)
+			return err
+		}
+	}
+
+	if internalIgnitionOverride != nil && *internalIgnitionOverride != "" {
+		_, err := ignition.ParseToLatest([]byte(*internalIgnitionOverride))
+		if err != nil {
+			log.WithError(err).Errorf("Failed to parse internal ignition config patch %s", *internalIgnitionOverride)
 			return err
 		}
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10136,6 +10136,15 @@ var _ = Describe("infraEnvs", func() {
 				Expect(pathList[5]).To(Equal(common.TestDefaultConfig.OpenShiftVersion))
 			})
 
+			It("fails when the internal ignition config is invalid", func() {
+				invalidIgnition := "{\"foo\": \"bar\"}"
+				_, err := bm.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{
+					InfraEnvID:           infraEnvID,
+					InfraEnvUpdateParams: &models.InfraEnvUpdateParams{},
+				}, &invalidIgnition, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
 			Context("with rhsso auth", func() {
 				BeforeEach(func() {
 					_, cert := auth.GetTokenAndCert(false)

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -22,9 +22,9 @@ func ParseToLatest(content []byte) (*config_latest_types.Config, error) {
 		// TODO(deprecate-ignition-3.1.0)
 		// We always want to work with the object of the type v3.2 but carry a value of v3.1 inside.
 		// For this reason we are translating the config to v3.2 and manually override the Version.
-		configBackwards, _, err := config_31.Parse(content)
+		configBackwards, report, err := config_31.Parse(content)
 		if err != nil {
-			return nil, errors.Errorf("error parsing ignition: %v", err)
+			return nil, errors.Errorf("error parsing ignition: %v, error report: %s", err, report.String())
 		}
 		config = config_latest_trans.Translate(configBackwards)
 		config.Ignition.Version = "3.1.0"


### PR DESCRIPTION
Users have seen some situations where they are unable to download the
discovery ISO because the ignition doesn't generate correctly on the
service side.

The only explanation seems to be that there is a malformed override and
the only override we're adding in all of these cases is the internal one
which also happens to not be validated.

Relates to https://issues.redhat.com/browse/MGMT-19844

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
