### PR TITLE
[release-ocm-2.11] ACM-17953: Don't remove spoke resources when cluster is being deleted

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -32,6 +32,7 @@ import (
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	. "github.com/openshift/assisted-service/api/common"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
@@ -453,6 +454,8 @@ func (r *AgentReconciler) handleAgentFinalizer(ctx context.Context, log logrus.F
 					if err := r.removeSpokeResources(ctx, log, agent); err != nil {
 						return &ctrl.Result{}, errors.Wrap(err, "failed to clean spoke cluster resources")
 					}
+				} else {
+					log.Info("skipping spoke resource removal for deleted cluster")
 				}
 			}
 			// deletion finalizer found, deregister the backend host and delete the agent
@@ -566,8 +569,20 @@ func (r *AgentReconciler) clusterExists(ctx context.Context, agent *aiv1beta1.Ag
 	if err := r.Client.Get(ctx, cdKey, cd); err != nil {
 		return false, client.IgnoreNotFound(err)
 	}
+	if !cd.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
 
-	return cd.DeletionTimestamp.IsZero(), nil
+	if cd.Spec.ClusterInstallRef == nil {
+		return false, fmt.Errorf("failed to check agent cluster install existence, cluster install ref is empty")
+	}
+	aciRef := types.NamespacedName{Name: cd.Spec.ClusterInstallRef.Name, Namespace: cd.Namespace}
+	aci := &hiveext.AgentClusterInstall{}
+	if err := r.Client.Get(ctx, aciRef, aci); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	return aci.DeletionTimestamp.IsZero(), nil
 }
 
 func (r *AgentReconciler) shouldReclaimOnUnbind(ctx context.Context, agent *aiv1beta1.Agent) bool {


### PR DESCRIPTION
The intention in the agent controller was to only remove the spoke resources when the entire cluster was not being removed. This was previously done my check the cluster deployment, but the agent cluster install is what actually triggers the agent removal. This means that we really should be checking both resources to avoid a race when everything is removed at the same time.

Before this change it was possible for a node or two to be removed before the deletion timestamp was set on the cluster deployment. Now this will no longer happen as one of the resources will need to be marked as deleted before any agent gets removed.

Resolves https://issues.redhat.com/browse/ACM-17953

Manual cherry-pick of https://github.com/openshift/assisted-service/pull/7303

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
