### PR TITLE
MGMT-20245: Add kernel args for raid (Intel VROC)

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -327,6 +327,10 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 		if err != nil {
 			return "", err
 		}
+		installerArgs, err = appendRaidArgs(installerArgs, installationDisk)
+		if err != nil {
+			return "", err
+		}
 
 		// When using ISCSI along OCI, we expect the user (via a
 		// script) to configure the network statically on the nodes as
@@ -421,6 +425,20 @@ func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inve
 		installerArgs = append(installerArgs, "--append-karg", netArgs)
 	}
 
+	return installerArgs, nil
+}
+
+func appendRaidArgs(installerArgs []string, installationDisk *models.Disk) ([]string, error) {
+	// Add kernel args for Intel VROC
+	if installationDisk.DriveType != models.DriveTypeRAID {
+		return installerArgs, nil
+	}
+	args := []string{"rd.md=1", "rd.auto=1"}
+	for _, arg := range args {
+		if !lo.Contains(installerArgs, arg) {
+			installerArgs = append(installerArgs, "--append-karg", arg)
+		}
+	}
 	return installerArgs, nil
 }
 

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1020,6 +1020,32 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp"]`))
 	})
+	It("Raid installation disk - Host IPv4 address", func() {
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}
+		host.InstallerArgs = ""
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+					{
+						"id": "other-id",
+						"drive_type": "HDD"
+					},
+					{
+						"id": "install-id",
+						"drive_type": "%s"
+					}
+			],
+			"interfaces":[
+				{
+					"name": "eth1",
+					"ipv4_addresses":["10.56.20.80/25"]
+				}
+			]
+		}`, models.DriveTypeRAID)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.md=1","--append-karg","rd.auto=1"]`))
+	})
 	It("ip=<nic>:dhcp6 added when machine CIDR is IPv6", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "2001:db8::/64"}}
 		host.Inventory = `{


### PR DESCRIPTION
Intel VROC supports raid creation from BIOS and creates raid devices on booted os.
When raid is installation disk, reboot fails because device not detectd. Enable kernel args - rd.md=1 and rd.auto=1

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
