### PR TITLE
MGMT-20384: Feature flag for AMD GPU supported OCP versions

### DIFF
--- a/internal/featuresupport/feature_support_config.go
+++ b/internal/featuresupport/feature_support_config.go
@@ -1,0 +1,53 @@
+package featuresupport
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+// Config contains configuration for the feature support logic.
+type Config struct {
+	// AmdGpuSupportedOpenShiftversions is a comma separated list of versions of OpenShift that where the AMD GPU
+	// operator // is supported.
+	//
+	// This is needed because when the operator was initially released it was supported only 4.17 and not in 4.18
+	// and we wanted to be able to enable/disable versions in the production environment without having to deploy
+	// a new version of the service.
+	//
+	// If the value is '*' then all versions will be supported.
+	AmdGpuSupportedOpenShiftversions []string `envconfig:"AMD_GPU_SUPPORTED_OPENSHIFT_VERSIONS" default:"*"`
+}
+
+// The configuration is handled as a singleton that is lazily initialized. Don't use these variables directly, use the
+// GetConfig function instead.
+var (
+	config     *Config
+	configLock *sync.Mutex = &sync.Mutex{}
+)
+
+// GetConfig returns the configuration, reading it from the environment variables first if this is the first time it is
+// used.
+func GetConfig() (result *Config, err error) {
+	configLock.Lock()
+	defer configLock.Unlock()
+	if config == nil {
+		config = &Config{}
+		err = envconfig.Process("", config)
+		if err != nil {
+			err = fmt.Errorf("failed to load feature support configuration: %w", err)
+			return
+		}
+	}
+	result = config
+	return
+}
+
+// SetConfig replaces the configuration. This is intended for unit tests, where it is convenient to set the
+// configuration without changing the environment variables.
+func SetConfig(replacement *Config) {
+	configLock.Lock()
+	defer configLock.Unlock()
+	config = replacement
+}

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/nodemaintenance"
 	"github.com/openshift/assisted-service/internal/operators/selfnoderemediation"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 )
 
@@ -778,7 +779,32 @@ func (f *AMDGPUFeature) getSupportLevel(filters SupportLevelFilters) models.Supp
 		return models.SupportLevelUnavailable
 	}
 
-	return models.SupportLevelDevPreview
+	if f.isOpenShiftVersionSupported(filters.OpenshiftVersion) {
+		return models.SupportLevelDevPreview
+	}
+	return models.SupportLevelUnavailable
+}
+
+func (f *AMDGPUFeature) isOpenShiftVersionSupported(openShiftVersion string) bool {
+	config, err := GetConfig()
+	if err != nil {
+		logrus.WithError(err).Error("Failed to load feature support configuration")
+		return false
+	}
+	for _, supportedOpenShiftVersion := range config.AmdGpuSupportedOpenShiftversions {
+		if supportedOpenShiftVersion == "*" {
+			return true
+		}
+		equal, err := common.BaseVersionEqual(openShiftVersion, supportedOpenShiftVersion)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to compare versions")
+			continue
+		}
+		if equal {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *AMDGPUFeature) getIncompatibleArchitectures(_ *string) *[]models.ArchitectureSupportLevelID {

--- a/internal/featuresupport/features_olm_operators_test.go
+++ b/internal/featuresupport/features_olm_operators_test.go
@@ -338,4 +338,105 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			Entry("on Nutanix", "4.12", common.X86CPUArchitecture, models.PlatformTypeExternal, models.SupportLevelUnavailable),
 		)
 	})
+
+	DescribeTable(
+		"AMD GPU feature",
+		func(config *Config, version string, expected bool) {
+			SetConfig(config)
+			actual := IsFeatureAvailable(
+				models.FeatureSupportLevelIDAMDGPU,
+				version,
+				swag.String(models.ClusterCPUArchitectureX8664),
+			)
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"Supports 4.17 if list contains star",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"*"},
+			},
+			"4.17",
+			true,
+		),
+		Entry(
+			"Supports 4.18 if list contains star",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"*"},
+			},
+			"4.18",
+			true,
+		),
+		Entry(
+			"Supports 4.19 if list contains star",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"*"},
+			},
+			"4.19",
+			true,
+		),
+		Entry(
+			"Doesn't support 4.17 if list is empty",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{},
+			},
+			"4.17",
+			false,
+		),
+		Entry(
+			"Doesn't support 4.18 if list is empty",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{},
+			},
+			"4.18",
+			false,
+		),
+		Entry(
+			"Doesn't support 4.19 if list is empty",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{},
+			},
+			"4.19",
+			false,
+		),
+		Entry(
+			"Supports 4.17 if included in list with one element",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"4.17"},
+			},
+			"4.17",
+			true,
+		),
+		Entry(
+			"Doesn't support 4.17 if not included in list with one element",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"4.18"},
+			},
+			"4.17",
+			false,
+		),
+		Entry(
+			"Supports 4.17 if included in list with two elements",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"4.17", "4.18"},
+			},
+			"4.17",
+			true,
+		),
+		Entry(
+			"Doesn't support 4.17 if not included in list with two elements",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"4.16", "4.18"},
+			},
+			"4.17",
+			false,
+		),
+		Entry(
+			"Tolerates junk",
+			&Config{
+				AmdGpuSupportedOpenShiftversions: []string{"junk", "4.18"},
+			},
+			"4.18",
+			true,
+		),
+	)
 })

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -228,6 +228,8 @@ parameters:
   value: "10de"
 - name: AMD_SUPPORTED_GPUS
   value: "1002"
+- name: AMD_GPU_SUPPORTED_OPENSHIFT_VERSIONS
+  value: "4.17"
 apiVersion: v1
 kind: Template
 metadata:
@@ -508,6 +510,8 @@ objects:
                 value: ${NVIDIA_SUPPORTED_GPUS}
               - name: AMD_SUPPORTED_GPUS
                 value: ${AMD_SUPPORTED_GPUS}
+              - name: AMD_GPU_SUPPORTED_OPENSHIFT_VERSIONS
+                value: ${AMD_GPU_SUPPORTED_OPENSHIFT_VERSIONS}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
The AMD GPU operator was available in version 4.17 of OpenShift in the certified operators catalog, but it isn't yet in that same catalog for 4.18. As a result when the operator is enabled for 4.18 the installation will start but will never finish correctly because the operator will never be installed. To avoid that this patch adds a new environment variable to control for what versions of OpenShift the operator will be enabled. For example, to explicitly enable both 4.17 and 4.18:

```shell
AMD_GPU_SUPPORTED_OPENSHIF_VERSION="4.17,4.18"
```

The default value for the variable is `*`, which means that the operator is enabled for all versions of OpenShift.

The variable is set to `4.17` in the deployment template, so that in the production environment the operator will only be enabled for OpenShift 4.17.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-20384

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
