### PR TITLE
MGMT-20099: add nmstate to /v2/supported-operators

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6013,7 +6013,8 @@ func init() {
                   "lvm",
                   "mce",
                   "node_feature_discovery",
-                  "serverless"
+                  "serverless",
+                  "nmstate"
                 ]
               }
             }
@@ -16985,7 +16986,8 @@ func init() {
                   "lvm",
                   "mce",
                   "node_feature_discovery",
-                  "serverless"
+                  "serverless",
+                  "nmstate"
                 ]
               }
             }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2718,6 +2718,7 @@ paths:
               - 'mce'
               - 'node_feature_discovery'
               - 'serverless'
+              - 'nmstate'
         "401":
           description: Unauthorized.
           schema:


### PR DESCRIPTION
[MGMT-20099](https://issues.redhat.com//browse/MGMT-20099): add nmstate to /v2/supported-operators
nmstate was missing from the list of supported operators

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
