### PR TITLE
MGMT-20606: Update Agent webhook to allow unsetting clusterDeploymentName during host install

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -259,6 +259,12 @@ type AgentStatus struct {
 	// DeprovisionInfo stores data related to the agent's previous cluster binding in order to clean up when the agent re-registers
 	// +optional
 	DeprovisionInfo *AgentDeprovisionInfo `json:"deprovision_info,omitempty"`
+
+	// Kind corresponds to the same field in the model Host. It indicates the type of cluster the host is
+	// being installed to; either an existing cluster (day-2) or a new cluster (day-1).
+	// Value is one of: "AddToExistingClusterHost" (day-2) or "Host" (day-1)
+	// +optional
+	Kind string `json:"kind,omitempty"`
 }
 
 type DebugInfo struct {

--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -361,6 +361,12 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              kind:
+                description: |-
+                  Kind corresponds to the same field in the model Host. It indicates the type of cluster the host is
+                  being installed to; either an existing cluster (day-2) or a new cluster (day-1).
+                  Value is one of: "AddToExistingClusterHost" (day-2) or "Host" (day-1)
+                type: string
               ntpSources:
                 items:
                   properties:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -1158,6 +1158,12 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              kind:
+                description: |-
+                  Kind corresponds to the same field in the model Host. It indicates the type of cluster the host is
+                  being installed to; either an existing cluster (day-2) or a new cluster (day-1).
+                  Value is one of: "AddToExistingClusterHost" (day-2) or "Host" (day-1)
+                type: string
               ntpSources:
                 items:
                   properties:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -371,6 +371,12 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              kind:
+                description: |-
+                  Kind corresponds to the same field in the model Host. It indicates the type of cluster the host is
+                  being installed to; either an existing cluster (day-2) or a new cluster (day-1).
+                  Value is one of: "AddToExistingClusterHost" (day-2) or "Host" (day-1)
+                type: string
               ntpSources:
                 items:
                   properties:

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -862,6 +862,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		agent.Status.DebugInfo.State = swag.StringValue(h.Status)
 		agent.Status.DebugInfo.StateInfo = swag.StringValue(h.StatusInfo)
 		agent.Status.InstallationDiskID = h.InstallationDiskID
+		agent.Status.Kind = swag.StringValue(h.Kind)
 
 		if h.ValidationsInfo != "" {
 			newValidationsInfo := ValidationsStatus{}

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -259,6 +259,12 @@ type AgentStatus struct {
 	// DeprovisionInfo stores data related to the agent's previous cluster binding in order to clean up when the agent re-registers
 	// +optional
 	DeprovisionInfo *AgentDeprovisionInfo `json:"deprovision_info,omitempty"`
+
+	// Kind corresponds to the same field in the model Host. It indicates the type of cluster the host is
+	// being installed to; either an existing cluster (day-2) or a new cluster (day-1).
+	// Value is one of: "AddToExistingClusterHost" (day-2) or "Host" (day-1)
+	// +optional
+	Kind string `json:"kind,omitempty"`
 }
 
 type DebugInfo struct {


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

The Agent webhook previously blocked any attempt to change the clusterDeploymentName once a host is installing. This unblocks that, but only allows it to be changed when:
1. The host is not installing (as it was before)
2. The host is day-2 and the new cluster reference is nil (aka unset)

This will still block attempts to change the clusterDeploymentName on an Agent if it's an installing day-1 host or if the change is to a different cluster while the host is installing.


## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): See corresponding PR https://github.com/openshift/assisted-service/pull/7642
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 