### PR TITLE
OCPBUGS-52285: ABI vSphere Installation Fails Due to disk.EnableUUID 

### DIFF
--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -1622,6 +1622,7 @@ var _ = Describe("Validations test", func() {
 			updateHostInventory(func(inventory *models.Inventory) {
 				for _, disk := range inventory.Disks {
 					disk.HasUUID = false
+					disk.InstallationEligibility.Eligible = true
 				}
 			})
 
@@ -1639,12 +1640,20 @@ var _ = Describe("Validations test", func() {
 				SizeBytes: conversions.GibToBytes(120),
 				DriveType: "CDROM",
 				HasUUID:   false,
+				InstallationEligibility: models.DiskInstallationEligibility{
+					Eligible:           true,
+					NotEligibleReasons: []string{},
+				},
 			}
 
 			HDD := &models.Disk{
 				SizeBytes: conversions.GibToBytes(120),
 				DriveType: "HDD",
 				HasUUID:   true,
+				InstallationEligibility: models.DiskInstallationEligibility{
+					Eligible:           true,
+					NotEligibleReasons: []string{},
+				},
 			}
 
 			updateHostInventory(func(inventory *models.Inventory) {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1774,7 +1774,10 @@ func (v *validator) isVSphereDiskUUIDEnabled(c *validationContext) (ValidationSt
 		// if any of them doesn't have that flag, it's likely because the user has forgotten to
 		// enable `disk.EnableUUID` for this virtual machine
 		// See https://access.redhat.com/solutions/4606201
-		if v.hwValidator.IsValidStorageDeviceType(disk, c.inventory.CPU.Architecture, "") && !disk.HasUUID {
+		// Additionally checking if the disk is eligible for installation before verifying the UUID flag
+		if disk.InstallationEligibility.Eligible &&
+			v.hwValidator.IsValidStorageDeviceType(disk, c.inventory.CPU.Architecture, "") &&
+			!disk.HasUUID {
 			return ValidationFailure, "VSphere disk.EnableUUID isn't enabled for this virtual machine, it's necessary for disks to be mounted properly"
 		}
 	}


### PR DESCRIPTION
The vSphere installation was failing due to a false validation error stating that disk.EnableUUID was not enabled, despite it being correctly configured in the VM settings. 

For example, there are two types of disks:

- Installable disk (HDD or other types): A disk eligible for installation with a valid UUID (HasUUID:true). This disk should be validated and mounted correctly.

- Non-installable disk (e.g., ISO, small SSD): A disk not eligible for installation (InstallationEligibility.Eligible:false), often used for media or other purposes, and may not have a UUID. This disk should be ignored in the validation process.


The issue occurred because the validation logic was incorrectly checking both types of disks for UUIDs. The fix ensures that only installable disks are validated for HasUUID, avoiding false positives and allowing the cluster to deploy without errors related to disk.EnableUUID.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
