### PR TITLE
MGMT-19773: block forbidden hostname

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	MaxHostnameLength = 63
+	MaxHostnameLength = 253
 	HostnamePattern   = "^[a-z0-9][a-z0-9-]{0,62}(?:[.][a-z0-9-]{1,63})*$"
 )
 
@@ -77,7 +77,7 @@ func GetEventSeverityFromHostStatus(status string) string {
 
 func ValidateHostname(hostname string) error {
 	if len(hostname) > MaxHostnameLength {
-		return common.NewApiError(http.StatusBadRequest, errors.Errorf("hostname is too long, must be 63 characters or less. Hostname: %s has %d characters", hostname, len(hostname)))
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("hostname is too long, must be 253 characters or less. Hostname: %s has %d characters", hostname, len(hostname)))
 	}
 	b, err := regexp.MatchString(HostnamePattern, hostname)
 	if err != nil {


### PR DESCRIPTION
Hostname validation slightly improved. The original bug could not be reproduced, but while testing it was revealed that  hostname length was limited to 63 characters (though it should be 253) and unit test was not comprehensive enough.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
