### PR TITLE
NO-JIRA: OKD: Use /tmp as socket directory when calling pg_ctl and postgres

### DIFF
--- a/hack/agent_installer/start_db.sh
+++ b/hack/agent_installer/start_db.sh
@@ -4,9 +4,9 @@ set -o nounset
 set -euo pipefail
 set -o errexit
 
-/usr/bin/pg_ctl -D /tmp/postgres/data/ -l /tmp/postgres/logfile start -w
+/usr/bin/pg_ctl -D /tmp/postgres/data/ -l /tmp/postgres/logfile start -w -o "-k /tmp"
 createuser -s admin -h localhost
 createdb installer -h localhost
 
-/usr/bin/pg_ctl -D /tmp/postgres/data/ -l /tmp/postgres/logfile stop -w
-exec postgres -D /tmp/postgres/data/
+/usr/bin/pg_ctl -D /tmp/postgres/data/ -l /tmp/postgres/logfile stop -w -o "-k /tmp"
+exec postgres -D /tmp/postgres/data/ -k /tmp


### PR DESCRIPTION
OKD installations are failing when using agent and assisted service as described here: https://github.com/okd-project/okd/discussions/2068#discussioncomment-11733877 with:

```
FATAL:  could not create lock file "/var/run/postgresql/.s.PGSQL.5432.lock": No such file or directory"
```

Explicitly tell postgres to use /tmp as the unix socket directory to fix the issue.

