### PR TITLE
MGMT-18930: Consolidate static network configuration log messages

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -248,6 +248,7 @@ func (s *StaticNetworkConfigGenerator) createNMConnectionFiles(nmstateOutput, ho
 	if len(connectionsList) == 0 {
 		return nil, errors.Errorf("nmstate generated an empty NetworkManager config file content")
 	}
+
 	for _, connection := range connectionsList {
 		connectionElems := connection.([]interface{})
 		fileName := connectionElems[0].(string)
@@ -255,13 +256,23 @@ func (s *StaticNetworkConfigGenerator) createNMConnectionFiles(nmstateOutput, ho
 		if err != nil {
 			return nil, err
 		}
-		s.log.Infof("Adding NMConnection file <%s>", fileName)
+
 		newFile := StaticNetworkConfigData{
 			FilePath:     filepath.Join(hostDir, fileName),
 			FileContents: fileContents,
 		}
+
 		filesList = append(filesList, newFile)
 	}
+
+	if len(filesList) > 0 {
+		s.log.Infof("Adding NMConnection files: <%s>",
+			strings.Join(lo.Map(filesList, func(f StaticNetworkConfigData, _ int) string {
+				return filepath.Base(f.FilePath)
+			}), ">, <"),
+		)
+	}
+
 	return filesList, nil
 }
 


### PR DESCRIPTION
This commit changes the logging behavior in the StaticNetworkConfigGenerator to reduce log verbosity by consolidating multiple individual "Adding NMConnection file" log messages into a single message. Instead of logging each NM connection file separately, the code now collects all file names and outputs them in a single log entry.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
