### PR TITLE
OCPBUGS-54319: mirror changes to openshift-installer with oci-eval-user-data

### DIFF
--- a/internal/ignition/templates/oci-eval-user-data.sh
+++ b/internal/ignition/templates/oci-eval-user-data.sh
@@ -2,6 +2,13 @@
 
 set -euxo pipefail
 
+# dmidecode is not available on ppc64le/s390x
+if [ "$(arch)" == "ppc64le" ] || [ "$(arch)" == "s390x" ] 
+then
+    echo "Non OCI architecture... exiting early"
+    exit 0
+fi
+
 chassis_asset_tag="$(dmidecode --string chassis-asset-tag)"
 if [ "${chassis_asset_tag}" != "OracleCloud.com" ]
 then


### PR DESCRIPTION
Mirror changes to [oci-eval-user-data.sh](https://github.com/openshift/installer/blob/main/data/data/agent/files/usr/local/bin/oci-eval-user-data.sh) in the installer

## List all the issues related to this PR
- [X] Bug fix

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [] Operator Managed Deployments
- [x] None

## How was this code tested?

- [X] Manual (Elaborate on how it was tested)
- [x] No tests needed

The fix was run locally with an assisted setup.

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)
- NA on unit-tests due to being a shellscript

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear? yes
- Is there a bug required (and linked) for this change? yes
- Should this PR be backported? yes to 4.18

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
