### PR TITLE
MGMT-20366: fix ironic inspection bug when ironic image override annotation is provided in disconnected environments

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -402,17 +402,13 @@ func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(ctx context.Conte
 	return mapInfraEnvPPI
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromUserOverride(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentImageFromUserOverride(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) string {
 	ironicAgentImage, ok := infraEnv.GetAnnotations()[ironicAgentImageOverrideAnnotation]
 	if ok && ironicAgentImage != "" {
 		log.Infof("Using override ironic agent image (%s) from infraEnv", ironicAgentImage)
-		return &ICCConfig{
-			IronicAgentImage: ironicAgentImage,
-		}
+		return ironicAgentImage
 	}
-
-	return nil
-
+	return ""
 }
 
 func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
@@ -436,7 +432,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx contex
 	return nil
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentImageFromHUB(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) string {
 	image := r.hubIronicAgentImage
 	architectures := r.hubReleaseArchitectures
 	if image == "" {
@@ -444,17 +440,17 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Cont
 		err := r.Get(ctx, types.NamespacedName{Name: "version"}, cv)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get ClusterVersion")
-			return nil
+			return ""
 		}
 		architectures, err = r.OcRelease.GetReleaseArchitecture(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnvInternal.PullSecret)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get release architecture for (%s)", cv.Status.Desired.Image)
-			return nil
+			return ""
 		}
 		image, err = r.OcRelease.GetIronicAgentImage(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnvInternal.PullSecret)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get ironic agent image from release (%s)", cv.Status.Desired.Image)
-			return nil
+			return ""
 		}
 		r.hubIronicAgentImage = image
 		r.hubReleaseArchitectures = architectures
@@ -463,16 +459,14 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Cont
 
 	if !funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
 		log.Warningf("Release image architectures %v do not match infraEnv architecture %s", architectures, infraEnvInternal.CPUArchitecture)
-		return nil
+		return ""
 	}
 
 	log.Infof("Setting ironic agent image (%s) from HUB cluster", image)
-	return &ICCConfig{
-		IronicAgentImage: image,
-	}
+	return image
 }
 
-func (r *PreprovisioningImageReconciler) getIronicDefaultConfig(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentDefaultImage(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) string {
 	var ironicAgentImage string
 	if infraEnvInternal.CPUArchitecture == common.ARM64CPUArchitecture {
 		ironicAgentImage = r.Config.BaremetalIronicAgentImageForArm
@@ -481,37 +475,32 @@ func (r *PreprovisioningImageReconciler) getIronicDefaultConfig(log logrus.Field
 	}
 
 	log.Infof("Setting default ironic agent image (%s)", ironicAgentImage)
-	return &ICCConfig{
-		IronicAgentImage: ironicAgentImage,
-	}
+	return ironicAgentImage
 }
 
 func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv, infraEnvInternal *common.InfraEnv) (*ICCConfig, error) {
-	var iccConfig *ICCConfig
-
-	iccConfig = r.getIronicConfigFromUserOverride(log, infraEnv)
-
+	iccConfig := r.getIronicConfigFromBMOConfig(ctx, log, infraEnvInternal)
 	if iccConfig == nil {
-		iccConfig = r.getIronicConfigFromBMOConfig(ctx, log, infraEnvInternal)
-	}
-
-	if iccConfig == nil {
-		iccConfig = r.getIronicConfigFromHUB(ctx, log, infraEnvInternal)
-	}
-
-	if iccConfig == nil {
-		iccConfig = r.getIronicDefaultConfig(log, infraEnvInternal)
-	}
-
-	if iccConfig == nil {
-		return nil, fmt.Errorf("Failed to determine ironic config")
-	}
-
-	if iccConfig.IronicBaseURL == "" && iccConfig.IronicInspectorBaseUrl == "" {
-		err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig)
-		if err != nil {
+		iccConfig = &ICCConfig{}
+		if err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig); err != nil {
 			return nil, err
 		}
+	}
+
+	if ironicAgentImageUserOverride := r.getIronicAgentImageFromUserOverride(log, infraEnv); ironicAgentImageUserOverride != "" {
+		iccConfig.IronicAgentImage = ironicAgentImageUserOverride
+	}
+
+	if iccConfig.IronicAgentImage == "" {
+		iccConfig.IronicAgentImage = r.getIronicAgentImageFromHUB(ctx, log, infraEnvInternal)
+	}
+
+	if iccConfig.IronicAgentImage == "" {
+		iccConfig.IronicAgentImage = r.getIronicAgentDefaultImage(log, infraEnvInternal)
+	}
+
+	if iccConfig.IronicAgentImage == "" {
+		return nil, fmt.Errorf("Failed to determine ironic config")
 	}
 
 	log.Infof("Ironic Agent Image is (%s) Ironic URL is (%s) Inspector URL is (%s)",

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -258,6 +258,55 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Get(ctx, key, infraEnv)).To(BeNil())
 			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
 		})
+
+		It("uses ICC config URLs when ICC contains URLs and user override annotation", func() {
+			overrideAgentImage := "ironic-agent-override:latest"
+			iccConfig := &ICCConfig{
+				IronicAgentImage: "ironic-agent-image",
+				IronicBaseURL:    "ironic-base-url",
+			}
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "x86_64"
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(iccConfig, nil)
+			mockOcRelease.EXPECT().GetImageArchitecture(gomock.Any(), iccConfig.IronicAgentImage, backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, _ *common.MirrorRegistryConfiguration) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(iccConfig.IronicBaseURL))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(overrideAgentImage))
+					Expect(url.QueryUnescape(*internalIgnitionConfig)).To(MatchRegexp(`(?m)^inspection_callback_url\s=\s$`)) // matches inspection_callback_url = <empty>
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
+		It("sets ironic URLs from cluster when ICC config is unavailable and ironic image annotation override is set", func() {
+			overrideAgentImage := "ironic-agent-override:latest"
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "x86_64"
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, _ *common.MirrorRegistryConfiguration) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(ironicServiceIPs[0])))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(ironicInspectorIPs[0])))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(overrideAgentImage))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
 		It("Wait for InfraEnv cool down", func() {
 			infraEnv.Status.ISODownloadURL = downloadURL
 			infraEnv.Status.CreatedTime = &metav1.Time{Time: time.Now()}
@@ -625,7 +674,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			backendInfraEnv.CPUArchitecture = "x86_64"
 			backendInfraEnv.PullSecret = "mypullsecret"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))


### PR DESCRIPTION
 fix ironic inspection bug when ironic image override annotation is provided in disconnected environments
 https://issues.redhat.com/browse/MGMT-20366