### PR TITLE
MGMT-19860: Add ID and title to operator bundles

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/bundle.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/bundle.go
@@ -17,14 +17,20 @@ import (
 // swagger:model bundle
 type Bundle struct {
 
-	// Short description of the bundle, for example `OpenShift AI with NVIDIA GPUs`.
+	// Longer human friendly description for the bundle, usually one or more sentences.
+	//
 	Description string `json:"description,omitempty"`
 
-	// The name of the bundle.
-	Name string `json:"name,omitempty"`
+	// Unique identifier of the bundle, for example `virtualization` or `openshift-ai-nvidia`.
+	ID string `json:"id,omitempty"`
 
 	// List of operators associated with the bundle.
 	Operators []string `json:"operators"`
+
+	// Short human friendly description for the bundle, usually only a few words, for example `Virtualization` or
+	// `OpenShift AI (NVIDIA)`.
+	//
+	Title string `json:"title,omitempty"`
 }
 
 // Validate validates this bundle

--- a/api/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -20,7 +20,7 @@ import (
 // swagger:model monitored-operator
 type MonitoredOperator struct {
 
-	// List of bundles associated with the operator. Can be empty.
+	// List of identifier of the bundles associated with the operator. Can be empty.
 	Bundles pq.StringArray `json:"bundles" gorm:"type:text[]"`
 
 	// The cluster that this operator is associated with.

--- a/client/operators/operators_client.go
+++ b/client/operators/operators_client.go
@@ -69,7 +69,7 @@ func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "V2GetBundle",
 		Method:             "GET",
-		PathPattern:        "/v2/operators/bundles/{bundle_name}",
+		PathPattern:        "/v2/operators/bundles/{id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/operators/v2_get_bundle_parameters.go
+++ b/client/operators/v2_get_bundle_parameters.go
@@ -61,11 +61,11 @@ V2GetBundleParams contains all the parameters to send to the API endpoint
 */
 type V2GetBundleParams struct {
 
-	/* BundleName.
+	/* ID.
 
-	   The name of the bundle.
+	   Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
 	*/
-	BundleName string
+	ID string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -120,15 +120,15 @@ func (o *V2GetBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBundleName adds the bundleName to the v2 get bundle params
-func (o *V2GetBundleParams) WithBundleName(bundleName string) *V2GetBundleParams {
-	o.SetBundleName(bundleName)
+// WithID adds the id to the v2 get bundle params
+func (o *V2GetBundleParams) WithID(id string) *V2GetBundleParams {
+	o.SetID(id)
 	return o
 }
 
-// SetBundleName adds the bundleName to the v2 get bundle params
-func (o *V2GetBundleParams) SetBundleName(bundleName string) {
-	o.BundleName = bundleName
+// SetID adds the id to the v2 get bundle params
+func (o *V2GetBundleParams) SetID(id string) {
+	o.ID = id
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -139,8 +139,8 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 	}
 	var res []error
 
-	// path param bundle_name
-	if err := r.SetPathParam("bundle_name", o.BundleName); err != nil {
+	// path param id
+	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
 	}
 

--- a/client/operators/v2_get_bundle_responses.go
+++ b/client/operators/v2_get_bundle_responses.go
@@ -86,11 +86,11 @@ func (o *V2GetBundleOK) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleOK) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleOK  %+v", 200, o.Payload)
 }
 
 func (o *V2GetBundleOK) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleOK  %+v", 200, o.Payload)
 }
 
 func (o *V2GetBundleOK) GetPayload() *models.Bundle {
@@ -149,11 +149,11 @@ func (o *V2GetBundleNotFound) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleNotFound) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
 }
 
 func (o *V2GetBundleNotFound) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
 }
 
 func (o *V2GetBundleNotFound) GetPayload() *models.Error {
@@ -212,11 +212,11 @@ func (o *V2GetBundleInternalServerError) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *V2GetBundleInternalServerError) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *V2GetBundleInternalServerError) GetPayload() *models.Error {

--- a/client/vendor/github.com/openshift/assisted-service/models/bundle.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/bundle.go
@@ -17,14 +17,20 @@ import (
 // swagger:model bundle
 type Bundle struct {
 
-	// Short description of the bundle, for example `OpenShift AI with NVIDIA GPUs`.
+	// Longer human friendly description for the bundle, usually one or more sentences.
+	//
 	Description string `json:"description,omitempty"`
 
-	// The name of the bundle.
-	Name string `json:"name,omitempty"`
+	// Unique identifier of the bundle, for example `virtualization` or `openshift-ai-nvidia`.
+	ID string `json:"id,omitempty"`
 
 	// List of operators associated with the bundle.
 	Operators []string `json:"operators"`
+
+	// Short human friendly description for the bundle, usually only a few words, for example `Virtualization` or
+	// `OpenShift AI (NVIDIA)`.
+	//
+	Title string `json:"title,omitempty"`
 }
 
 // Validate validates this bundle

--- a/client/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -20,7 +20,7 @@ import (
 // swagger:model monitored-operator
 type MonitoredOperator struct {
 
-	// List of bundles associated with the operator. Can be empty.
+	// List of identifier of the bundles associated with the operator. Can be empty.
 	Bundles pq.StringArray `json:"bundles" gorm:"type:text[]"`
 
 	// The cluster that this operator is associated with.

--- a/internal/operators/authorino/authorino_operator.go
+++ b/internal/operators/authorino/authorino_operator.go
@@ -20,7 +20,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "authorino-operator",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -39,7 +39,9 @@ var Operator = models.MonitoredOperator{
 	OperatorType:     models.OperatorTypeOlm,
 	SubscriptionName: "hco-operatorhub",
 	TimeoutSeconds:   60 * 60,
-	Bundles:          pq.StringArray{operatorscommon.BundleVirtualization},
+	Bundles: pq.StringArray{
+		operatorscommon.BundleVirtualization.ID,
+	},
 }
 
 // NewCNVOperator creates new instance of a Container Native Virtualization installation plugin

--- a/internal/operators/common/bundles.go
+++ b/internal/operators/common/bundles.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"github.com/openshift/assisted-service/models"
+)
+
+// BundleVirtualization contains the basic information of the 'virtualization' bundle.
+var BundleVirtualization = &models.Bundle{
+	ID:          "virtualization",
+	Title:       "Virtualization",
+	Description: "Run virtual machines alongside containers on one platform.",
+}
+
+// BundleOpenShiftAINVIDIA contains the basic information of the 'openshift-ai-nvidia' bundle.
+var BundleOpenShiftAINVIDIA = &models.Bundle{
+	ID:          "openshift-ai-nvidia",
+	Title:       "OpenShift AI (NVIDIA)",
+	Description: "Train, serve, monitor and manage AI/ML models and applications using NVIDIA GPUs.",
+}
+
+// Bundles is the list of valid bundles. Note that this list contains the basic information of the
+// bundle, like identifier title and description, but it doesn't contain the list of operators that
+// is part of the bundle. That is calculated dynamically scanning the operators.
+var Bundles = []*models.Bundle{
+	BundleVirtualization,
+	BundleOpenShiftAINVIDIA,
+}

--- a/internal/operators/common/common.go
+++ b/internal/operators/common/common.go
@@ -5,22 +5,6 @@ import (
 	"github.com/openshift/assisted-service/pkg/conversions"
 )
 
-const (
-
-	// BundleVirtualization captures enum value "virtualization"
-	BundleVirtualization string = "virtualization"
-
-	// BundleOpenShiftAInvidia captures enum value "openshift-ai-nvidia"
-	BundleOpenShiftAINVIDIA string = "openshift-ai-nvidia"
-)
-
-var (
-	BundleDescriptions = map[string]string{
-		BundleVirtualization:    "Virtualization",
-		BundleOpenShiftAINVIDIA: "OpenShift AI with NVIDIA GPUs",
-	}
-)
-
 // Returns count for disks that are not installion disk and fulfill size requirements (eligible disks) and
 // disks that are not installation disk (available disks)
 func NonInstallationDiskCount(disks []*models.Disk, installationDiskID string, minSizeGB int64) (int64, int64) {

--- a/internal/operators/handler/handler_v2.go
+++ b/internal/operators/handler/handler_v2.go
@@ -45,9 +45,9 @@ func (h *Handler) V2ListBundles(_ context.Context, _ restoperators.V2ListBundles
 // V2GetBundle Retrieves the Bundle object for a specific bundleName.
 func (h *Handler) V2GetBundle(ctx context.Context, params restoperators.V2GetBundleParams) middleware.Responder {
 	log := logutil.FromContext(ctx, h.log)
-	bundle, err := h.operatorsAPI.GetBundle(params.BundleName)
+	bundle, err := h.operatorsAPI.GetBundle(params.ID)
 	if err != nil {
-		log.Errorf("Failed to get operators for bundle %s: %v", params.BundleName, err)
+		log.Errorf("Failed to get operators for bundle %s: %v", params.ID, err)
 		return common.GenerateErrorResponder(err)
 	}
 	return restoperators.NewV2GetBundleOK().WithPayload(bundle)

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -832,10 +832,10 @@ var _ = Describe("Operators manager", func() {
 			bundles := manager.ListBundles()
 			Expect(bundles).To(HaveLen(2))
 			for _, bundle := range bundles {
-				Expect(bundle.Name).To(BeElementOf(operatorscommon.BundleVirtualization, operatorscommon.BundleOpenShiftAINVIDIA))
+				Expect(bundle.ID).To(BeElementOf(operatorscommon.BundleVirtualization.ID, operatorscommon.BundleOpenShiftAINVIDIA.ID))
 				// lso isn't part of any bundle
 				Expect(bundle.Operators).NotTo(ContainElement(lso.Operator.Name))
-				if bundle.Name == operatorscommon.BundleVirtualization {
+				if bundle.ID == operatorscommon.BundleVirtualization.ID {
 					Expect(bundle.Operators).To(ContainElements(mtvOperator.GetName(), cnvOperator.GetName()))
 				} else {
 					Expect(bundle.Operators).To(ContainElements(oaiOperator.GetName(), serverlessOperator.GetName(), odfOperator.GetName()))
@@ -849,27 +849,39 @@ var _ = Describe("Operators manager", func() {
 			Expect(err).To(MatchError("bundle 'invalid bundle' is not supported"))
 			Expect(bundle).To(BeNil())
 
-			bundle, err = manager.GetBundle(operatorscommon.BundleVirtualization)
+			bundle, err = manager.GetBundle(operatorscommon.BundleVirtualization.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bundle.Operators).To(HaveLen(3))
 			Expect(bundle.Operators).To(ContainElements(cnvOperator.GetName(), mtvOperator.GetName(), nmstateOperator.GetName()))
 
-			bundle, err = manager.GetBundle(operatorscommon.BundleOpenShiftAINVIDIA)
+			bundle, err = manager.GetBundle(operatorscommon.BundleOpenShiftAINVIDIA.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bundle.Operators).To(HaveLen(3))
 			Expect(bundle.Operators).To(ContainElements(oaiOperator.GetName(), serverlessOperator.GetName(), odfOperator.GetName()))
 		})
 
 		It("OpenShift AI NVIDIA bundle should have a description", func() {
-			bundle, err := manager.GetBundle(operatorscommon.BundleOpenShiftAINVIDIA)
+			bundle, err := manager.GetBundle(operatorscommon.BundleOpenShiftAINVIDIA.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bundle.Description).ToNot(BeEmpty())
 		})
 
+		It("OpenShift AI NVIDIA bundle should have a title", func() {
+			bundle, err := manager.GetBundle(operatorscommon.BundleOpenShiftAINVIDIA.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bundle.Title).ToNot(BeEmpty())
+		})
+
 		It("Virtualization bundle should have a description", func() {
-			bundle, err := manager.GetBundle(operatorscommon.BundleVirtualization)
+			bundle, err := manager.GetBundle(operatorscommon.BundleVirtualization.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bundle.Description).ToNot(BeEmpty())
+		})
+
+		It("Virtualization bundle should have a title", func() {
+			bundle, err := manager.GetBundle(operatorscommon.BundleVirtualization.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bundle.Title).ToNot(BeEmpty())
 		})
 	})
 })

--- a/internal/operators/mtv/operator.go
+++ b/internal/operators/mtv/operator.go
@@ -28,7 +28,9 @@ var Operator = models.MonitoredOperator{
 	OperatorType:     models.OperatorTypeOlm,
 	SubscriptionName: Subscription,
 	TimeoutSeconds:   60 * 60,
-	Bundles:          pq.StringArray{operatorscommon.BundleVirtualization},
+	Bundles: pq.StringArray{
+		operatorscommon.BundleVirtualization.ID,
+	},
 }
 
 func NewMTVOperator(log logrus.FieldLogger) *operator {

--- a/internal/operators/nmstate/operator.go
+++ b/internal/operators/nmstate/operator.go
@@ -25,7 +25,9 @@ var Operator = models.MonitoredOperator{
 	OperatorType:     models.OperatorTypeOlm,
 	SubscriptionName: SubscriptionName,
 	TimeoutSeconds:   60 * 60,
-	Bundles:          pq.StringArray{operatorscommon.BundleVirtualization},
+	Bundles: pq.StringArray{
+		operatorscommon.BundleVirtualization.ID,
+	},
 }
 
 // New NMSTATEperator creates new instance of a Local Storage Operator installation plugin

--- a/internal/operators/nvidiagpu/nvidia_gpu_operator.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator.go
@@ -25,7 +25,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "gpu-operator-certified",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/odf/odf_operator.go
+++ b/internal/operators/odf/odf_operator.go
@@ -47,7 +47,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "odf-operator",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/openshiftai/openshift_ai_operator.go
+++ b/internal/operators/openshiftai/openshift_ai_operator.go
@@ -30,7 +30,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "rhods-operator",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/pipelines/pipelines_operator.go
+++ b/internal/operators/pipelines/pipelines_operator.go
@@ -21,7 +21,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "openshift-pipelines-operator-rh",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/serverless/serverless_operator.go
+++ b/internal/operators/serverless/serverless_operator.go
@@ -21,7 +21,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "serverless-operator",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/internal/operators/servicemesh/servicemesh_operator.go
+++ b/internal/operators/servicemesh/servicemesh_operator.go
@@ -21,7 +21,7 @@ var Operator = models.MonitoredOperator{
 	SubscriptionName: "servicemeshoperator",
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
-		operatorscommon.BundleOpenShiftAINVIDIA,
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 

--- a/models/bundle.go
+++ b/models/bundle.go
@@ -17,14 +17,20 @@ import (
 // swagger:model bundle
 type Bundle struct {
 
-	// Short description of the bundle, for example `OpenShift AI with NVIDIA GPUs`.
+	// Longer human friendly description for the bundle, usually one or more sentences.
+	//
 	Description string `json:"description,omitempty"`
 
-	// The name of the bundle.
-	Name string `json:"name,omitempty"`
+	// Unique identifier of the bundle, for example `virtualization` or `openshift-ai-nvidia`.
+	ID string `json:"id,omitempty"`
 
 	// List of operators associated with the bundle.
 	Operators []string `json:"operators"`
+
+	// Short human friendly description for the bundle, usually only a few words, for example `Virtualization` or
+	// `OpenShift AI (NVIDIA)`.
+	//
+	Title string `json:"title,omitempty"`
 }
 
 // Validate validates this bundle

--- a/models/monitored_operator.go
+++ b/models/monitored_operator.go
@@ -20,7 +20,7 @@ import (
 // swagger:model monitored-operator
 type MonitoredOperator struct {
 
-	// List of bundles associated with the operator. Can be empty.
+	// List of identifier of the bundles associated with the operator. Can be empty.
 	Bundles pq.StringArray `json:"bundles" gorm:"type:text[]"`
 
 	// The cluster that this operator is associated with.

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5744,7 +5744,7 @@ func init() {
         }
       }
     },
-    "/v2/operators/bundles/{bundle_name}": {
+    "/v2/operators/bundles/{id}": {
       "get": {
         "description": "Retrieves an array of operator properties for the specified bundle.",
         "tags": [
@@ -5755,8 +5755,8 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "The name of the bundle.",
-            "name": "bundle_name",
+            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
+            "name": "id",
             "in": "path",
             "required": true
           }
@@ -6239,11 +6239,11 @@ func init() {
       "type": "object",
       "properties": {
         "description": {
-          "description": "Short description of the bundle, for example ` + "`" + `OpenShift AI with NVIDIA GPUs` + "`" + `.",
+          "description": "Longer human friendly description for the bundle, usually one or more sentences.\n",
           "type": "string"
         },
-        "name": {
-          "description": "The name of the bundle.",
+        "id": {
+          "description": "Unique identifier of the bundle, for example ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
           "type": "string"
         },
         "operators": {
@@ -6252,6 +6252,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "title": {
+          "description": "Short human friendly description for the bundle, usually only a few words, for example ` + "`" + `Virtualization` + "`" + ` or\n` + "`" + `OpenShift AI (NVIDIA)` + "`" + `.\n",
+          "type": "string"
         }
       }
     },
@@ -9640,7 +9644,7 @@ func init() {
       "type": "object",
       "properties": {
         "bundles": {
-          "description": "List of bundles associated with the operator. Can be empty.",
+          "description": "List of identifier of the bundles associated with the operator. Can be empty.",
           "type": "array",
           "items": {
             "type": "string"
@@ -16706,7 +16710,7 @@ func init() {
         }
       }
     },
-    "/v2/operators/bundles/{bundle_name}": {
+    "/v2/operators/bundles/{id}": {
       "get": {
         "description": "Retrieves an array of operator properties for the specified bundle.",
         "tags": [
@@ -16717,8 +16721,8 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "The name of the bundle.",
-            "name": "bundle_name",
+            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
+            "name": "id",
             "in": "path",
             "required": true
           }
@@ -17319,11 +17323,11 @@ func init() {
       "type": "object",
       "properties": {
         "description": {
-          "description": "Short description of the bundle, for example ` + "`" + `OpenShift AI with NVIDIA GPUs` + "`" + `.",
+          "description": "Longer human friendly description for the bundle, usually one or more sentences.\n",
           "type": "string"
         },
-        "name": {
-          "description": "The name of the bundle.",
+        "id": {
+          "description": "Unique identifier of the bundle, for example ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
           "type": "string"
         },
         "operators": {
@@ -17332,6 +17336,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "title": {
+          "description": "Short human friendly description for the bundle, usually only a few words, for example ` + "`" + `Virtualization` + "`" + ` or\n` + "`" + `OpenShift AI (NVIDIA)` + "`" + `.\n",
+          "type": "string"
         }
       }
     },
@@ -20678,7 +20686,7 @@ func init() {
       "type": "object",
       "properties": {
         "bundles": {
-          "description": "List of bundles associated with the operator. Can be empty.",
+          "description": "List of identifier of the bundles associated with the operator. Can be empty.",
           "type": "array",
           "items": {
             "type": "string"

--- a/restapi/operations/assisted_install_api.go
+++ b/restapi/operations/assisted_install_api.go
@@ -1097,7 +1097,7 @@ func (o *AssistedInstallAPI) initHandlerCache() {
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/v2/operators/bundles/{bundle_name}"] = operators.NewV2GetBundle(o.context, o.OperatorsV2GetBundleHandler)
+	o.handlers["GET"]["/v2/operators/bundles/{id}"] = operators.NewV2GetBundle(o.context, o.OperatorsV2GetBundleHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}

--- a/restapi/operations/operators/v2_get_bundle.go
+++ b/restapi/operations/operators/v2_get_bundle.go
@@ -30,7 +30,7 @@ func NewV2GetBundle(ctx *middleware.Context, handler V2GetBundleHandler) *V2GetB
 }
 
 /*
-	V2GetBundle swagger:route GET /v2/operators/bundles/{bundle_name} operators v2GetBundle
+	V2GetBundle swagger:route GET /v2/operators/bundles/{id} operators v2GetBundle
 
 # Get operator properties for a bundle
 

--- a/restapi/operations/operators/v2_get_bundle_parameters.go
+++ b/restapi/operations/operators/v2_get_bundle_parameters.go
@@ -30,11 +30,11 @@ type V2GetBundleParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The name of the bundle.
+	/*Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
 	  Required: true
 	  In: path
 	*/
-	BundleName string
+	ID string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -46,8 +46,8 @@ func (o *V2GetBundleParams) BindRequest(r *http.Request, route *middleware.Match
 
 	o.HTTPRequest = r
 
-	rBundleName, rhkBundleName, _ := route.Params.GetOK("bundle_name")
-	if err := o.bindBundleName(rBundleName, rhkBundleName, route.Formats); err != nil {
+	rID, rhkID, _ := route.Params.GetOK("id")
+	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -56,8 +56,8 @@ func (o *V2GetBundleParams) BindRequest(r *http.Request, route *middleware.Match
 	return nil
 }
 
-// bindBundleName binds and validates parameter BundleName from path.
-func (o *V2GetBundleParams) bindBundleName(rawData []string, hasKey bool, formats strfmt.Registry) error {
+// bindID binds and validates parameter ID from path.
+func (o *V2GetBundleParams) bindID(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
@@ -65,7 +65,7 @@ func (o *V2GetBundleParams) bindBundleName(rawData []string, hasKey bool, format
 
 	// Required: true
 	// Parameter is provided by construction from the route
-	o.BundleName = raw
+	o.ID = raw
 
 	return nil
 }

--- a/restapi/operations/operators/v2_get_bundle_urlbuilder.go
+++ b/restapi/operations/operators/v2_get_bundle_urlbuilder.go
@@ -14,7 +14,7 @@ import (
 
 // V2GetBundleURL generates an URL for the v2 get bundle operation
 type V2GetBundleURL struct {
-	BundleName string
+	ID string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -40,13 +40,13 @@ func (o *V2GetBundleURL) SetBasePath(bp string) {
 func (o *V2GetBundleURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/v2/operators/bundles/{bundle_name}"
+	var _path = "/v2/operators/bundles/{id}"
 
-	bundleName := o.BundleName
-	if bundleName != "" {
-		_path = strings.Replace(_path, "{bundle_name}", bundleName, -1)
+	id := o.ID
+	if id != "" {
+		_path = strings.Replace(_path, "{id}", id, -1)
 	} else {
-		return nil, errors.New("bundleName is required on V2GetBundleURL")
+		return nil, errors.New("id is required on V2GetBundleURL")
 	}
 
 	_basePath := o._basePath

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2750,7 +2750,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /v2/operators/bundles/{bundle_name}:
+  /v2/operators/bundles/{id}:
     get:
       tags:
         - operators
@@ -2759,8 +2759,8 @@ paths:
       operationId: V2GetBundle
       parameters:
         - in: path
-          name: bundle_name
-          description: The name of the bundle.
+          name: id
+          description: Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
           required: true
           type: string
       responses:
@@ -4104,7 +4104,7 @@ definitions:
         description: Time at which the operator was last updated.
       bundles:
         type: array
-        description: List of bundles associated with the operator. Can be empty.
+        description: List of identifier of the bundles associated with the operator. Can be empty.
         items:
           type: string
         x-go-custom-tag: gorm:"type:text[]"
@@ -4158,11 +4158,17 @@ definitions:
   bundle:
     type: object
     properties:
-      name:
-        description: The name of the bundle.
+      id:
+        description: Unique identifier of the bundle, for example `virtualization` or `openshift-ai-nvidia`.
+        type: string
+      title:
+        description: |
+          Short human friendly description for the bundle, usually only a few words, for example `Virtualization` or
+          `OpenShift AI (NVIDIA)`.
         type: string
       description:
-        description: Short description of the bundle, for example `OpenShift AI with NVIDIA GPUs`.
+        description: |
+          Longer human friendly description for the bundle, usually one or more sentences.
         type: string
       operators:
         description: List of operators associated with the bundle.

--- a/vendor/github.com/openshift/assisted-service/client/operators/operators_client.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/operators_client.go
@@ -69,7 +69,7 @@ func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "V2GetBundle",
 		Method:             "GET",
-		PathPattern:        "/v2/operators/bundles/{bundle_name}",
+		PathPattern:        "/v2/operators/bundles/{id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_parameters.go
@@ -61,11 +61,11 @@ V2GetBundleParams contains all the parameters to send to the API endpoint
 */
 type V2GetBundleParams struct {
 
-	/* BundleName.
+	/* ID.
 
-	   The name of the bundle.
+	   Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
 	*/
-	BundleName string
+	ID string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -120,15 +120,15 @@ func (o *V2GetBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBundleName adds the bundleName to the v2 get bundle params
-func (o *V2GetBundleParams) WithBundleName(bundleName string) *V2GetBundleParams {
-	o.SetBundleName(bundleName)
+// WithID adds the id to the v2 get bundle params
+func (o *V2GetBundleParams) WithID(id string) *V2GetBundleParams {
+	o.SetID(id)
 	return o
 }
 
-// SetBundleName adds the bundleName to the v2 get bundle params
-func (o *V2GetBundleParams) SetBundleName(bundleName string) {
-	o.BundleName = bundleName
+// SetID adds the id to the v2 get bundle params
+func (o *V2GetBundleParams) SetID(id string) {
+	o.ID = id
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -139,8 +139,8 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 	}
 	var res []error
 
-	// path param bundle_name
-	if err := r.SetPathParam("bundle_name", o.BundleName); err != nil {
+	// path param id
+	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_responses.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_responses.go
@@ -86,11 +86,11 @@ func (o *V2GetBundleOK) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleOK) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleOK  %+v", 200, o.Payload)
 }
 
 func (o *V2GetBundleOK) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleOK  %+v", 200, o.Payload)
 }
 
 func (o *V2GetBundleOK) GetPayload() *models.Bundle {
@@ -149,11 +149,11 @@ func (o *V2GetBundleNotFound) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleNotFound) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
 }
 
 func (o *V2GetBundleNotFound) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleNotFound  %+v", 404, o.Payload)
 }
 
 func (o *V2GetBundleNotFound) GetPayload() *models.Error {
@@ -212,11 +212,11 @@ func (o *V2GetBundleInternalServerError) IsCode(code int) bool {
 }
 
 func (o *V2GetBundleInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *V2GetBundleInternalServerError) String() string {
-	return fmt.Sprintf("[GET /v2/operators/bundles/{bundle_name}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *V2GetBundleInternalServerError) GetPayload() *models.Error {

--- a/vendor/github.com/openshift/assisted-service/models/bundle.go
+++ b/vendor/github.com/openshift/assisted-service/models/bundle.go
@@ -17,14 +17,20 @@ import (
 // swagger:model bundle
 type Bundle struct {
 
-	// Short description of the bundle, for example `OpenShift AI with NVIDIA GPUs`.
+	// Longer human friendly description for the bundle, usually one or more sentences.
+	//
 	Description string `json:"description,omitempty"`
 
-	// The name of the bundle.
-	Name string `json:"name,omitempty"`
+	// Unique identifier of the bundle, for example `virtualization` or `openshift-ai-nvidia`.
+	ID string `json:"id,omitempty"`
 
 	// List of operators associated with the bundle.
 	Operators []string `json:"operators"`
+
+	// Short human friendly description for the bundle, usually only a few words, for example `Virtualization` or
+	// `OpenShift AI (NVIDIA)`.
+	//
+	Title string `json:"title,omitempty"`
 }
 
 // Validate validates this bundle

--- a/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -20,7 +20,7 @@ import (
 // swagger:model monitored-operator
 type MonitoredOperator struct {
 
-	// List of bundles associated with the operator. Can be empty.
+	// List of identifier of the bundles associated with the operator. Can be empty.
 	Bundles pq.StringArray `json:"bundles" gorm:"type:text[]"`
 
 	// The cluster that this operator is associated with.


### PR DESCRIPTION
Currently operator bundles have a `name` field that contains an unique identifier of the bundle, for example `virtualization` and `openshift-ai-nvida`. They also have a `description` field that contains a short description of the bundle, for examplel _OpenShift AI with NVIDIA GPUs_. But for the UI it is convenient to display a short title and also a longer description. For example, for the `openshift-ai-nvidia` bundle it would be convenient to have this:

- Title - OpenShift AI with NVIDIA GPUs
- Description - Train, serve, monitor and manage AI/ML models and applications using NVIDIA GPUs.

In order to support that this patch renames the existing `name` field to `id` and introduces a new `title` field for the short description. The existing `description` field will be used for the long description.

The bundles endpoint will now return something like this:

```
GET /api/assisted-install/v2/operators/bundles",

[
  {
    "id": "virtualization",
    "title": "Virtualization",
    "description": "Run virtual machines alongside containers on one platform.",
    "operators": [
      "cnv",
      "mtv",
      "nmstate",
      "odf"
    ]
  },
  {
    "id": "openshift-ai-nvidia",
    "title": "OpenShift AI with NVIDIA GPUs",
    "description": "Train, serve, monitor and manage AI/ML models and applications using NVIDIA GPUs.",
    "operators": [
      "authorino",
      "nvidia-gpu",
      "odf",
      "openshift-ai",
      "pipelines",
      "serverless",
      "servicemesh"
    ]
  }
]
```

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19860

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
