### PR TITLE
NO-ISSUE: Change node-maintenance operator namespace to avoid conflict with node-healthcheck operator

### DIFF
--- a/internal/operators/nodemaintenance/node_maintenance_consts.go
+++ b/internal/operators/nodemaintenance/node_maintenance_consts.go
@@ -3,6 +3,6 @@ package nodemaintenance
 const (
 	operatorName             = "node-maintenance"
 	operatorSubscriptionName = "node-maintenance-operator"
-	operatorNamespace        = "openshift-workload-availability"
+	operatorNamespace        = "openshift-workload-maintenance"
 	OperatorFullName         = "Node Maintenance Operator"
 )


### PR DESCRIPTION
Fix ignition creation conflict between `node-maintenance` operator and `node-healthcheck` operator by changing `node-maintenance` namespace
```
Mar 31 13:13:04 master-0 service[2580]: time="2025-03-31T13:13:04Z" level=error msg="error running openshift-install create ignition-configs, stdout: level=info msg=Consuming Certificate (admin-kubeconfig-signer) from target directory\nlevel=info msg=Consuming Certificate (kube-apiserver-localhost-signer) from target directory\nlevel=info msg=Consuming Certificate (kube-apiserver-service-network-signer) from target directory\nlevel=info msg=Consuming Certificate (kube-apiserver-lb-signer) from target directory\nlevel=fatal msg=failed to fetch Bootstrap Ignition Config: failed to fetch dependency of \"Bootstrap Ignition Config\": failed to generate asset \"CVO Ignore\": multiple manifests for group  kind Namespace namespace  name openshift-workload-availability: openshift/50_node_healthcheck_namespace.yaml, openshift/50_node_maintenance_namespace.yaml\n" func="github.com/openshift/assisted-service/internal/ignition.(*installerGenerator).runCreateCommand" file="/src/internal/ignition/installmanifests.go:1238" cluster_id=c548807c-3044-4e44-a392-8697629e79a5 error="exit status 1" go-id=521 request_id=
```
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
