### PR TITLE
MGMT-19860: Remove dependencies from OpenShift AI operator

### DIFF
--- a/internal/operators/openshiftai/openshift_ai_config.go
+++ b/internal/operators/openshiftai/openshift_ai_config.go
@@ -7,15 +7,9 @@ type Config struct {
 	MinWorkerNodes     int64 `envconfig:"OPENSHIFT_AI_MIN_WORKER_NODES" default:"2"`
 	MinWorkerMemoryGiB int64 `envconfig:"OPENSHIFT_AI_MIN_WORKER_MEMORY_GIB" default:"32"`
 	MinWorkerCPUCores  int64 `envconfig:"OPENSHIFT_AI_MIN_WORKER_CPU_CORES" default:"8"`
-	RequireGPU         bool  `envconfig:"OPENSHIFT_AI_REQUIRE_GPU" default:"true"`
 
 	// TODO: Currently we use the controller image to run the setup tools because all we need is the shell and the
 	// `oc` command, and that way we don't need an additional image. But in the future we will probably want to have
 	// a separate image that contains the things that we need to run these setup jobs.
 	ControllerImage string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-controller:latest"`
-
-	// SupportedGPUS is a comma separated list of vendor identifiers of supported GPUs. For examaple, to enable
-	// support for NVIDIA and Virtio GPUS the value should be `10de,1af4`. By default only NVIDIA GPUs are
-	// supported.
-	SupportedGPUs []string `envconfig:"OPENSHIFT_AI_SUPPORTED_GPUS" default:"10de"`
 }

--- a/internal/operators/openshiftai/openshift_ai_operator_test.go
+++ b/internal/operators/openshiftai/openshift_ai_operator_test.go
@@ -2,7 +2,6 @@ package openshiftai
 
 import (
 	"context"
-	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -95,81 +94,6 @@ var _ = Describe("Operator", func() {
 				Status:       api.Success,
 				ValidationId: operator.GetHostValidationID(),
 			},
-		),
-	)
-
-	DescribeTable(
-		"Is supported GPU",
-		func(env map[string]string, gpu *models.Gpu, expected bool) {
-			// Set the environment variables and restore the previous values when finished:
-			for name, value := range env {
-				oldValue, present := os.LookupEnv(name)
-				if present {
-					defer func() {
-						err := os.Setenv(name, oldValue)
-						Expect(err).ToNot(HaveOccurred())
-					}()
-				} else {
-					defer func() {
-						err := os.Unsetenv(name)
-						Expect(err).ToNot(HaveOccurred())
-					}()
-				}
-				err := os.Setenv(name, value)
-				Expect(err).ToNot(HaveOccurred())
-			}
-
-			// Create the operator:
-			operator = NewOpenShiftAIOperator(common.GetTestLog())
-
-			// Run the check:
-			actual, err := operator.isSupportedGpu(gpu)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(Equal(expected))
-		},
-		Entry(
-			"NVIDIA is supported by default",
-			nil,
-			&models.Gpu{
-				VendorID: "10de",
-			},
-			true,
-		),
-		Entry(
-			"Virtio isn't supported by default",
-			nil,
-			&models.Gpu{
-				VendorID: "1af4",
-			},
-			false,
-		),
-		Entry(
-			"Virtio is supported if explicitly added",
-			map[string]string{
-				"OPENSHIFT_AI_SUPPORTED_GPUS": "10de,1af4",
-			},
-			&models.Gpu{
-				VendorID: "1af4",
-			},
-			true,
-		),
-		Entry(
-			"Order isn't relevant",
-			map[string]string{
-				"OPENSHIFT_AI_SUPPORTED_GPUS": "1af4,10de",
-			},
-			&models.Gpu{
-				VendorID: "10de",
-			},
-			true,
-		),
-		Entry(
-			"Case isn't relevant",
-			nil,
-			&models.Gpu{
-				VendorID: "10DE",
-			},
-			true,
 		),
 	)
 })


### PR DESCRIPTION
With the introduction of operator bundles it is no longer necessary to add dependencies to the OpenShift AI operator because those will be part of the bundle.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19860:

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
