### PR TITLE
MGMT-20605: Add logic to handle cancelling a day-2 host installation

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -18325,6 +18325,18 @@ var _ = Describe("UnbindHost", func() {
 		verifyApiError(response, http.StatusConflict)
 	})
 
+	It("unbind during installation should fail", func() {
+		params := installer.UnbindHostParams{
+			HostID:     hostID,
+			InfraEnvID: infraEnvID,
+		}
+		var hostObj models.Host
+		Expect(db.First(&hostObj, "id = ?", hostID).Error).ShouldNot(HaveOccurred())
+		Expect(db.Model(&hostObj).Update("status", models.HostStatusInstalling).Error).ShouldNot(HaveOccurred())
+		response := bm.UnbindHost(ctx, params)
+		verifyApiErrorString(response, http.StatusConflict, fmt.Sprintf("Cannot unbind Host %s while it is in the middle of installing.", hostID))
+	})
+
 	It("transition failed", func() {
 		params := installer.UnbindHostParams{
 			HostID:     hostID,

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -78,6 +78,15 @@ var SnoStages = [...]models.HostStage{
 	models.HostStageRebooting, models.HostStageJoined, models.HostStageDone,
 }
 
+var HostInstallingStatuses = []string{
+	models.HostStatusPreparingForInstallation,
+	models.HostStatusPreparingFailed,
+	models.HostStatusPreparingSuccessful,
+	models.HostStatusInstalling,
+	models.HostStatusInstallingInProgress,
+	models.HostStatusInstallingPendingUserAction,
+}
+
 var manualRebootStages = []models.HostStage{
 	models.HostStageRebooting,
 	models.HostStageWaitingForIgnition,

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1935,14 +1935,14 @@ var _ = Describe("Unbind host", func() {
 			{
 				name:        models.HostStatusInstalling,
 				srcState:    models.HostStatusInstalling,
-				validation:  failure,
-				expectEvent: false,
+				validation:  success,
+				expectEvent: true,
 			},
 			{
 				name:        models.HostStatusInstallingInProgress,
 				srcState:    models.HostStatusInstallingInProgress,
-				validation:  failure,
-				expectEvent: false,
+				validation:  success,
+				expectEvent: true,
 			},
 			{
 				name:        models.HostStatusResettingPendingUserAction,

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -347,6 +347,12 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeUnbindHost,
 		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusPreparingForInstallation),
+			stateswitch.State(models.HostStatusPreparingSuccessful),
+			stateswitch.State(models.HostStatusPreparingFailed),
+			stateswitch.State(models.HostStatusInstalling),
+			stateswitch.State(models.HostStatusInstallingInProgress),
+			stateswitch.State(models.HostStatusInstallingPendingUserAction),
 			stateswitch.State(models.HostStatusInstalled),
 			stateswitch.State(models.HostStatusAddedToExistingCluster),
 			stateswitch.State(models.HostStatusError),

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1100,11 +1100,11 @@ var _ = Describe("Unbind", func() {
 			reclaim:   true,
 		},
 		{
-			name:      "installing noop",
+			name:      "installing",
 			srcState:  models.HostStatusInstalling,
-			dstState:  models.HostStatusInstalling,
-			success:   false,
-			sendEvent: false,
+			dstState:  models.HostStatusUnbindingPendingUserAction,
+			success:   true,
+			sendEvent: true,
 			reclaim:   false,
 		},
 		{


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

In kube-API, an Agent will be allowed to have its Cluster Deployment unset while the host is installing. This procedure indicates a host install cancellation. The host should be allowed to have its installation cancelled only if it's a day-2 host. The typical procedure to unbind a host while it's not installing should not change. 

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): see below
- [ ] No tests needed

### Manual Testing 

1. Install a dev-scripts cluster with 2 extra hosts, these changes, hypershift enabled, and the changes for the webhook (PR: https://github.com/openshift/assisted-service/pull/7643)
2. Create a hosted cluster, boot the hosts using BMHs
3. Scale up the NodePool to 1
4. When the host goes into installing, scale down the NodePool to 0
5. Observe the Agent getting its clusterDeploymentName reference removed and its status moving to `unbinding-pending-user-action`
6. Once the BMH deprovisions and reprovisions, observe the Agent moving to `known-unbound` and verify that there's no Node created in the HostedCluster
7. Scale up the NodePool to 1
8. When the Node for the new host appears in the hosted cluster, scale down the NodePool to 0
9. Observe the Agent getting its clusterDeploymentName reference removed and its status moving to `unbinding-pending-user-action`
10. Once the BMH deprovisions and reprovisions, observe the Agent moving to `known-unbound` and verify that the Node is removed from the HostedCluster


## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 
