### PR TITLE
MGMT-20207: avoid adding system CA bundle to AdditionalTrustBundle

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -28,7 +28,10 @@ const (
 
 	consoleUrlPrefix = "https://console-openshift-console.apps"
 
-	MirrorRegistriesCertificateFile = "tls-ca-bundle.pem"
+	SystemCertificateBundle     = "tls-ca-bundle.pem"
+	SystemCertificateBundlePath = "/etc/pki/ca-trust/extracted/pem/" + SystemCertificateBundle
+
+	MirrorRegistriesCertificateFile = "user-registry-ca-bundle.pem"
 	MirrorRegistriesCertificatePath = "/etc/pki/ca-trust/extracted/pem/" + MirrorRegistriesCertificateFile
 	MirrorRegistriesConfigDir       = "/etc/containers"
 	MirrorRegistriesConfigFile      = "registries.conf"

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1854,7 +1854,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						Items: []corev1.KeyToPath{{
 							Key:  caBundleKey,
-							Path: common.MirrorRegistriesCertificateFile,
+							Path: common.SystemCertificateBundle,
 						}},
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: assistedCAConfigMapName,
@@ -1868,8 +1868,8 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			corev1.VolumeMount{Name: "tls-certs", MountPath: "/etc/assisted-tls-config"},
 			corev1.VolumeMount{
 				Name:      "trusted-ca-certs",
-				MountPath: common.MirrorRegistriesCertificatePath,
-				SubPath:   common.MirrorRegistriesCertificateFile,
+				MountPath: common.SystemCertificateBundlePath,
+				SubPath:   common.SystemCertificateBundle,
 			},
 		)
 		healthCheckScheme = corev1.URISchemeHTTPS
@@ -1983,7 +1983,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			return nil, nil, pkgerror.Wrapf(err, "Unable to mark mirror configmap for backup")
 		}
 
-		volume := corev1.Volume{
+		registriesConfVolume := corev1.Volume{
 			Name: mirrorRegistryConfigVolume,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1999,16 +1999,37 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			},
 		}
 
+		caBundleVolume := corev1.Volume{
+			Name: mirrorRegistryCertBundleVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: *asc.spec.MirrorRegistryRef,
+					DefaultMode:          swag.Int32(420),
+					Items: []corev1.KeyToPath{
+						{
+							Key:  mirrorRegistryRefCertKey,
+							Path: common.MirrorRegistriesCertificateFile,
+						},
+					},
+				},
+			},
+		}
+
 		serviceContainer.VolumeMounts = append(
 			serviceContainer.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      mirrorRegistryConfigVolume,
 				MountPath: common.MirrorRegistriesConfigDir,
 			},
+			corev1.VolumeMount{
+				Name:      mirrorRegistryCertBundleVolume,
+				MountPath: common.MirrorRegistriesCertificatePath,
+				SubPath:   common.MirrorRegistriesCertificateFile,
+			},
 		)
 
 		// add our mirror registry config to volumes
