### PR TITLE
OCPBUGS-55300: For agent-installer remove bypass of manifest generation

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -65,14 +65,7 @@ func New(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config,
 // GenerateInstallConfig creates install config and ignition files
 func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster common.Cluster, cfg []byte, releaseImage, installerReleaseImageOverride string) error {
 	log := logutil.FromContext(ctx, k.log)
-
-	entries, err := os.ReadDir(k.workDir)
-	if k.Config.InstallInvoker == "agent-installer" && err == nil && len(entries) > 0 {
-		log.Infof("Work directory %s already exists, skipping generation of InstallConfig", k.workDir)
-		return nil
-	}
-
-	err = os.MkdirAll(k.workDir, 0o755)
+	err := os.MkdirAll(k.workDir, 0o755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When OVE UI uses the downloads/credentials endpoint the API handler generates the InstallConfig for the agent-based installer in order to make the credentials available in the Ready state. In order to prevent overwriting the kubeadmin-password, the generation of the InstallConfig the second time was bypassed (https://github.com/openshift/assisted-service/pull/7546). This inadvertently prevented the operator manifests from also being generated, and since the OVE UI configures the operators after it retrieves the credentials, the operators are not correctly installed.

This fix removes the bypass of the GenerateInstallConfig. To prevent the kubeadmin-password overwrite a installer change has been made https://github.com/openshift/installer/pull/9679

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
