### PR TITLE
MGMT-20296: Fix returned error code in PostRegisterAfterInstallation

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3443,15 +3443,15 @@ func readConfiguredAgentImage(fullName string, tagOnly bool) string {
 }
 
 func returnRegisterHostTransitionError(defaultCode int32, err error) error {
-	if isRegisterHostForbidden(err) {
-		return common.NewApiError(http.StatusForbidden, err)
+	if isRegisterHostConflict(err) {
+		return common.NewApiError(http.StatusConflict, err)
 	}
 	return common.NewApiError(defaultCode, err)
 }
 
-func isRegisterHostForbidden(err error) bool {
+func isRegisterHostConflict(err error) bool {
 	if serr, ok := err.(*common.ApiErrorResponse); ok {
-		return serr.StatusCode() == http.StatusForbidden
+		return serr.StatusCode() == http.StatusConflict
 	}
 	return false
 }

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -167,7 +167,7 @@ func (th *transitionHandler) PostRegisterAfterInstallation(sw stateswitch.StateS
 	}
 
 	return common.NewApiError(
-		http.StatusForbidden,
+		http.StatusConflict,
 		errors.New(
 			"Host is trying to register after the cluster has already been installed. "+
 				"That most probably means that the host is booting from the "+

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -169,7 +169,7 @@ var _ = Describe("RegisterHost", func() {
 				progressStage:         models.HostStageDone,
 				srcState:              models.HostStatusInstalled,
 				dstState:              models.HostStatusInstalled,
-				errorCode:             http.StatusForbidden,
+				errorCode:             http.StatusConflict,
 				expectedEventInfo:     "",
 				expectedNilStatusInfo: true,
 			},


### PR DESCRIPTION
Currently, when an installed host boots from the ISO, it triggers the PostRegisterAfterInstallation method. The error returned from this method is of type Error with a status code of 403 Forbidden.
However, on the client side, the response reader expects a 403 to be of type InfraError, which leads to an unmarshaling failure and a non-informative error message.
To resolve this, the returned status code was changed to 409 Conflict, which is both semantically accurate and correctly maps to the Error type on the client side — fixing the decoding issue.

the non-informative error before the fix:

`json: cannot unmarshal string into Go struct field InfraError.code of type int32`

Note that this change also requires an update in the agent repository — see: [assisted-installer-agent #990](https://github.com/openshift/assisted-installer-agent/pull/990)
The expected log after applying both fixes:

`Host will stop trying to register; cluster cannot accept new hosts in its current state: [409] Host is trying to register after the cluster has already been installed. That most probably means that the host is booting from the installation ISO, and therefore not effectively joining the cluster. The request will be ignored. Fix the boot order and reboot the host.`

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
