### PR TITLE
AGENT-538: For ABI, also allow early retrieval of kubeadmin-password

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4067,8 +4067,7 @@ func (b *bareMetalInventory) checkFileForDownload(ctx context.Context, clusterID
 	case constants.KubeadminPassword:
 		fallthrough
 	case constants.KubeconfigNoIngress:
-		agentInstaller := b.installerInvoker == "agent-installer"
-		err = clusterPkg.CanDownloadKubeconfigFiles(cluster, fileName, agentInstaller)
+		err = clusterPkg.CanDownloadKubeconfigFiles(cluster, fileName, b.installerInvoker)
 	case constants.ManifestFolder:
 		// do nothing. manifests can be downloaded at any given cluster state
 	default:

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -703,8 +703,8 @@ func CanDownloadFiles(c *common.Cluster) (err error) {
 	return checkDownloadAllowed(c, "files", allowedStatuses)
 }
 
-func CanDownloadKubeconfigFiles(c *common.Cluster, file string, agentInstaller bool) (err error) {
-	if !agentInstaller {
+func CanDownloadKubeconfigFiles(c *common.Cluster, file, installerInvoker string) (err error) {
+	if installerInvoker != "agent-installer" {
 		return CanDownloadFiles(c)
 	}
 

--- a/internal/common/error_utils.go
+++ b/internal/common/error_utils.go
@@ -75,6 +75,10 @@ func (a *ApiErrorResponse) Code() int32 {
 	return a.StatusCode()
 }
 
+func (a *ApiErrorResponse) Err() error {
+	return a.err
+}
+
 func NewApiError(statusCode int32, err error) *ApiErrorResponse {
 	return &ApiErrorResponse{
 		statusCode: statusCode,
@@ -101,6 +105,21 @@ func NewInfraError(statusCode int32, err error) *InfraErrorResponse {
 			statusCode: statusCode,
 			err:        err,
 		},
+	}
+}
+
+func IsNotFoundError(err error) bool {
+	switch err.(type) {
+	case *ApiErrorResponse:
+		notFoundErr := err.(*ApiErrorResponse).Err()
+		if _, ok := notFoundErr.(NotFound); ok {
+			return true
+		}
+		return false
+	case *InfraErrorResponse:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -2,6 +2,7 @@ package constants
 
 const Kubeconfig = "kubeconfig"
 const KubeconfigNoIngress = "kubeconfig-noingress"
+const KubeadminPassword = "kubeadmin-password"
 
 // an arbitrary subdomain of *.apps.<cluster-name>.<base-domain> used by DNS
 // validations to verify that *.apps wildcard is configured properly

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -65,7 +65,14 @@ func New(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config,
 // GenerateInstallConfig creates install config and ignition files
 func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster common.Cluster, cfg []byte, releaseImage, installerReleaseImageOverride string) error {
 	log := logutil.FromContext(ctx, k.log)
-	err := os.MkdirAll(k.workDir, 0o755)
+
+	entries, err := os.ReadDir(k.workDir)
+	if err == nil && len(entries) > 0 {
+		log.Infof("Work directory %s already exists, skipping generation of InstallConfig", k.workDir)
+		return nil
+	}
+
+	err = os.MkdirAll(k.workDir, 0o755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In https://github.com/openshift/assisted-service/pull/7391 changes were made to allow the kubeconfig to be retrieved in the Ready state for ABI only, in order to be integrate with the OVE UI. This change should also be made for kubeadmin-password, to allow it be retrieved prior to installing the cluster.

Some related changes address additional comments in the PR above.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
