### PR TITLE
MGMT-20506: Reset preprovisioningimage status after cooldown period

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -107,7 +107,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		Expect(metal3_v1alpha1.AddToScheme(schemes)).To(Succeed())
 		Expect(aiv1beta1.AddToScheme(schemes)).To(Succeed())
 		c = fakeclient.NewClientBuilder().WithScheme(schemes).
-			WithStatusSubresource(&metal3_v1alpha1.PreprovisioningImage{}).Build()
+			WithStatusSubresource(&metal3_v1alpha1.PreprovisioningImage{}, &aiv1beta1.InfraEnv{}).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
@@ -285,6 +285,64 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Status:  corev1.ConditionFalse},
 				ppi,
 			)
+		})
+
+		It("Should update the status after cool down and not reboot the host if the image didn't change", func() {
+			ppi.Status.ImageUrl = downloadURL
+			Expect(c.Status().Update(ctx, ppi)).To(BeNil())
+
+			infraEnv.Status.ISODownloadURL = downloadURL
+			infraEnv.Status.CreatedTime = &metav1.Time{Time: time.Now()}
+			infraEnv.Status.Conditions = []conditionsv1.Condition{{Type: aiv1beta1.ImageCreatedCondition,
+				Status:  corev1.ConditionTrue,
+				Reason:  "some reason",
+				Message: "Some message",
+			}}
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			setInfraEnvIronicConfig()
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(2).Return(nil, errors.Errorf("ICC configuration is not available"))
+
+			By("initially reconciling the preprovisioningimage during cooldown")
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res.Requeue).To(Equal(true))
+
+			By("verifying the preprovisioningimage has wait for cooldown status")
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "testPPI",
+			}
+			Expect(c.Get(ctx, key, ppi)).To(BeNil())
+			validateStatus(downloadURL,
+				&conditionsv1.Condition{
+					Reason:  "WaitingForInfraEnvImageToCoolDown",
+					Message: "Waiting for InfraEnv image to cool down",
+					Status:  corev1.ConditionFalse},
+				ppi,
+			)
+
+			By("modifying the infraenv creation time to make it seem like it's after the cooldown period")
+			Expect(c.Get(ctx, types.NamespacedName{Name: infraEnv.Name, Namespace: infraEnv.Namespace}, infraEnv)).To(BeNil())
+			infraEnv.Status.CreatedTime = &metav1.Time{Time: metav1.Now().Add(-InfraEnvImageCooldownPeriod)}
+			Expect(c.Status().Update(ctx, infraEnv)).To(BeNil())
+			setInfraEnvIronicConfig()
+
+			By("reconciling the preprovisioningimage after the cooldown period")
+			res, err = pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+
+			By("verifying the preprovisioningimage status has updated")
+			Expect(c.Get(ctx, key, ppi)).To(BeNil())
+			validateStatus(downloadURL, conditionsv1.FindStatusCondition(infraEnv.Status.Conditions, aiv1beta1.ImageCreatedCondition), ppi)
+
+			By("verifying the BMH does not have the reboot annotation")
+			bmhKey := types.NamespacedName{
+				Namespace: bmh.Namespace,
+				Name:      bmh.Name,
+			}
+			Expect(c.Get(ctx, bmhKey, bmh)).To(BeNil())
+			Expect(bmh.Annotations).ToNot(HaveKey("reboot.metal3.io"))
 		})
 
 		It("sets the image on the PPI to the ISO URL and doesn't force a reboot", func() {


### PR DESCRIPTION
If an InfraEnv's creation time gets updated, but the ISO image URL does not change, the PreprovisioningImage can get stuck in an error status.

This ensures that we update the status once the cooldown time is reached while still not triggering the BMH to reboot when the image URL is the same.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin @gamli75 