### PR TITLE
MGMT-20057: Add NFD operator to OpenShift AI NVIDIA bundle

### DIFF
--- a/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
+++ b/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
@@ -5,8 +5,10 @@ import (
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/lib/pq"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
+	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
 	"github.com/openshift/assisted-service/internal/templating"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -18,6 +20,9 @@ var Operator = models.MonitoredOperator{
 	OperatorType:     models.OperatorTypeOlm,
 	SubscriptionName: "nfd",
 	TimeoutSeconds:   30 * 60,
+	Bundles: pq.StringArray{
+		operatorscommon.BundleOpenShiftAINVIDIA.ID,
+	},
 }
 
 // operator is an node feature discovery OLM operator plugin.


### PR DESCRIPTION
Currently the node feature discovery operator isn't explicitly added to the OpenShift AI NVIDIA bundle. The reasoning for that is that it is a dependency of the NVIDIA GPU operator, so in the backend that isn't necessary. But the UI isn't aware of this dependency, only of the list of operators that are part of the bundle. To address the associated issues this patch adds the operator explicitly to the bundle.

## List all the issues related to this PR

Related: https://issues.redhat.com/browse/MGMT-20057

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
