### PR TITLE
[ACM 2.12] ACM-17877: Don't remove spoke resources when cluster is being deleted

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -32,6 +32,7 @@ import (
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	. "github.com/openshift/assisted-service/api/common"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
@@ -507,6 +508,8 @@ func (r *AgentReconciler) handleAgentFinalizer(ctx context.Context, log logrus.F
 					if err := removeSpokeResources(ctx, log, spokeClient, nodeName); err != nil {
 						return &ctrl.Result{}, errors.Wrap(err, "failed to clean spoke cluster resources")
 					}
+				} else {
+					log.Info("skipping spoke resource removal for deleted cluster")
 				}
 			}
 			// deletion finalizer found, deregister the backend host and delete the agent
@@ -612,8 +615,20 @@ func (r *AgentReconciler) clusterExists(ctx context.Context, clusterRef types.Na
 	if err := r.Client.Get(ctx, clusterRef, cd); err != nil {
 		return false, client.IgnoreNotFound(err)
 	}
+	if !cd.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
 
-	return cd.DeletionTimestamp.IsZero(), nil
+	if cd.Spec.ClusterInstallRef == nil {
+		return false, fmt.Errorf("failed to check agent cluster install existence, cluster install ref is empty")
+	}
+	aciRef := types.NamespacedName{Name: cd.Spec.ClusterInstallRef.Name, Namespace: cd.Namespace}
+	aci := &hiveext.AgentClusterInstall{}
+	if err := r.Client.Get(ctx, aciRef, aci); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	return aci.DeletionTimestamp.IsZero(), nil
 }
 
 func (r *AgentReconciler) shouldReclaimOnUnbind(ctx context.Context, agent *aiv1beta1.Agent) bool {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4038,10 +4038,6 @@ var _ = Describe("handleAgentFinalizer", func() {
 	})
 
 	Context("agent is being deleted with the finalizer set", func() {
-		var (
-			fakeSpokeClient spoke_k8s_client.SpokeK8sClient
-		)
-
 		expectAgentFinalizerRemoved := func() {
 			mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).DoAndReturn(
 				func(_ context.Context, updatedAgent *v1beta1.Agent, _ ...client.UpdateOption) error {
@@ -4066,45 +4062,10 @@ var _ = Describe("handleAgentFinalizer", func() {
 			mockInstallerInternal.EXPECT().V2DeregisterHostInternal(ctx, params, bminventory.NonInteractive).Return(nil)
 		}
 
-		mockSpokeClient := func() {
-			cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
-			mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
-				func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
-					cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
-						AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "clusterKubeConfig"},
-					}
-					return nil
-				},
-			).AnyTimes()
-
-			secretKey := types.NamespacedName{Name: "clusterKubeConfig", Namespace: testNamespace}
-			mockClient.EXPECT().Get(ctx, secretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, key client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-					secret.ObjectMeta.Labels = map[string]string{
-						BackupLabel:        "true",
-						WatchResourceLabel: "true",
-					}
-					secret.Data = map[string][]byte{"kubeconfig": []byte("definitely_a_kubeconfig")}
-					return nil
-				},
-			).AnyTimes()
-
-			mockClientFactory.EXPECT().CreateFromSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(secret *corev1.Secret) (spoke_k8s_client.SpokeK8sClient, error) {
-					Expect(secret.Data["kubeconfig"]).To(Equal([]byte("definitely_a_kubeconfig")))
-					return fakeSpokeClient, nil
-				},
-			).AnyTimes()
-		}
-
 		BeforeEach(func() {
 			now := metav1.Now()
 			agent.ObjectMeta.DeletionTimestamp = &now
 			agent.ObjectMeta.Finalizers = []string{AgentFinalizerName}
-			schemes := GetKubeClientSchemes()
-			fakeClient := fakeclient.NewClientBuilder().WithScheme(schemes).Build()
-			fakeSpokeClient = fakeSpokeK8sClient{Client: fakeClient}
-			mockSpokeClient()
 			expectHostRemoved()
 			expectAgentFinalizerRemoved()
 		})
@@ -4117,174 +4078,309 @@ var _ = Describe("handleAgentFinalizer", func() {
 			Expect(res).NotTo(BeNil())
 		})
 