-		volumes = append(volumes, volume)
+		volumes = append(volumes, registriesConfVolume, caBundleVolume)
 	}
 
 	deploymentLabels := map[string]string{

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1699,7 +1699,7 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 
 				found := &appsv1.Deployment{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
-				Expect(found.Spec.Template.Spec.Volumes).To(HaveLen(6))
+				Expect(found.Spec.Template.Spec.Volumes).To(HaveLen(7))
 				Expect(found.Spec.Template.Spec.Containers[0].VolumeMounts).Should(ContainElement(
 					corev1.VolumeMount{
 						Name:      mirrorRegistryConfigVolume,
@@ -1759,7 +1759,7 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 
 				found := &appsv1.Deployment{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
-				Expect(found.Spec.Template.Spec.Volumes).To(HaveLen(6))
+				Expect(found.Spec.Template.Spec.Volumes).To(HaveLen(7))
 				Expect(found.Spec.Template.Spec.Volumes).To(ContainElement(
 					corev1.Volume{
 						Name: "trusted-ca-certs",
@@ -1767,10 +1767,27 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								Items: []corev1.KeyToPath{{
 									Key:  caBundleKey,
-									Path: common.MirrorRegistriesCertificateFile,
+									Path: common.SystemCertificateBundle,
 								}},
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: assistedCAConfigMapName,
+								},
+								DefaultMode: swag.Int32(420),
+							},
+						},
+					},
+				))
+				Expect(found.Spec.Template.Spec.Volumes).To(ContainElement(
+					corev1.Volume{
+						Name: mirrorRegistryCertBundleVolume,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								Items: []corev1.KeyToPath{{
+									Key:  mirrorRegistryRefCertKey,
+									Path: common.MirrorRegistriesCertificateFile,
+								}},
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: testMirrorRegConfigmapName,
 								},
 								DefaultMode: swag.Int32(420),
 							},
@@ -1787,6 +1804,13 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 				Expect(found.Spec.Template.Spec.Containers[0].VolumeMounts).Should(ContainElement(
 					corev1.VolumeMount{
 						Name:      "trusted-ca-certs",
+						MountPath: common.SystemCertificateBundlePath,
+						SubPath:   common.SystemCertificateBundle,
+					}),
+				)
+				Expect(found.Spec.Template.Spec.Containers[0].VolumeMounts).Should(ContainElement(
+					corev1.VolumeMount{
+						Name:      mirrorRegistryCertBundleVolume,
 						MountPath: common.MirrorRegistriesCertificatePath,
 						SubPath:   common.MirrorRegistriesCertificateFile,
 					}),

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -50,6 +50,7 @@ const (
 	mirrorRegistryRefCertKey         = caBundleKey
 	mirrorRegistryRefRegistryConfKey = "registries.conf"
 	mirrorRegistryConfigVolume       = "mirror-registry-config"
+	mirrorRegistryCertBundleVolume   = "mirror-registry-ca-bundle"
 	WatchResourceLabel               = "agent-install.openshift.io/watch"
 	WatchResourceValue               = "true"
 	BackupLabel                      = "cluster.open-cluster-management.io/backup"

--- a/pkg/mirrorregistries/generator.go
+++ b/pkg/mirrorregistries/generator.go
@@ -18,12 +18,14 @@ type ServiceMirrorRegistriesConfigBuilder interface {
 type mirrorRegistriesConfigBuilder struct {
 	MirrorRegistriesConfigPath      string
 	MirrorRegistriesCertificatePath string
+	SystemCertificateBundlePath     string
 }
 
 func New() ServiceMirrorRegistriesConfigBuilder {
 	return &mirrorRegistriesConfigBuilder{
 		MirrorRegistriesConfigPath:      common.MirrorRegistriesConfigPath,
 		MirrorRegistriesCertificatePath: common.MirrorRegistriesCertificatePath,
+		SystemCertificateBundlePath:     common.SystemCertificateBundlePath,
 	}
 }
 
@@ -59,7 +61,12 @@ func (m *mirrorRegistriesConfigBuilder) IsMirrorRegistriesConfigured() bool {
 // the mirror registries are not configured.
 // empty dir is due to the way we mao configmap in the assisted-service pod
 func (m *mirrorRegistriesConfigBuilder) GetMirrorCA() ([]byte, error) {
-	return os.ReadFile(m.MirrorRegistriesCertificatePath)
+	bytes, err := os.ReadFile(m.MirrorRegistriesCertificatePath)
+	if err != nil {
+		// fallback to tls-ca-bundle.pem (used by ABI)
+		return os.ReadFile(m.SystemCertificateBundlePath)
+	}
+	return bytes, nil
 }
 
 // GetMirrorRegistries returns error if the file is not present, which will also indicate that

--- a/pkg/mirrorregistries/mirror_registry_test.go
+++ b/pkg/mirrorregistries/mirror_registry_test.go
@@ -132,6 +132,56 @@ var _ = Describe("Generator tests", func() {
 		})
 	})
 
+	var _ = Describe("GetMirrorCA", func() {
+		var (
+			tempRegistryCA *os.File
+			tempSystemCA   *os.File
+			m              mirrorRegistriesConfigBuilder
+			err            error
+		)
+
+		BeforeEach(func() {
+			tempRegistryCA, err = os.CreateTemp(os.TempDir(), "user-registry-ca-bundle.pem")
+			Expect(err).NotTo(HaveOccurred())
+			_, _ = tempRegistryCA.WriteString("registry CA bundle")
+
+			tempSystemCA, err = os.CreateTemp(os.TempDir(), "tls-ca-bundle.pem")
+			Expect(err).NotTo(HaveOccurred())
+			_, _ = tempSystemCA.WriteString("system CA bundle")
+		})
+
+		It("should return registry bundle when registry bundle exists", func() {
+			m = mirrorRegistriesConfigBuilder{
+				MirrorRegistriesCertificatePath: tempRegistryCA.Name(),
+			}
+
+			result, err := m.GetMirrorCA()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).To(Equal([]byte("registry CA bundle")))
+		})
+
+		It("should return the system CA bundle when registry bundle doesn't exist", func() {
+			m = mirrorRegistriesConfigBuilder{
+				MirrorRegistriesCertificatePath: "/tmp/does-not-exist",
+				SystemCertificateBundlePath:     tempSystemCA.Name(),
+			}
+
+			result, err := m.GetMirrorCA()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).To(Equal([]byte("system CA bundle")))
+		})
+
+		It("should return an error if both files don't exist", func() {
+			m = mirrorRegistriesConfigBuilder{
+				MirrorRegistriesCertificatePath: "/tmp/does-not-exist",
+				SystemCertificateBundlePath:     "/tmp/does-not-exist",
+			}
+
+			result, err := m.GetMirrorCA()
+			Expect(err).Should(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
 })
 
 const (


### PR DESCRIPTION
When generating the install config, it should not include the entire system CA bundle. I.e. when setting the AdditionalTrustBundle[1]. However, when using a mirror regsitry (e.g. with MirrorRegistryRef[2] in ASC), the installConfigBuilder is adding the content of tls-ca-bundle.pem[3]. This pem file is created[4] by ASC controller, and includes the full system CA bundle since the bundle[5] is injected into 'cluster-trusted-ca-bundle'.

Therefore, the suggestion solution is to create a separate pem file just for the certificates specified in MirrorRegistryRef. I.e. generate a new 'user-registry-ca-bundle.pem' file, that will be included as part of AdditionalTrustBundle. These certificates will propagate into the 'user-ca-bundle' CM during cluster installation.
This will ensure that 'user-ca-bundle' CM indeed includes only custom certificates mandatory for the user, instead of the system CA bundle.

Note: as backwards compatibility, for flows like ABI, we keep a fallback to the current behaviour (i.e. include 'tls-ca-bundle.pem' only when 'user-registry-ca-bundle.pem' doesn't exist).

[1] https://github.com/openshift/assisted-service/blob/40ab10db5e872e519ab0a97e82fc318423feeaba/internal/installcfg/builder/builder.go#L275
[2] https://github.com/openshift/assisted-service/blob/cb169a2d2c97bb3dccd06ad4b75f2937e01f78f4/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go#L82
[3] https://github.com/openshift/assisted-service/blob/a1c3229afee1f0f774b286283fb0d0098b9eac03/internal/common/common.go#L35
[4] https://github.com/openshift/assisted-service/blob/341f9860c455cccc42741f350024d05aa72755f8/internal/controller/controllers/agentserviceconfig_controller.go#L1848
[5] https://github.com/openshift/assisted-service/blob/341f9860c455cccc42741f350024d05aa72755f8/internal/controller/controllers/agentserviceconfig_controller.go#L1059

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
