### PR TITLE
MGMT-20527: Ensure no_proxy contains no duplicates in the install command

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
 )
 
@@ -235,7 +236,7 @@ func (i *installCmd) getProxyArguments(clusterName, baseDNSDomain, httpProxy, ht
 	} else {
 		noProxyUpdated := []string{}
 		if noProxyTrim != "" {
-			noProxyUpdated = append(noProxyUpdated, noProxyTrim)
+			noProxyUpdated = strings.Split(noProxyTrim, ",")
 		}
 		// if we set proxy we need to update assisted installer no proxy with no proxy params as installer.
 		// it must be able to connect to api int. Added this way for not to pass name and base domain
@@ -245,7 +246,7 @@ func (i *installCmd) getProxyArguments(clusterName, baseDNSDomain, httpProxy, ht
 			".svc",
 			".cluster.local",
 			fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain))
-		proxy.NoProxy = swag.String(strings.Join(noProxyUpdated, ","))
+		proxy.NoProxy = swag.String(strings.Join(funk.UniqString(noProxyUpdated), ","))
 	}
 
 	return &proxy

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -679,6 +679,10 @@ var _ = Describe("installcmd arguments", func() {
 			Expect(swag.StringValue(noProxy.HTTPProxy)).Should(Equal("http://10.56.20.90:8080"))
 			Expect(swag.StringValue(noProxy.NoProxy)).Should(Equal("*"))
 		})
+		It("should not create duplicate no_proxy values", func() {
+			noProxy := installCmd.getProxyArguments("t-cluster", "proxy.org", "http://10.56.20.90:8080", "", "127.0.0.1,localhost")
+			Expect(strings.Split(swag.StringValue(noProxy.NoProxy), ",")).Should(ConsistOf("127.0.0.1", "localhost", ".svc", ".cluster.local", "api-int.t-cluster.proxy.org"))
+		})
 	})
 })
 


### PR DESCRIPTION
The agent validates no_proxy using the `ValidateNoProxyFormat` function which was recently changed to ensure no duplicates exist.

If a user adds one of the entries that the install command is trying to add automatically, this caused duplicates and the install command failed verification.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-20527

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Unit tests and @trewest is testing manually in the environment where the bug was found.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

