### PR TITLE
MGMT-19887: Add Histogram Metric for Host Monitoring Time

### DIFF
--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -88,7 +88,7 @@ var _ = Describe("monitor_disconnection", func() {
 		db.First(&host, "id = ? and cluster_id = ?", host.ID, host.ClusterID)
 
 		mockMetricApi.EXPECT().Duration("HostMonitoring", gomock.Any()).Times(1)
-		mockMetricApi.EXPECT().MonitoredHostsCount(gomock.Any()).Times(1)
+		mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
 		mockOperators.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
@@ -249,7 +249,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		It("do not reset with status disconnected", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusDisconnected, models.HostKindHost)
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(2)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -264,7 +264,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			otherClusterId := strfmt.UUID(uuid.New().String())
 			addHost(otherClusterId, models.HostRoleAutoAssign, models.HostStatusKnown, models.HostKindHost)
 			addHost(otherClusterId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindHost)
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(2)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -276,7 +276,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		It("do not reset with day2 host", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusKnown, models.HostKindAddToExistingClusterHost)
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(2)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -306,17 +306,17 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		}
 
 		It("5 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(5)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(5)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(15)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(15)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(765)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(765)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -334,7 +334,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
 			Expect(db.Model(&host).Update("status", hostStatus).Error).ShouldNot(HaveOccurred())
 
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(expectedCount)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(expectedCount)
 			state.HostMonitoring()
 		},
 			Entry("HostStatusAddedToExistingCluster is not monitored", models.ClusterStatusReady, models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
@@ -459,17 +459,17 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		}
 
 		It("5 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(5)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(5)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(15)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(15)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(765)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(765)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -491,7 +491,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		}
 
 		It("times out Reclaiming hosts", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(1)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaiming)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)
@@ -499,7 +499,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		})
 
 		It("times out ReclaimingRebooting hosts", func() {
-			mockMetricApi.EXPECT().MonitoredHostsCount(int64(1)).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaimingRebooting)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -169,28 +169,28 @@ func (mr *MockAPIMockRecorder) InstallationStarted() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallationStarted", reflect.TypeOf((*MockAPI)(nil).InstallationStarted))
 }
 
-// MonitoredClusterCount mocks base method.
-func (m *MockAPI) MonitoredClusterCount(monitoredClusters int64) {
+// MonitoredClustersDurationMs mocks base method.
+func (m *MockAPI) MonitoredClustersDurationMs(monitoredClustersMillis float64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MonitoredClusterCount", monitoredClusters)
+	m.ctrl.Call(m, "MonitoredClustersDurationMs", monitoredClustersMillis)
 }
 
-// MonitoredClusterCount indicates an expected call of MonitoredClusterCount.
-func (mr *MockAPIMockRecorder) MonitoredClusterCount(monitoredClusters interface{}) *gomock.Call {
+// MonitoredClustersDurationMs indicates an expected call of MonitoredClustersDurationMs.
+func (mr *MockAPIMockRecorder) MonitoredClustersDurationMs(monitoredClustersMillis interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredClusterCount", reflect.TypeOf((*MockAPI)(nil).MonitoredClusterCount), monitoredClusters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredClustersDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredClustersDurationMs), monitoredClustersMillis)
 }
 
-// MonitoredHostsCount mocks base method.
-func (m *MockAPI) MonitoredHostsCount(monitoredHosts int64) {
+// MonitoredHostsDurationMs mocks base method.
+func (m *MockAPI) MonitoredHostsDurationMs(monitoredHostsMillis float64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MonitoredHostsCount", monitoredHosts)
+	m.ctrl.Call(m, "MonitoredHostsDurationMs", monitoredHostsMillis)
 }
 
-// MonitoredHostsCount indicates an expected call of MonitoredHostsCount.
-func (mr *MockAPIMockRecorder) MonitoredHostsCount(monitoredHosts interface{}) *gomock.Call {
+// MonitoredHostsDurationMs indicates an expected call of MonitoredHostsDurationMs.
+func (mr *MockAPIMockRecorder) MonitoredHostsDurationMs(monitoredHostsMillis interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsCount", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsCount), monitoredHosts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsDurationMs), monitoredHostsMillis)
 }
 
 // ReportHostInstallationMetrics mocks base method.


### PR DESCRIPTION
This PR updates the monitoring metrics, which were previously reported as gauge, to use histograms.

Instead of simply counting the number of monitored hosts and clusters, the new histograms will track the duration of each monitoring operation, allowing us to retain valuable timing data and improve performance insights.

Previously, using gauge led to misleading metrics—since the host monitoring loop runs every few seconds but Prometheus scrapes at different intervals, a significant number of monitored hosts could be lost, leading to inaccurate analysis. The same issue applied to monitored clusters.

By switching to histograms, we can now accurately measure how long each monitoring process takes and identify potential performance bottlenecks.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
