### PR TITLE
MGMT-19830: Enable installation of OCP clusters in vSphere environments with user-managed LB

### DIFF
--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -994,7 +994,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Entry(
 			"vsphere platform",
 			[]SupportLevelFeature{&VsphereIntegrationFeature{}},
-			false,
+			true,
 		),
 
 		Entry(
@@ -1006,6 +1006,24 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Entry(
 			"user managed networking",
 			[]SupportLevelFeature{&UserManagedNetworkingFeature{}},
+			false,
+		),
+
+		Entry(
+			"SNO",
+			[]SupportLevelFeature{&UserManagedNetworkingFeature{}},
+			false,
+		),
+
+		Entry(
+			"dual stack",
+			[]SupportLevelFeature{&DualStackFeature{}},
+			false,
+		),
+
+		Entry(
+			"dual stack vips",
+			[]SupportLevelFeature{&DualStackVipsFeature{}},
 			false,
 		),
 

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -504,7 +504,6 @@ func (feature *UserManagedLoadBalancerFeature) getIncompatibleFeatures(string) *
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDVIPAUTOALLOC,
-		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDDUALSTACK,
 		models.FeatureSupportLevelIDDUALSTACKVIPS,
 		models.FeatureSupportLevelIDSNO,

--- a/internal/featuresupport/features_platforms.go
+++ b/internal/featuresupport/features_platforms.go
@@ -243,7 +243,6 @@ func (feature *VsphereIntegrationFeature) getIncompatibleFeatures(openshiftVersi
 		models.FeatureSupportLevelIDMTV,
 		models.FeatureSupportLevelIDNONSTANDARDHACONTROLPLANE,
 		models.FeatureSupportLevelIDOSC,
-		models.FeatureSupportLevelIDUSERMANAGEDLOADBALANCER,
 	}
 
 	if isNotSupported, err := common.BaseVersionLessThan("4.13", openshiftVersion); isNotSupported || err != nil {

--- a/internal/provider/baremetal/installConfig.go
+++ b/internal/provider/baremetal/installConfig.go
@@ -114,9 +114,8 @@ func (p *baremetalProvider) AddPlatformToInstallConfig(
 	// here because older versions will just ignore it.
 	cfg.Platform.Baremetal.AdditionalNTPServers = ntpServers
 
-	err = p.addLoadBalancer(cfg, cluster)
-	if err != nil {
-		return err
+	if err := p.addLoadBalancer(cfg, cluster); err != nil {
+		return errors.Wrap(err, "failed to set bare metal's cluster install-config.yaml load balancer as user-managed")
 	}
 
 	return nil

--- a/internal/provider/vsphere/installConfig_test.go
+++ b/internal/provider/vsphere/installConfig_test.go
@@ -1,0 +1,87 @@
+package vsphere
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/installcfg"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("AddPlatformToInstallConfig", func() {
+	var (
+		logger    logrus.FieldLogger
+		cluster   *common.Cluster
+		infraEnvs []*common.InfraEnv
+		cfg       *installcfg.InstallerConfigBaremetal
+		provider  provider.Provider
+	)
+
+	BeforeEach(func() {
+		logger = common.GetTestLog()
+		cluster = &common.Cluster{
+			Cluster: models.Cluster{
+				OpenshiftVersion: common.MinimumVersionForUserManagedLoadBalancerFeature,
+				APIVips: []*models.APIVip{
+					{IP: "192.168.127.1"},
+				},
+				IngressVips: []*models.IngressVip{
+					{IP: "192.168.127.1"},
+				},
+			},
+		}
+		infraEnvs = []*common.InfraEnv{{
+			InfraEnv: models.InfraEnv{},
+		}}
+		cfg = &installcfg.InstallerConfigBaremetal{
+			ControlPlane: struct {
+				Hyperthreading string "json:\"hyperthreading,omitempty\""
+				Name           string "json:\"name\""
+				Replicas       int    "json:\"replicas\""
+			}{
+				Replicas: 1,
+			},
+			Compute: []struct {
+				Hyperthreading string "json:\"hyperthreading,omitempty\""
+				Name           string "json:\"name\""
+				Replicas       int    "json:\"replicas\""
+			}{{
+				Replicas: 1,
+			}},
+		}
+		provider = NewVsphereProvider(logger)
+	})
+
+	Context("addLoadBalancer", func() {
+		It("Does nothing if there is no load balancer", func() {
+			err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Platform.Vsphere.LoadBalancer).To(BeNil())
+		})
+
+		It("Does nothing if the load balancer is cluster-managed", func() {
+			cluster.LoadBalancer = &models.LoadBalancer{Type: models.LoadBalancerTypeClusterManaged}
+			err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Platform.Vsphere.LoadBalancer).To(BeNil())
+		})
+
+		It("Adds user-managed load balancer", func() {
+			cluster.LoadBalancer = &models.LoadBalancer{Type: models.LoadBalancerTypeUserManaged}
+			err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Platform.Vsphere.LoadBalancer).ToNot(BeNil())
+			Expect(cfg.Platform.Vsphere.LoadBalancer.Type).To(Equal(configv1.LoadBalancerTypeUserManaged))
+		})
+
+		It("Returns error if load balancer type is not supported", func() {
+			cluster.LoadBalancer = &models.LoadBalancer{Type: "unsupported"}
+			err := provider.AddPlatformToInstallConfig(cfg, cluster, infraEnvs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("load balancer type is set to unsupported value 'unsupported'"))
+		})
+	})
+})


### PR DESCRIPTION
This PR adds support for installations with user-managed LB on `vSphere` platform. As most of the logic already added in previous PRs while enabling for `baremetal` platform, this PR only adds the required data to the `install-config.yaml` file. A dedicated e2e job was added to test this flow - `edge-e2e-vsphere-assisted-umlb-4-18`
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
