### PR TITLE
MGMT-19840: Gather operational metrics from installercache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -492,7 +492,7 @@ func main() {
 	Options.BMConfig.S3EndpointURL = newUrl
 
 	Options.InstallerCacheConfig.CacheDir = filepath.Join(Options.GeneratorConfig.GetWorkingDirectory(), "installercache")
-	installerCache, err := installercache.New(Options.InstallerCacheConfig, eventsHandler, diskStatsHelper, log)
+	installerCache, err := installercache.New(Options.InstallerCacheConfig, eventsHandler, metricsManager, diskStatsHelper, log)
 	failOnError(err, "failed to instantiate installercache")
 
 	generator := generator.New(log, objectHandler, Options.GeneratorConfig, providerRegistry, manifestsApi, eventsHandler, installerCache)

--- a/internal/ignition/installmanifests_test.go
+++ b/internal/ignition/installmanifests_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		manifestsAPI   *manifestsapi.MockManifestsAPI
 		eventsHandler  *eventsapi.MockHandler
 		installerCache *installercache.Installers
+		metricsAPI     *metrics.MockAPI
 	)
 
 	BeforeEach(func() {
@@ -105,12 +106,13 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		err1 = os.WriteFile(examplePath, []byte(bootstrap1), 0600)
 		Expect(err1).NotTo(HaveOccurred())
 		ctrl = gomock.NewController(GinkgoT())
+		metricsAPI = metrics.NewMockAPI(ctrl)
 		installerCacheConfig := installercache.Config{
 			CacheDir:       filepath.Join(workDir, "some-dir", "installercache"),
 			MaxCapacity:    installercache.Size(5),
 			MaxReleaseSize: installercache.Size(5),
 		}
-		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
+		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metricsAPI, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
@@ -262,6 +264,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		ctrl           *gomock.Controller
 		manifestsAPI   *manifestsapi.MockManifestsAPI
 		eventsHandler  eventsapi.Handler
+		metricsAPI     *metrics.MockAPI
 		installerCache *installercache.Installers
 	)
 
@@ -286,12 +289,13 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		metricsAPI = metrics.NewMockAPI(ctrl)
 		installerCacheConfig := installercache.Config{
 			CacheDir:       filepath.Join(workDir, "some-dir", "installercache"),
 			MaxCapacity:    installercache.Size(5),
 			MaxReleaseSize: installercache.Size(5),
 		}
-		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
+		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metricsAPI, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -456,6 +460,7 @@ var _ = Describe("createHostIgnitions", func() {
 		workDir        string
 		manifestsAPI   *manifestsapi.MockManifestsAPI
 		eventsHandler  eventsapi.Handler
+		metricsAPI     *metrics.MockAPI
 		installerCache *installercache.Installers
 	)
 
@@ -476,13 +481,14 @@ var _ = Describe("createHostIgnitions", func() {
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		metricsAPI = metrics.NewMockAPI(ctrl)
 		cluster = testCluster()
 		installerCacheConfig := installercache.Config{
 			CacheDir:       filepath.Join(workDir, "some-dir", "installercache"),
 			MaxCapacity:    installercache.Size(5),
 			MaxReleaseSize: installercache.Size(5),
 		}
-		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
+		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metricsAPI, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -1779,6 +1785,7 @@ var _ = Describe("Bare metal host generation", func() {
 		ctrl           *gomock.Controller
 		manifestsAPI   *manifestsapi.MockManifestsAPI
 		eventsHandler  eventsapi.Handler
+		metricsAPI     *metrics.MockAPI
 		installerCache *installercache.Installers
 	)
 
@@ -1789,13 +1796,14 @@ var _ = Describe("Bare metal host generation", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		metricsAPI = metrics.NewMockAPI(ctrl)
 		installerCacheConfig := installercache.Config{
 			CacheDir:                  filepath.Join(workDir, "some-dir", "installercache"),
 			MaxCapacity:               installercache.Size(5),
 			MaxReleaseSize:            installercache.Size(5),
 			ReleaseFetchRetryInterval: 1 * time.Microsecond,
 		}
-		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
+		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metricsAPI, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -1889,6 +1897,7 @@ var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 		ctrl           *gomock.Controller
 		manifestsAPI   *manifestsapi.MockManifestsAPI
 		eventsHandler  eventsapi.Handler
+		metricsAPI     *metrics.MockAPI
 		installerCache *installercache.Installers
 	)
 
@@ -1920,13 +1929,14 @@ var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		manifestsAPI = manifestsapi.NewMockManifestsAPI(ctrl)
 		eventsHandler = eventsapi.NewMockHandler(ctrl)
+		metricsAPI = metrics.NewMockAPI(ctrl)
 		installerCacheConfig := installercache.Config{
 			CacheDir:                  filepath.Join(workDir, "some-dir", "installercache"),
 			MaxCapacity:               installercache.Size(5),
 			MaxReleaseSize:            installercache.Size(5),
 			ReleaseFetchRetryInterval: 1 * time.Microsecond,
 		}
-		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
+		installerCache, err = installercache.New(installerCacheConfig, eventsHandler, metricsAPI, metrics.NewOSDiskStatsHelper(logrus.New()), logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -169,6 +169,30 @@ func (mr *MockAPIMockRecorder) InstallationStarted() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallationStarted", reflect.TypeOf((*MockAPI)(nil).InstallationStarted))
 }
 
+// InstallerCacheGetReleaseCached mocks base method.
+func (m *MockAPI) InstallerCacheGetReleaseCached(releaseId string, cacheHit bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InstallerCacheGetReleaseCached", releaseId, cacheHit)
+}
+
+// InstallerCacheGetReleaseCached indicates an expected call of InstallerCacheGetReleaseCached.
+func (mr *MockAPIMockRecorder) InstallerCacheGetReleaseCached(releaseId, cacheHit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallerCacheGetReleaseCached", reflect.TypeOf((*MockAPI)(nil).InstallerCacheGetReleaseCached), releaseId, cacheHit)
+}
+
+// InstallerCacheReleaseEvicted mocks base method.
+func (m *MockAPI) InstallerCacheReleaseEvicted(success bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InstallerCacheReleaseEvicted", success)
+}
+
+// InstallerCacheReleaseEvicted indicates an expected call of InstallerCacheReleaseEvicted.
+func (mr *MockAPIMockRecorder) InstallerCacheReleaseEvicted(success interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallerCacheReleaseEvicted", reflect.TypeOf((*MockAPI)(nil).InstallerCacheReleaseEvicted), success)
+}
+
 // MonitoredClustersDurationMs mocks base method.
 func (m *MockAPI) MonitoredClustersDurationMs(monitoredClustersMillis float64) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
We implement the following metrics:
Record cache hits and misses

The purpose of this metric is to measure efficiency of the cache. This metric should be a counter. The total sum should be the equivalent to the sum of hits+misses (each request served). Errors should be logged instead.

 

assisted_installer_release_cache{hit=(true|false),release="\d.\d"} 

 
Labels

    hit: hit should either be true or false
    release: release is major and minor openshift version, so that cardinality is contained. if we can't retrive major/minor, we label it as `unknown`

Record cache evictions

This metric is a counter. The purpose of this metric is to count the number of eviction attempts. For each eviction attempt we should just count one with success=true label if the operation evicted at least one file, false if evicted 0 files). Individual file deletion and possible errors should be logged instead.

assisted_installer_release_cache_eviction{success=(true|false)}

Labels
    success: is true if the operation removed at least one file, false otherwise


This, combined with the event based metrics gathered in openshift#7156 should provide enough information to track the behaviour of the cache.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
