### PR TITLE
MGMT-18437: Consumer label on AgentClusterInstall to identify clusters used by CAPI providers

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -82,6 +82,8 @@ const (
 	ClusterLastInstallationPreparationFailedErrorReason string                             = "The last installation preparation failed"
 	ClusterLastInstallationPreparationPending           string                             = "Cluster preparation has never been performed for this cluster"
 	ClusterLastInstallationPreparationFailedCondition   hivev1.ClusterInstallConditionType = "LastInstallationPreparationFailed"
+
+	ClusterConsumerLabel string = "agentclusterinstalls.agent-install.openshift.io/consumer"
 )
 
 // +genclient

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1176,6 +1176,11 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(
 		update = true
 	}
 
+	if label, exists := clusterInstall.GetLabels()[hiveext.ClusterConsumerLabel]; exists && label != cluster.Tags {
+		params.Tags = &label
+		update = true
+	}
+
 	if !update {
 		return cluster, nil
 	}
@@ -1462,6 +1467,10 @@ func CreateClusterParams(clusterDeployment *hivev1.ClusterDeployment, clusterIns
 
 	if len(olmOperators) != 0 {
 		clusterParams.OlmOperators = olmOperators
+	}
+
+	if label, exists := clusterInstall.GetLabels()[hiveext.ClusterConsumerLabel]; exists && label != "" {
+		clusterParams.Tags = &label
 	}
 
 	return clusterParams

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1287,6 +1287,19 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(params.CPUArchitecture).To(Equal(cpuArch))
 			Expect(params.OpenshiftVersion).To(Equal(&openshiftVersion))
 		})
+
+		It("create new param with consumer label and tags - success", func() {
+			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+			aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cluster)
+			aci.Labels = map[string]string{hiveext.ClusterConsumerLabel: "CAPIOpenshiftAssisted"}
+
+			params := CreateClusterParams(cluster, aci, "", "4.10.0-rc1", "x86_64", nil, nil)
+			Expect(params.Name).To(Equal(&cluster.Spec.ClusterName))
+			Expect(params.Tags).NotTo(BeNil())
+			Expect(*params.Tags).To((Equal("CAPIOpenshiftAssisted")))
+		})
 	})
 
 	Context("Add validationsInfo to agentclusterinstall", func() {

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -82,6 +82,8 @@ const (
 	ClusterLastInstallationPreparationFailedErrorReason string                             = "The last installation preparation failed"
 	ClusterLastInstallationPreparationPending           string                             = "Cluster preparation has never been performed for this cluster"
 	ClusterLastInstallationPreparationFailedCondition   hivev1.ClusterInstallConditionType = "LastInstallationPreparationFailed"
+
+	ClusterConsumerLabel string = "agentclusterinstalls.agent-install.openshift.io/consumer"
 )
 
 // +genclient


### PR DESCRIPTION
Defines the label `"agentclusterinstalls.agent-install.openshift.io/consumer"` in the `AgentClusterInstall` that can be set by the CAPI OpenshiftAssisted providers to indicate the cluster is used by these providers. 

The value of the label is added to the `tags` field of the cluster, which is sent with the cluster data during on-prem data collection

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @rccrdpccl 