-		It("removes a node with no machine", func() {
-			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: agentHostname}}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+		It("doesn't remove the node when the cluster deployment is being deleted", func() {
+			cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
+				func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
+					now := metav1.Now()
+					cd.ObjectMeta.DeletionTimestamp = &now
+					return nil
+				},
+			).AnyTimes()
 
 			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
 			Expect(err).To(BeNil())
 			Expect(res).NotTo(BeNil())
-
-			err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("removes a node with an invalid machine annotation", func() {
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        agentHostname,
-					Annotations: map[string]string{"machine.openshift.io/machine": "namewithoutaslash"},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+		It("doesn't remove the node when the cluster deployment has been deleted", func() {
+			cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			notFoundError := k8serrors.NewNotFound(schema.GroupResource{Group: "hive.openshift.io", Resource: "ClusterDeployment"}, cdKey.Name)
+			mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).Return(notFoundError).AnyTimes()
 
 			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
 			Expect(err).To(BeNil())
 			Expect(res).NotTo(BeNil())
-
-			err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("removes a node referencing a missing machine", func() {
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        agentHostname,
-					Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/machine0"},
+		It("doesn't remove the node when the agent cluster install has been deleted", func() {
+			cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
+				func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
+					cd.ObjectMeta.Name = agent.Spec.ClusterDeploymentName.Name
+					cd.ObjectMeta.Namespace = testNamespace
+					cd.Spec.ClusterInstallRef = &hivev1.ClusterInstallLocalReference{
+						Group:   hiveext.Group,
+						Kind:    "AgentClusterInstall",
+						Name:    cd.Name,
+						Version: hiveext.Version,
+					}
+					return nil
 				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+			).AnyTimes()
+
+			aciKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			notFoundError := k8serrors.NewNotFound(schema.GroupResource{Group: hiveext.Group, Resource: "AgentClusterInstall"}, aciKey.Name)
+			mockClient.EXPECT().Get(ctx, aciKey, gomock.AssignableToTypeOf(&hiveext.AgentClusterInstall{})).Return(notFoundError).AnyTimes()
 
 			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
 			Expect(err).To(BeNil())
 			Expect(res).NotTo(BeNil())
-
-			err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("removes a machine without a machineset label", func() {
-			machineNSName := client.ObjectKey{
-				Name:      "machine0",
-				Namespace: "openshift-machine-api",
-			}
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        agentHostname,
-					Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+		It("doesn't remove the node when the agent cluster install is being deleted", func() {
+			cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
+				func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
+					cd.ObjectMeta.Name = agent.Spec.ClusterDeploymentName.Name
+					cd.ObjectMeta.Namespace = testNamespace
+					cd.Spec.ClusterInstallRef = &hivev1.ClusterInstallLocalReference{
+						Group:   hiveext.Group,
+						Kind:    "AgentClusterInstall",
+						Name:    cd.Name,
+						Version: hiveext.Version,
+					}
+					return nil
 				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+			).AnyTimes()
 
-			machine := &machinev1beta1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      machineNSName.Name,
+			aciKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+			mockClient.EXPECT().Get(ctx, aciKey, gomock.AssignableToTypeOf(&hiveext.AgentClusterInstall{})).DoAndReturn(
+				func(_ context.Context, key client.ObjectKey, aci *hiveext.AgentClusterInstall, _ ...client.GetOption) error {
+					now := metav1.Now()
+					aci.ObjectMeta.DeletionTimestamp = &now
+					return nil
+				},
+			).AnyTimes()
+
+			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+			Expect(err).To(BeNil())
+			Expect(res).NotTo(BeNil())
+		})
+
+		Context("with a fake spoke client", func() {
+			var (
+				fakeSpokeClient spoke_k8s_client.SpokeK8sClient
+			)
+
+			mockSpokeClient := func() {
+				cdKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+				mockClient.EXPECT().Get(ctx, cdKey, gomock.AssignableToTypeOf(&hivev1.ClusterDeployment{})).DoAndReturn(
+					func(_ context.Context, key client.ObjectKey, cd *hivev1.ClusterDeployment, _ ...client.GetOption) error {
+						cd.ObjectMeta.Name = agent.Spec.ClusterDeploymentName.Name
+						cd.ObjectMeta.Namespace = testNamespace
+						cd.Spec.ClusterInstallRef = &hivev1.ClusterInstallLocalReference{
+							Group:   hiveext.Group,
+							Kind:    "AgentClusterInstall",
+							Name:    cd.Name,
+							Version: hiveext.Version,
+						}
+						cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+							AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "clusterKubeConfig"},
+						}
+						return nil
+					},
+				).AnyTimes()
+
+				aciKey := types.NamespacedName{Name: agent.Spec.ClusterDeploymentName.Name, Namespace: testNamespace}
+				mockClient.EXPECT().Get(ctx, aciKey, gomock.AssignableToTypeOf(&hiveext.AgentClusterInstall{})).Return(nil).AnyTimes()
+
+				secretKey := types.NamespacedName{Name: "clusterKubeConfig", Namespace: testNamespace}
+				mockClient.EXPECT().Get(ctx, secretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(_ context.Context, key client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
+						secret.ObjectMeta.Labels = map[string]string{
+							BackupLabel:        "true",
+							WatchResourceLabel: "true",
+						}
+						secret.Data = map[string][]byte{"kubeconfig": []byte("definitely_a_kubeconfig")}
+						return nil
+					},
+				).AnyTimes()
+
+				mockClientFactory.EXPECT().CreateFromSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(secret *corev1.Secret) (spoke_k8s_client.SpokeK8sClient, error) {
+						Expect(secret.Data["kubeconfig"]).To(Equal([]byte("definitely_a_kubeconfig")))
+						return fakeSpokeClient, nil
+					},
+				).AnyTimes()
+			}
+
+			BeforeEach(func() {
+				schemes := GetKubeClientSchemes()
+				fakeClient := fakeclient.NewClientBuilder().WithScheme(schemes).Build()
+				fakeSpokeClient = fakeSpokeK8sClient{Client: fakeClient}
+				mockSpokeClient()
+			})
+
+			It("removes a node with no machine", func() {
+				node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: agentHostname}}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a node with an invalid machine annotation", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": "namewithoutaslash"},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a node referencing a missing machine", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/machine0"},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, client.ObjectKey{Name: agentHostname}, &corev1.Node{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a machine without a machineset label", func() {
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
+				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineNSName.Name,
+						Namespace: machineNSName.Namespace,
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("removes a machine referencing a missing machineset", func() {
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
+				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineNSName.Name,
+						Namespace: machineNSName.Namespace,
+						Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "machineset0"},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
+
+				err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("annotates a machine and machineset for autoscaling and removes the BMH", func() {
+				bmhNSName := client.ObjectKey{
+					Name:      "host0",
+					Namespace: "openshift-machine-api",
+				}
+				bmh := &bmh_v1alpha1.BareMetalHost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      bmhNSName.Name,
+						Namespace: bmhNSName.Namespace,
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, bmh)).To(Succeed())
+
+				machineNSName := client.ObjectKey{
+					Name:      "machine0",
+					Namespace: "openshift-machine-api",
+				}
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        agentHostname,
+						Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+
+				machineSetNSName := client.ObjectKey{
+					Name:      "machineset0",
 					Namespace: machineNSName.Namespace,
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+				}
+				machine := &machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        machineNSName.Name,
+						Namespace:   machineNSName.Namespace,
+						Labels:      map[string]string{"machine.openshift.io/cluster-api-machineset": machineSetNSName.Name},
+						Annotations: map[string]string{"metal3.io/BareMetalHost": bmhNSName.String()},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
 
-			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-			Expect(err).To(BeNil())
-			Expect(res).NotTo(BeNil())
+				machineSet := &machinev1beta1.MachineSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineSetNSName.Name,
+						Namespace: machineSetNSName.Namespace,
+					},
+					Spec: machinev1beta1.MachineSetSpec{
+						Selector: metav1.LabelSelector{MatchLabels: machine.Labels},
+					},
+				}
+				Expect(fakeSpokeClient.Create(ctx, machineSet)).To(Succeed())
 
-			err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-		})
+				res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
+				Expect(err).To(BeNil())
+				Expect(res).NotTo(BeNil())
 
-		It("removes a machine referencing a missing machineset", func() {
-			machineNSName := client.ObjectKey{
-				Name:      "machine0",
-				Namespace: "openshift-machine-api",
-			}
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        agentHostname,
-					Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
+				Expect(fakeSpokeClient.Get(ctx, machineNSName, machine)).To(Succeed())
+				Expect(fakeSpokeClient.Get(ctx, machineSetNSName, machineSet)).To(Succeed())
 
-			machine := &machinev1beta1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      machineNSName.Name,
-					Namespace: machineNSName.Namespace,
-					Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "machineset0"},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
+				Expect(machine.Annotations).To(HaveKey("machine.openshift.io/delete-machine"))
+				Expect(machine.Annotations).To(HaveKey("machine.openshift.io/exclude-node-draining"))
+				Expect(machineSet.Annotations).To(HaveKey("metal3.io/autoscale-to-hosts"))
 
-			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-			Expect(err).To(BeNil())
-			Expect(res).NotTo(BeNil())
-
-			err = fakeSpokeClient.Get(ctx, machineNSName, &machinev1beta1.Machine{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-		})
-
-		It("annotates a machine and machineset for autoscaling and removes the BMH", func() {
-			bmhNSName := client.ObjectKey{
-				Name:      "host0",
-				Namespace: "openshift-machine-api",
-			}
-			bmh := &bmh_v1alpha1.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      bmhNSName.Name,
-					Namespace: bmhNSName.Namespace,
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, bmh)).To(Succeed())
-
-			machineNSName := client.ObjectKey{
-				Name:      "machine0",
-				Namespace: "openshift-machine-api",
-			}
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        agentHostname,
-					Annotations: map[string]string{"machine.openshift.io/machine": machineNSName.String()},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, node)).To(Succeed())
-
-			machineSetNSName := client.ObjectKey{
-				Name:      "machineset0",
-				Namespace: machineNSName.Namespace,
-			}
-			machine := &machinev1beta1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        machineNSName.Name,
-					Namespace:   machineNSName.Namespace,
-					Labels:      map[string]string{"machine.openshift.io/cluster-api-machineset": machineSetNSName.Name},
-					Annotations: map[string]string{"metal3.io/BareMetalHost": bmhNSName.String()},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, machine)).To(Succeed())
-
-			machineSet := &machinev1beta1.MachineSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      machineSetNSName.Name,
-					Namespace: machineSetNSName.Namespace,
-				},
-				Spec: machinev1beta1.MachineSetSpec{
-					Selector: metav1.LabelSelector{MatchLabels: machine.Labels},
-				},
-			}
-			Expect(fakeSpokeClient.Create(ctx, machineSet)).To(Succeed())
-
-			res, err := r.handleAgentFinalizer(ctx, common.GetTestLog(), agent)
-			Expect(err).To(BeNil())
-			Expect(res).NotTo(BeNil())
-
-			Expect(fakeSpokeClient.Get(ctx, machineNSName, machine)).To(Succeed())
-			Expect(fakeSpokeClient.Get(ctx, machineSetNSName, machineSet)).To(Succeed())
-
-			Expect(machine.Annotations).To(HaveKey("machine.openshift.io/delete-machine"))
-			Expect(machine.Annotations).To(HaveKey("machine.openshift.io/exclude-node-draining"))
-			Expect(machineSet.Annotations).To(HaveKey("metal3.io/autoscale-to-hosts"))
-
-			err = fakeSpokeClient.Get(ctx, bmhNSName, &bmh_v1alpha1.BareMetalHost{})
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				err = fakeSpokeClient.Get(ctx, bmhNSName, &bmh_v1alpha1.BareMetalHost{})
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
 		})
 	})
 })


### PR DESCRIPTION
The intention in the agent controller was to only remove the spoke resources when the entire cluster was not being removed. This was previously done my check the cluster deployment, but the agent cluster install is what actually triggers the agent removal. This means that we really should be checking both resources to avoid a race when everything is removed at the same time.

Before this change it was possible for a node or two to be removed before the deletion timestamp was set on the cluster deployment. Now this will no longer happen as one of the resources will need to be marked as deleted before any agent gets removed.

Resolves https://issues.redhat.com/browse/ACM-17877

Manual cherry-pick of https://github.com/openshift/assisted-service/pull/7303

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
