### PR TITLE
MGMT-19297: Error when querying /events endpoint with ?host_ids=uuid1…

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -427,11 +427,6 @@ func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParam
 
 	events := []*common.Event{}
 
-	// add authorization check to query
-	if e.authz != nil {
-		tx = e.authz.OwnedBy(ctx, tx)
-	}
-
 	tx = e.prepareEventsTable(ctx, tx, params.ClusterID, params.HostIds, params.InfraEnvID, params.Severities, params.Message, params.DeletedHosts)
 	if tx == nil {
 		return make([]*common.Event, 0), &common.EventSeverityCount{}, swag.Int64(0), nil
@@ -468,6 +463,10 @@ func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParam
 	params.Limit, params.Offset = preparePaginationParams(params.Limit, params.Offset)
 	if *params.Limit == 0 {
 		return make([]*common.Event, 0), eventSeverityCount, &eventCount, nil
+	}
+
+	if e.authz != nil && !e.authz.IsAdmin(ctx) {
+		tx = e.authz.OwnedBy(ctx, cleanQuery.Table("(?) as s", tx))
 	}
 
 	err = tx.Offset(int(*params.Offset)).Limit(int(*params.Limit)).Find(&events).Error

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -570,6 +570,16 @@ var _ = Describe("Events library", func() {
 				evs := response.GetEvents()
 				Expect(len(evs)).To(Equal(0))
 			})
+
+			It("can fetch events by host id when org tenancy is not enabled", func() {
+				cfg := &auth.Config{AuthType: auth.TypeRHSSO, EnableOrgTenancy: false}
+				authz_handler := auth.NewAuthzHandler(cfg, nil, logrus.New(), db)
+				theEvents.(*Events).authz = authz_handler
+				response, err := theEvents.V2GetEvents(ctx, common.GetDefaultV2GetEventsParams(nil, []strfmt.UUID{host}, nil))
+				Expect(err).ShouldNot(HaveOccurred())
+				evs := response.GetEvents()
+				Expect(len(evs)).To(Equal(2))
+			})
 		})
 	})
 


### PR DESCRIPTION

Fixes an SQL ambiguity issue when querying the /events endpoint with host_ids using `RHSSO` authentication. The ambiguity arises due to joins between `infra_envs`, hosts, and clusters, causing column name conflicts (e.g., `user_name`, `org_id`).

This change ensures the authorization check is applied after the main query by wrapping it in a subquery, preventing conflicts while maintaining access control. Also includes a test case to verify event retrieval by host ID when org tenancy is disabled.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
