### PR TITLE
MGMT-19649: Monitored host count shouldn't be gauge

### DIFF
--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -117,8 +117,8 @@ type MetricsManager struct {
 	serviceLogicClusterValidationFailed                *prometheus.CounterVec
 	serviceLogicClusterValidationChanged               *prometheus.CounterVec
 	serviceLogicFilesystemUsagePercentage              *prometheus.GaugeVec
-	serviceLogicMonitoredHosts                         *prometheus.GaugeVec
-	serviceLogicMonitoredClusters                      *prometheus.GaugeVec
+	serviceLogicMonitoredHosts                         *prometheus.CounterVec
+	serviceLogicMonitoredClusters                      *prometheus.CounterVec
 	collectors                                         []prometheus.Collector
 }
 
@@ -275,19 +275,21 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler eventsapi.H
 			}, []string{},
 		),
 
-		serviceLogicMonitoredHosts: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      counterMonitoredHosts,
-			Help:      counterDescriptionMonitoredHosts,
-		}, []string{hosts}),
+		serviceLogicMonitoredHosts: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      counterMonitoredHosts,
+				Help:      counterDescriptionMonitoredHosts,
+			}, []string{hosts}),
 
-		serviceLogicMonitoredClusters: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      counterMonitoredClusters,
-			Help:      counterDescriptionMonitoredClusters,
-		}, []string{hosts}),
+		serviceLogicMonitoredClusters: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      counterMonitoredClusters,
+				Help:      counterDescriptionMonitoredClusters,
+			}, []string{hosts}),
 	}
 
 	m.collectors = append(m.collectors, newDirectoryUsageCollector(metricsManagerConfig.DirectoryUsageMonitorConfig.Directories, diskStatsHelper, log))
@@ -476,11 +478,11 @@ func (m *MetricsManager) FileSystemUsage(usageInPercentage float64) {
 }
 
 func (m *MetricsManager) MonitoredHostsCount(monitoredHosts int64) {
-	m.serviceLogicMonitoredHosts.WithLabelValues(hosts).Set(float64(monitoredHosts))
+	m.serviceLogicMonitoredHosts.WithLabelValues(hosts).Add(float64(monitoredHosts))
 }
 
 func (m *MetricsManager) MonitoredClusterCount(monitoredClusters int64) {
-	m.serviceLogicMonitoredClusters.WithLabelValues(clusters).Set(float64(monitoredClusters))
+	m.serviceLogicMonitoredClusters.WithLabelValues(clusters).Add(float64(monitoredClusters))
 }
 
 func bytesToGib(bytes int64) int64 {


### PR DESCRIPTION
The `service_assisted_installer_monitored_hosts` metric was previously implemented as a gauge, which could lead to misleading insights. Since the host monitoring loop runs every few seconds while Prometheus scrapes at a different interval, some monitored host data may be lost.

Similarly, `service_assisted_installer_monitored_clusters` faced the same issue.

To improve the accuracy of these metrics, they have been changed from a gauge to a counter, ensuring Prometheus records cumulative increases rather than snapshot values. This change provides a more reliable view of monitored hosts and clusters over time.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 @rccrdpccl 