### PR TITLE
MGMT-20124: Introduce DependencyOnly property on Operator

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -27,6 +27,9 @@ type MonitoredOperator struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 
+	// Whether the operator can't be installed without being required by another operator.
+	DependencyOnly bool `json:"dependency_only,omitempty"`
+
 	// Unique name of the operator.
 	Name string `json:"name,omitempty" gorm:"primaryKey"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -27,6 +27,9 @@ type MonitoredOperator struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 
+	// Whether the operator can't be installed without being required by another operator.
+	DependencyOnly bool `json:"dependency_only,omitempty"`
+
 	// Unique name of the operator.
 	Name string `json:"name,omitempty" gorm:"primaryKey"`
 

--- a/models/monitored_operator.go
+++ b/models/monitored_operator.go
@@ -27,6 +27,9 @@ type MonitoredOperator struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 
+	// Whether the operator can't be installed without being required by another operator.
+	DependencyOnly bool `json:"dependency_only,omitempty"`
+
 	// Unique name of the operator.
 	Name string `json:"name,omitempty" gorm:"primaryKey"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9686,6 +9686,10 @@ func init() {
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primaryKey\""
         },
+        "dependency_only": {
+          "description": "Whether the operator can't be installed without being required by another operator.",
+          "type": "boolean"
+        },
         "name": {
           "description": "Unique name of the operator.",
           "type": "string",
@@ -20747,6 +20751,10 @@ func init() {
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primaryKey\""
+        },
+        "dependency_only": {
+          "description": "Whether the operator can't be installed without being required by another operator.",
+          "type": "boolean"
         },
         "name": {
           "description": "Unique name of the operator.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4122,6 +4122,9 @@ definitions:
             package: github.com/lib/pq
           hints:
             noValidation: true
+      dependency_only:
+        type: boolean
+        description: Whether the operator can't be installed without being required by another operator.
 
   operator-monitor-report:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
+++ b/vendor/github.com/openshift/assisted-service/models/monitored_operator.go
@@ -27,6 +27,9 @@ type MonitoredOperator struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 
+	// Whether the operator can't be installed without being required by another operator.
+	DependencyOnly bool `json:"dependency_only,omitempty"`
+
 	// Unique name of the operator.
 	Name string `json:"name,omitempty" gorm:"primaryKey"`
 


### PR DESCRIPTION
This property should be reserved for operator that can not be installed as standalone operator.

This change is a prerequisite to be able to remove nvidia-gpu, amd-gpu or kmm operator if, after choosing openshiftai, we found that no host has amd/nvidia gpu.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Alongside with the initiative to have a single openshiftAI bundle, we need to be able to add dependent operators (namely nvidia-gpu or amd-gpu) based on the host discovery result
Which also imply to be able to remove those dependency-operator if they are not needed (in the first palce or if the only host with nvidia GPU has been removed for example)

This PR proposes to add a new property on Operator that describes if the operator can only exist as a dependency of another operator. So that another PR can remove those operator if they are not considered as needed anymore

The property is intended to be used like this: https://github.com/openshift/assisted-service/pull/7528

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Local cluster alongside with all other changes related to have a single openshiftAI bundle

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
