### PR TITLE
MGMT-20095: Remove KMM operator from OpenShift AI NVIDIA bundle

### DIFF
--- a/internal/operators/kmm/kmm_operator.go
+++ b/internal/operators/kmm/kmm_operator.go
@@ -22,7 +22,6 @@ var Operator = models.MonitoredOperator{
 	TimeoutSeconds:   30 * 60,
 	Bundles: pq.StringArray{
 		operatorscommon.BundleOpenShiftAIAMD.ID,
-		operatorscommon.BundleOpenShiftAINVIDIA.ID,
 	},
 }
 


### PR DESCRIPTION
This isn't needed, it is only needed by the OpenShift AI AMD bundle, was added by accident.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-20095

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Manually tested that the operator bundles endpoint doesn't return the KMM operator for the NVIDIA bundle.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
