### PR TITLE
MGMT-20324:  Fix day2 add hosts with P/Z CPU architectures

### DIFF
--- a/internal/featuresupport/common.go
+++ b/internal/featuresupport/common.go
@@ -23,6 +23,12 @@ func ValidateActiveFeatures(log logrus.FieldLogger, cluster *common.Cluster, inf
 	if cluster == nil {
 		return err
 	}
+
+	if swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster {
+		log.Infof("skipping feature support validation: cluster %s is of kind AddHostsCluster", cluster.ID.String())
+		return nil
+	}
+
 	activatedFeatures := getActivatedFeatures(log, cluster, infraEnv, updateParams)
 	for _, feature := range activatedFeatures {
 		logFields := logrus.Fields{
@@ -50,6 +56,10 @@ func ValidateIncompatibleFeatures(log logrus.FieldLogger, cpuArchitecture string
 	var openshiftVersion *string
 	if cluster != nil {
 		openshiftVersion = &cluster.OpenshiftVersion
+	}
+	if cluster != nil && swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster {
+		log.Infof("skipping feature support validation: cluster %s is of kind AddHostsCluster", cluster.ID.String())
+		return nil
 	}
 
 	activatedFeatures := getActivatedFeatures(log, cluster, infraEnv, updateParams)


### PR DESCRIPTION
Disable feature validation when creating and updating assisted objects due to an error when user is trying to add hosts on day2 with P/Z arch

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 