### PR TITLE
MGMT-18518: Renovate configuration tu update golang and golangci-lint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,87 @@
 {
-    "schedule": ["on Saturday"],
-    "groupName": "Konflux build pipeline",
-    "includePaths": [".tekton/*"],
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
     "commitMessagePrefix": "NO-ISSUE: ",
-    "labels": ["lgtm", "approved", "konflux"]
+    "labels": ["lgtm", "approved"],
+
+    "prHourlyLimit": 0,
+    "prConcurrentLimit": 0,
+
+    "enabledManagers": [
+        "dockerfile",
+        "regex",
+        "tekton"
+    ],
+
+    "tekton": {
+        "fileMatch": ["^.tekton/*"]
+    },
+
+    "dockerfile": {
+        "fileMatch": [
+            "^ci-images/Dockerfile.base$",
+            "^Dockerfile.assisted-service-build$",
+            "^Dockerfile.assisted-service-debug$",
+            "^Dockerfile.assisted-service-rhel8-mce$",
+            "^Dockerfile.assisted-service-rhel9-mce$"
+        ]
+    },
+
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^ci-images/Dockerfile.lint$",
+                "^Dockerfile.assisted-service-build$"
+            ],
+            "matchStrings": [
+                "RUN curl .*https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- .* (?<currentValue>.*?)\\n"
+            ],
+            "depNameTemplate": "github.com/golangci/golangci-lint",
+            "datasourceTemplate": "go"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": ["^Dockerfile.assisted-service$"],
+            "matchStrings": [
+                "FROM registry.access.redhat.com/ubi\\${RHEL_VERSION}/go-toolset:(?<currentValue>.*?) AS golang\\n"
+            ],
+            "depNameTemplate": "registry.access.redhat.com/ubi9/go-toolset",
+            "datasourceTemplate": "docker"
+        }
+    ],
+
+    "packageRules": [
+        {
+            "groupName": "Go Builder",
+            "addLabels": ["golang"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchUpdateTypes": ["minor"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "enabled": false
+        },
+        {
+            "groupName": "Linter",
+            "addLabels": ["linter"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"],
+            "enabled": false
+        },
+        {
+            "groupName": "Konflux build pipeline",
+            "addLabels": ["konflux"],
+            "schedule": ["on Saturday"],
+            "matchManagers": ["tekton"]
+        }
+    ]
 }


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Add renovate configuration to update linter and golang

* golangci-lint should be updated as soon as possible to avoid blocking golang update.
  * PR should happen as soon as there is a new release
  * major updates are disabled, golangci-lint 2.0.x is already out
* golang version can be updated once the linter has been updated.
  * Since we are using a variable in Dockerfile.assisted-service, I assume that ubi8/go-toolset and ubi9/go-toolset will have the same tag, so I used ubi9/go-toolset to update that from (this is why there is a custom manager).
  * PR should happen as soon as there is a new release
  * major updates are disable because of the tagging mechanism of that image (9.4 is a tag, it makes renovate think it's a golang version)
* Konflux should be unchanged.
  * PR should still happen every Saturday

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

* Here is my test repo: https://github.com/pastequo/test-renovate
* Here the PR it created while launching renovate from my machine: https://github.com/pastequo/test-renovate/pulls 

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
