### PR TITLE
MGMT-19622: Proxy setting with special characters are ignored when minimal ISO is used

### DIFF
--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/cavaliercoder/go-cpio"
@@ -92,8 +93,8 @@ func RamdiskImageArchive(netFiles []staticnetworkconfig.StaticNetworkConfigData,
 
 func formatRootfsServiceConfigFile(clusterProxyInfo *ClusterProxyInfo) (string, error) {
 	var rootfsServicConfigParams = map[string]string{
-		"HTTP_PROXY":  clusterProxyInfo.HTTPProxy,
-		"HTTPS_PROXY": clusterProxyInfo.HTTPSProxy,
+		"HTTP_PROXY":  strings.ReplaceAll(clusterProxyInfo.HTTPProxy, "%", "%%"),
+		"HTTPS_PROXY": strings.ReplaceAll(clusterProxyInfo.HTTPSProxy, "%", "%%"),
 		"NO_PROXY":    clusterProxyInfo.NoProxy,
 	}
 	tmpl, err := template.New("rootfsServiceConfig").Parse(rootfsServiceConfigFormat)


### PR DESCRIPTION
This PR is to solve an issue where discovering nodes with minimal iso and authenticated proxy with special characters will fail, same as #6356, need to escape '%' with '%%' in order to properly pass the Environment variables to coreos-livepxe-rootfs service in order to properly boot the node with minimal iso

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
