### PR TITLE
MGMT-20134: Disable OLM Catalog for CAPI CI tests

### DIFF
--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -145,6 +145,10 @@ EOM
     # 7. reference the control plane operator image in the mirrored registry which will be added as a CLI flag when creating the hosted cluster
     export CONTROL_PLANE_OPERATOR_IMAGE=$(oc adm release info "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}" --image-for hypershift)
     export CONTROL_PLANE_OPERATOR_IMAGE="${OCP_MIRROR_REGISTRY}@$(oc image info $CONTROL_PLANE_OPERATOR_IMAGE -ojson | jq -r '.digest')"
+
+    # disconnected hypershift starting from ACM 2.13/MCE 2.8 requires the olm catalog be explicitly disabled and placed on the guest cluster
+    # or it'll block the nodepool from deploying properly, which will prevent installing any hosts to the hosted cluster.
+    export EXTRA_HYPERSHIFT_CREATE_COMMANDS="$EXTRA_HYPERSHIFT_CREATE_COMMANDS --olm-catalog-placement Guest --olm-disable-default-sources"
 fi
 
 # TODO: make SSH public key configurable


### PR DESCRIPTION
Starting from ACM 2.13/MCE 2.8, Hypershift
blocks and prevents installation of hosts to a hosted cluster if the catalog sources are unreachable,
which will always happen in the disconnected case unless the catalog is mirrored.

To resolve this, the OLM catalog will now be disabled during the hosted cluster creation and the OLM catalog is now set to guest mode.

---
Note: this will need to be backported to ACM 2.13 branch
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): Tested on rehearsal CI
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
