### PR TITLE
MGMT-20216: Remove memory and CPU requirements

### DIFF
--- a/internal/operators/nmstate/config.go
+++ b/internal/operators/nmstate/config.go
@@ -9,13 +9,4 @@ const (
 	SourceName                 = "kubernetes-nmstate-operator"
 	GroupName                  = "openshift-nmstate"
 	NmstateMinOpenshiftVersion = "4.12.0"
-
-	// Memory value provided in MiB
-	MasterMemory int64 = 100
-	// TODO: change to 0.3 when float values would be accepted for ClusterHostRequirementsDetails.CPUCores
-	MasterCPU int64 = 0
-	// Memory value provided in MiB
-	WorkerMemory int64 = 100
-	// TODO: change to 0.3 when float values would be accepted for ClusterHostRequirementsDetails.CPUCores
-	WorkerCPU int64 = 0
 )

--- a/internal/operators/nmstate/operator_test.go
+++ b/internal/operators/nmstate/operator_test.go
@@ -1,24 +1,14 @@
 package nmstate
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/conversions"
 )
 
 var _ = Describe("NMState Operator", func() {
-	const (
-		// TODO: change to 0.3 when float values would be accepted for ClusterHostRequirementsDetails.CPUCores
-		minCpu    = 0
-		minRamMib = 100
-	)
-
 	var (
 		log      = common.GetTestLog()
 		operator api.Operator
@@ -47,107 +37,4 @@ var _ = Describe("NMState Operator", func() {
 			Expect(operator.GetBundleLabels()).To(Equal(bundle))
 		})
 	})
-
-	Context("host requirements", func() {
-		BeforeEach(func() {
-			operator = NewNmstateOperator(log)
-		})
-
-		var cluster common.Cluster
-
-		BeforeEach(func() {
-			cluster = common.Cluster{
-				Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode},
-			}
-		})
-
-		DescribeTable("should return minimum requirements", func(role models.HostRole, expectedRequirements *models.ClusterHostRequirementsDetails) {
-			host := models.Host{Role: role}
-
-			requirements, err := operator.GetHostRequirements(context.TODO(), &cluster, &host)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(requirements).ToNot(BeNil())
-			Expect(requirements).To(BeEquivalentTo(expectedRequirements))
-
-		},
-			Entry("min requirements", models.HostRoleMaster, newRequirements(minCpu, minRamMib)),
-			Entry("min requirements", models.HostRoleWorker, newRequirements(minCpu, minRamMib)),
-		)
-
-	})
-
-	Context("Host validation", func() {
-		BeforeEach(func() {
-			operator = NewNmstateOperator(log)
-		})
-
-		var cluster common.Cluster
-
-		BeforeEach(func() {
-			cluster = common.Cluster{
-				Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode},
-			}
-		})
-
-		It("should pass when master has enough resources", func() {
-			host := models.Host{Role: models.HostRoleMaster, Inventory: getInventory(int64(1024))}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Success))
-		})
-
-		It("should pass when worker has enough resources", func() {
-			host := models.Host{Role: models.HostRoleWorker, Inventory: getInventory(int64(1024))}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Success))
-		})
-
-		It("should fail when master not enough memory", func() {
-			host := models.Host{Role: models.HostRoleMaster, Inventory: getInventory(int64(50))}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Failure))
-		})
-
-		It("should fail when worker not enough memory", func() {
-			host := models.Host{Role: models.HostRoleWorker, Inventory: getInventory(int64(50))}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Failure))
-		})
-
-		It("should fail if no master node inventory was provided", func() {
-			host := models.Host{Role: models.HostRoleMaster}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Pending))
-		})
-
-		It("should fail if no worker node inventory was provided", func() {
-			host := models.Host{Role: models.HostRoleWorker}
-
-			result, err := operator.ValidateHost(context.TODO(), &cluster, &host, nil)
-			Expect(err).To(BeNil())
-			Expect(result.Status).To(Equal(api.Pending))
-		})
-
-	})
 })
-
-func newRequirements(cpuCores int64, ramMib int64) *models.ClusterHostRequirementsDetails {
-	return &models.ClusterHostRequirementsDetails{CPUCores: cpuCores, RAMMib: ramMib}
-}
-
-func getInventory(memMiB int64) string {
-	inventory := models.Inventory{CPU: &models.CPU{Architecture: "x86_64", Count: 1}, Memory: &models.Memory{UsableBytes: conversions.MibToBytes(memMiB)}}
-	inventoryJSON, err := common.MarshalInventory(&inventory)
-	Expect(err).ToNot(HaveOccurred())
-	return inventoryJSON
-}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -3625,14 +3625,6 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 			CPUCores: 8,
 			RAMMib:   conversions.GibToMib(32),
 		}
-		masterNMStateRequirements = models.ClusterHostRequirementsDetails{
-			CPUCores: nmstate.MasterCPU,
-			RAMMib:   nmstate.MasterMemory,
-		}
-		workerNMStateRequirements = models.ClusterHostRequirementsDetails{
-			CPUCores: nmstate.WorkerCPU,
-			RAMMib:   nmstate.WorkerMemory,
-		}
 	)
 
 	BeforeEach(func() {
@@ -3700,14 +3692,7 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 			case authorino.Operator.Name:
 				continue
 			case nmstate.Operator.Name:
-				Expect(*op.Requirements.Master.Quantitative).To(BeEquivalentTo(masterNMStateRequirements),
-					fmt.Sprintf("expected: CPUCores: %d,RAMMib: %d, masterMTVRequirements: CPUCores: %d,RAMMib: %d",
-						op.Requirements.Master.Quantitative.CPUCores, op.Requirements.Master.Quantitative.RAMMib,
-						masterNMStateRequirements.CPUCores, masterNMStateRequirements.RAMMib))
-				Expect(*op.Requirements.Worker.Quantitative).To(BeEquivalentTo(workerNMStateRequirements),
-					fmt.Sprintf("expected: CPUCores: %d,RAMMib: %d, workerMTVRequirements: CPUCores: %d,RAMMib: %d",
-						op.Requirements.Worker.Quantitative.CPUCores, op.Requirements.Worker.Quantitative.RAMMib,
-						workerNMStateRequirements.CPUCores, workerNMStateRequirements.RAMMib))
+				continue
 			case amdgpu.Operator.Name:
 				continue
 			case kmm.Operator.Name:


### PR DESCRIPTION
[MGMT-20216](https://issues.redhat.com//browse/MGMT-20216): Remove memory and CPU requirements
The assisted installer should not make any assumptions regarding the operator resource requirements unless those are specifically stated in official documentation. Nmstate operator has no such requirements.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
