### PR TITLE
[release-ocm-2.11] MGMT-19193: Add current stage when restoring host by Agent

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -75,6 +75,7 @@ const (
 	AgentInventoryAnnotation             = "agent." + aiv1beta1.Group + "/inventory"
 	AgentCurrentStageAnnotation          = "agent." + aiv1beta1.Group + "/current-stage"
 	AgentRoleAnnotation                  = "agent." + aiv1beta1.Group + "/role"
+	AgentValidationsInfoAnnotation       = "agent." + aiv1beta1.Group + "/validations-info"
 	AgentLabelHostManufacturer           = InventoryLabelPrefix + "host-manufacturer"
 	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
 	AgentLabelHostIsVirtual              = InventoryLabelPrefix + "host-isvirtual"
@@ -249,6 +250,7 @@ func updateAnnotations(log logrus.FieldLogger, agent *v1beta1.Agent, h *models.H
 	updated = setAgentAnnotation(log, agent, AgentStateAnnotation, swag.StringValue(h.Status))
 	updated = setAgentAnnotation(log, agent, AgentRoleAnnotation, string(h.Role)) || updated
 	updated = setAgentAnnotation(log, agent, AgentInventoryAnnotation, h.Inventory) || updated
+	updated = setAgentAnnotation(log, agent, AgentValidationsInfoAnnotation, h.ValidationsInfo) || updated
 	if h.Progress != nil {
 		updated = setAgentAnnotation(log, agent, AgentCurrentStageAnnotation, string(h.Progress.CurrentStage))
 	}
@@ -1777,6 +1779,7 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 	hostrole := agent.Annotations[AgentRoleAnnotation]
 	role := models.HostRole(hostrole)
 	inventory := agent.Annotations[AgentInventoryAnnotation]
+	validationsInfo := agent.Annotations[AgentValidationsInfoAnnotation]
 
 	// Fetch State
 	var hostStatus string
@@ -1793,16 +1796,17 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 	// Create Host model
 	hostID := strfmt.UUID(agent.Name)
 	host := &models.Host{
-		ID:            &hostID,
-		Kind:          swag.String(models.HostKindHost),
-		RegisteredAt:  strfmt.DateTime(agent.CreationTimestamp.Time),
-		CheckedInAt:   strfmt.DateTime(agent.CreationTimestamp.Time),
-		Role:          role,
-		SuggestedRole: role,
-		ClusterID:     clusterID,
-		InfraEnvID:    infraEnvID,
-		Status:        &hostStatus,
-		Inventory:     inventory,
+		ID:              &hostID,
+		Kind:            swag.String(models.HostKindHost),
+		RegisteredAt:    strfmt.DateTime(agent.CreationTimestamp.Time),
+		CheckedInAt:     strfmt.DateTime(agent.CreationTimestamp.Time),
+		Role:            role,
+		SuggestedRole:   role,
+		ClusterID:       clusterID,
+		InfraEnvID:      infraEnvID,
+		Status:          &hostStatus,
+		Inventory:       inventory,
+		ValidationsInfo: validationsInfo,
 	}
 
 	// Fetch Current Stage

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -80,6 +80,8 @@ const (
 	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
 	AgentLabelHostIsVirtual              = InventoryLabelPrefix + "host-isvirtual"
 	AgentLabelClusterDeploymentNamespace = BaseLabelPrefix + "clusterdeployment-namespace"
+
+	defaultRequeue = 1 * time.Minute
 )
 
 // AgentReconciler reconciles a Agent object
@@ -157,7 +159,7 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 			}
 			// Requeuing as the associated Host should exist now
 			log.Infof("Restored a Host for agent %s", agent.Name)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}, nil
 		} else {
 			log.WithError(err).Errorf("failed to retrieve Host %s from backend", agent.Name)
 			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -73,6 +73,7 @@ const (
 	AgentLabelCpuArchitecture            = InventoryLabelPrefix + "cpu-architecture"
 	AgentLabelCpuVirtEnabled             = InventoryLabelPrefix + "cpu-virtenabled"
 	AgentInventoryAnnotation             = "agent." + aiv1beta1.Group + "/inventory"
+	AgentCurrentStageAnnotation          = "agent." + aiv1beta1.Group + "/current-stage"
 	AgentRoleAnnotation                  = "agent." + aiv1beta1.Group + "/role"
 	AgentLabelHostManufacturer           = InventoryLabelPrefix + "host-manufacturer"
 	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
@@ -246,9 +247,10 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 func updateAnnotations(log logrus.FieldLogger, agent *v1beta1.Agent, h *models.Host) bool {
 	updated := false
 	updated = setAgentAnnotation(log, agent, AgentStateAnnotation, swag.StringValue(h.Status))
-	updated = updated || setAgentAnnotation(log, agent, AgentRoleAnnotation, string(h.Role))
-	if h.Inventory != "" {
-		updated = updated || setAgentAnnotation(log, agent, AgentInventoryAnnotation, h.Inventory)
+	updated = setAgentAnnotation(log, agent, AgentRoleAnnotation, string(h.Role)) || updated
+	updated = setAgentAnnotation(log, agent, AgentInventoryAnnotation, h.Inventory) || updated
+	if h.Progress != nil {
+		updated = setAgentAnnotation(log, agent, AgentCurrentStageAnnotation, string(h.Progress.CurrentStage))
 	}
 	return updated
 }
@@ -1801,6 +1803,14 @@ func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strf
 		InfraEnvID:    infraEnvID,
 		Status:        &hostStatus,
 		Inventory:     inventory,
+	}
+
+	// Fetch Current Stage
+	if stage, has_annotation := agent.GetAnnotations()[AgentCurrentStageAnnotation]; has_annotation {
+		currentStage := models.HostStage(stage)
+		if err := currentStage.Validate(nil); err == nil {
+			host.Progress = &models.HostProgressInfo{CurrentStage: currentStage}
+		}
 	}
 
 	return host, nil

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4210,7 +4210,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4251,7 +4251,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4296,7 +4296,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4364,7 +4364,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		// Reconcile Agent
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 		// Ensure the Agent exists
 		key := types.NamespacedName{
@@ -4492,7 +4492,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			// Reconcile Agent
 			result, err := hr.Reconcile(ctx, newHostRequest(agent))
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 			// Ensure the Agent exists
 			key := types.NamespacedName{
@@ -4548,7 +4548,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			// Reconcile Agent
 			result, err := hr.Reconcile(ctx, newHostRequest(agent))
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 
 			// Ensure the Agent exists
 			key := types.NamespacedName{

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4307,6 +4307,92 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		Expect(agent.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
 	})
 
+	It("should restore Host with missing validationsInfo", func() {
+		// Create Validations Info
+		validationInfoKey := "some-check"
+		var validationInfoId = "checking1"
+
+		validationInfo := common_api.ValidationsStatus{
+			validationInfoKey: common_api.ValidationResults{
+				{
+					ID:      validationInfoId,
+					Status:  "success",
+					Message: "check1 is okay",
+				},
+			},
+		}
+		var bytesValidationInfo []byte
+		var err error
+		bytesValidationInfo, err = json.Marshal(validationInfo)
+		Expect(err).To(BeNil())
+		stringifiedValidationInfo := string(bytesValidationInfo)
+
+		// Create ClusterDeployment
+		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+
+		// Create Agent
+		agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace}})
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
+		agent.ObjectMeta.Labels = map[string]string{
+			v1beta1.InfraEnvNameLabel:  "infraEnvName",
+			AgentLabelHostManufacturer: "RedHat",
+		}
+		agent.ObjectMeta.Annotations = map[string]string{
+			AgentValidationsInfoAnnotation: stringifiedValidationInfo,
+		}
+		Expect(c.Create(ctx, agent)).To(BeNil())
+
+		// Mock InfraEnv
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		infraEnvKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "infraEnvName",
+		}
+		clusterId := *backEndCluster.ID
+		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Create Host
+		host, err := createNewHost(agent, &clusterId, infraEnvId)
+		Expect(err).To(BeNil())
+		Expect(host.Status).To(Equal(swag.String(models.HostStatusKnown)))
+		mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(gomock.Any(), infraEnvKey, host).Return(nil).Times(1)
+		dbHost := common.Host{Host: *host}
+
+		// Reconcile Agent
+		result, err := hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+		// Ensure the Agent exists
+		key := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "agent",
+		}
+		Expect(c.Get(ctx, key, agent)).To(BeNil())
+		Expect(agent.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		// Reconcile Agent again to set the status
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&dbHost, nil).Times(1)
+		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, infraEnvKey.Name)
+		result, err = hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		// Ensure the Agent exists
+		key = types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "agent",
+		}
+		Expect(c.Get(ctx, key, agent)).To(BeNil())
+		Expect(agent.Status.ValidationsInfo).ToNot(BeNil())
+		Expect(agent.Status.ValidationsInfo[validationInfoKey]).ToNot(BeNil())
+		Expect(len(agent.Status.ValidationsInfo[validationInfoKey])).To(Equal(1))
+		Expect(agent.Status.ValidationsInfo[validationInfoKey][0].ID).To(Equal(validationInfoId))
+	})
+
 	It("should fail if the associated Cluster is missing", func() {
 		// Create Agent
 		agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace}})


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->
Manual cherry pick of PRs:
https://github.com/openshift/assisted-service/pull/7026 [MGMT-19193](https://issues.redhat.com//browse/MGMT-19193): Add current stage when restoring host by Agent
https://github.com/openshift/assisted-service/pull/7064 [MGMT-19413](https://issues.redhat.com//browse/MGMT-19413): Add validations info to the Agents annotations
https://github.com/openshift/assisted-service/pull/7063 [MGMT-19414](https://issues.redhat.com//browse/MGMT-19414): Add default requeue time when Hosts are created from Agents

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 