### PR TITLE
MGMT-20455: Add NFD as dependency of NVIDIA GPU

### DIFF
--- a/internal/operators/nvidiagpu/nvidia_gpu_operator.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
+	"github.com/openshift/assisted-service/internal/operators/nodefeaturediscovery"
 	"github.com/openshift/assisted-service/internal/templating"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -65,7 +66,9 @@ func (o *operator) GetFullName() string {
 
 // GetDependencies provides a list of dependencies of the Operator
 func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	result := []string{}
+	result := []string{
+		nodefeaturediscovery.Operator.Name,
+	}
 	return result, nil
 }
 

--- a/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/internal/operators/nodefeaturediscovery"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -317,4 +318,10 @@ var _ = Describe("Operator", func() {
 			},
 		),
 	)
+
+	It("Depends on the node feature discovery operator", func() {
+		deps, err := operator.GetDependencies(&common.Cluster{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deps).To(ContainElement(nodefeaturediscovery.Operator.Name))
+	})
 })


### PR DESCRIPTION
Currently we don't add any dependencies for operators that are parts of bundles, in particular for the NVIDIA GPU operator we don't automatically add the node feature discovery operator. But some users wish to have the dependency because they are not interested in bundle, just in the GPU operator. This patch adds that dependency.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-20455

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested with the included unit test.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
