### PR TITLE
OCPEDGE-1311: add two node openshift deployment

### DIFF
--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -112,6 +112,18 @@ func (i *installConfigBuilder) getBasicInstallConfig(cluster *common.Cluster) (*
 		SSHKey:     cluster.SSHPublicKey,
 	}
 
+	if cfg.ControlPlane.Replicas == 2 {
+		cfg.Arbiter = struct {
+			Hyperthreading string `json:"hyperthreading,omitempty"`
+			Name           string `json:"name"`
+			Replicas       int    `json:"replicas"`
+		}{
+			Hyperthreading: i.getHypethreadingConfiguration(cluster, "master"),
+			Name:           string(models.HostRoleArbiter),
+			Replicas:       1,
+		}
+	}
+
 	cfg.Networking.NetworkType = networkType
 
 	for _, network := range cluster.ClusterNetworks {

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -233,6 +233,11 @@ type InstallerConfigBaremetal struct {
 		Name           string `json:"name"`
 		Replicas       int    `json:"replicas"`
 	} `json:"controlPlane"`
+	Arbiter struct {
+		Hyperthreading string `json:"hyperthreading,omitempty"`
+		Name           string `json:"name"`
+		Replicas       int    `json:"replicas"`
+	} `json:"arbiter"`
 	Platform              Platform            `json:"platform"`
 	BootstrapInPlace      *BootstrapInPlace   `json:"bootstrapInPlace,omitempty"`
 	FIPS                  bool                `json:"fips"`

--- a/models/host_role.go
+++ b/models/host_role.go
@@ -41,6 +41,9 @@ const (
 
 	// HostRoleBootstrap captures enum value "bootstrap"
 	HostRoleBootstrap HostRole = "bootstrap"
+
+	// HostRoleArbiter captures enum value "arbiter"
+	HostRoleArbiter HostRole = "arbiter"
 )
 
 // for schema
@@ -48,7 +51,7 @@ var hostRoleEnum []interface{}
 
 func init() {
 	var res []HostRole
-	if err := json.Unmarshal([]byte(`["auto-assign","master","worker","bootstrap"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["auto-assign","master","worker","bootstrap","arbiter"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6609,6 +6609,7 @@ definitions:
       - 'master'
       - 'worker'
       - 'bootstrap'
+      - 'arbiter'
 
   host-validation-id:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/host_role.go
+++ b/vendor/github.com/openshift/assisted-service/models/host_role.go
@@ -41,6 +41,9 @@ const (
 
 	// HostRoleBootstrap captures enum value "bootstrap"
 	HostRoleBootstrap HostRole = "bootstrap"
+
+	// HostRoleArbiter captures enum value "arbiter"
+	HostRoleArbiter HostRole = "arbiter"
 )
 
 // for schema
@@ -48,7 +51,7 @@ var hostRoleEnum []interface{}
 
 func init() {
 	var res []HostRole
-	if err := json.Unmarshal([]byte(`["auto-assign","master","worker","bootstrap"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["auto-assign","master","worker","bootstrap","arbiter"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
Add new deployment type to the assisted service called two node with arbiter(TNA). Install config changes are made according to https://github.com/openshift/enhancements/pull/1674 proposal

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
