### PR TITLE
MGMT-20331: Don't use the detached annotation with the converged flow

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -311,15 +311,13 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 		return res.Result()
 	}
 
-	if r.ConvergedFlowEnabled {
-		result = r.addBMHDetachedAnnotationIfBmhIsProvisioned(log, bmh, agent)
-	} else {
+	if !r.ConvergedFlowEnabled {
 		// After the agent has started installation, Ironic should not manage the host.
 		// Adding the detached annotation to the BMH stops Ironic from managing it.
 		result = r.addBMHDetachedAnnotationIfHostIsRebooting(log, bmh, agent)
-	}
-	if res := r.handleReconcileResult(ctx, log, result, bmh); res != nil {
-		return res.Result()
+		if res := r.handleReconcileResult(ctx, log, result, bmh); res != nil {
+			return res.Result()
+		}
 	}
 
 	result = r.reconcileSpokeBMH(ctx, log, bmh, agent)
@@ -596,16 +594,6 @@ func (r *BMACReconciler) reconcileClusterReference(bmh *bmh_v1alpha1.BareMetalHo
 	return false, nil
 }
 
-// The detached annotation is added if the BMH provisioning state is provisioned
-func (r *BMACReconciler) addBMHDetachedAnnotationIfBmhIsProvisioned(log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost, agent *aiv1beta1.Agent) reconcileResult {
-	if r.ConvergedFlowEnabled && bmh.Status.Provisioning.State != bmh_v1alpha1.StateProvisioned {
-		log.Debugf("Skipping adding detached annotation. BMH provisioning state is: %s should be: %s", bmh.Status.Provisioning.State, bmh_v1alpha1.StateProvisioned)
-		return reconcileComplete{}
-
-	}
-	return r.ensureBMHDetached(log, bmh, agent)
-}
-
 func (r *BMACReconciler) detachedValue(bmh *bmh_v1alpha1.BareMetalHost) (string, error) {
 	detachValue := []byte("assisted-service-controller")
 	if _, has_annotation := bmh.GetAnnotations()[BMH_DELETE_ANNOTATION]; has_annotation && r.ConvergedFlowEnabled {
@@ -620,6 +608,14 @@ func (r *BMACReconciler) detachedValue(bmh *bmh_v1alpha1.BareMetalHost) (string,
 }
 
 func (r *BMACReconciler) ensureBMHDetached(log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost, agent *aiv1beta1.Agent) reconcileResult {
+	currentValue, haveAnnotation := bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]
+
+	// Don't add the annotation if it doesn't exist, but if it does ensure it has the correct value until the user removes it
+	if r.ConvergedFlowEnabled && !haveAnnotation {
+		log.Debug("Ignoring request to detach BMH because converged flow is enabled")
+		return reconcileComplete{}
+	}
+
 	if bmh.ObjectMeta.Annotations == nil {
 		bmh.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -639,7 +635,6 @@ func (r *BMACReconciler) ensureBMHDetached(log logrus.FieldLogger, bmh *bmh_v1al
 	if err != nil {
 		return reconcileError{err: err}
 	}
-	currentValue, haveAnnotation := bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]
 	if haveAnnotation && currentValue == desiredValue {
 		return reconcileComplete{}
 	}

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -2441,7 +2441,7 @@ var _ = Describe("bmac reconcile - converged flow enabled", func() {
 				host.Spec.CustomDeploy = &bmh_v1alpha1.CustomDeploy{Method: ASSISTED_DEPLOY_METHOD}
 				host.Status.Provisioning.State = bmh_v1alpha1.StateProvisioned
 			})
-			It("should set detached annotation on the BMH", func() {
+			It("does not set detached annotation on the BMH", func() {
 				Expect(c.Update(ctx, host)).To(BeNil())
 
 				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
@@ -2451,11 +2451,9 @@ var _ = Describe("bmac reconcile - converged flow enabled", func() {
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
 				err = c.Get(ctx, types.NamespacedName{Name: "bmh-reconcile", Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
-				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
-
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
+				Expect(updatedHost.ObjectMeta.Annotations).ToNot(HaveKey(BMH_DETACHED_ANNOTATION))
 			})
-			It("sets the detached annotation metadata with the BMH delete annotation", func() {
+			It("does not set the detached annotation metadata with the BMH delete annotation", func() {
 				host.Annotations = map[string]string{BMH_DELETE_ANNOTATION: "true"}
 				Expect(c.Update(ctx, host)).To(Succeed())
 
@@ -2465,11 +2463,7 @@ var _ = Describe("bmac reconcile - converged flow enabled", func() {
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
 				Expect(c.Get(ctx, types.NamespacedName{Name: "bmh-reconcile", Namespace: testNamespace}, updatedHost)).To(Succeed())
-				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
-
-				args := &bmh_v1alpha1.DetachedAnnotationArguments{}
-				Expect(json.Unmarshal([]byte(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]), &args)).To(Succeed())
-				Expect(string(args.DeleteAction)).To(Equal(bmh_v1alpha1.DetachedDeleteActionDelay))
+				Expect(updatedHost.ObjectMeta.Annotations).ToNot(HaveKey(BMH_DETACHED_ANNOTATION))
 			})
 			It("removes the metadata when the delete annotation is removed", func() {
 				args := &bmh_v1alpha1.DetachedAnnotationArguments{

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -369,7 +369,17 @@ func (r *PreprovisioningImageReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		For(&metal3_v1alpha1.PreprovisioningImage{}).
 		Watches(&metal3_v1alpha1.PreprovisioningImage{}, &handler.EnqueueRequestForObject{}).
 		Watches(&aiv1beta1.InfraEnv{}, handler.EnqueueRequestsFromMapFunc(mapInfraEnvPPI)).
+		Watches(&metal3_v1alpha1.BareMetalHost{}, handler.EnqueueRequestsFromMapFunc(mapBMHtoPPI)).
 		Complete(r)
+}
+
+func mapBMHtoPPI(ctx context.Context, a client.Object) []reconcile.Request {
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: a.GetNamespace(),
+			Name:      a.GetName(),
+		},
+	}}
 }
 
 func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(ctx context.Context, a client.Object) []reconcile.Request {

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -460,6 +460,46 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(bmh.Annotations).To(HaveKey("reboot.metal3.io"))
 		})
 
+		It("doesn't reboot and sets a condition when an image is updated for a provisioned BMH", func() {
+			bmh.Status.Provisioning.State = metal3_v1alpha1.StateProvisioned
+			Expect(c.Update(ctx, bmh)).To(Succeed())
+
+			oldURL := "https://example.com/images/4b495e3f-6a3d-4742-aedd-7db57912c819?api_key=myotherkey&arch=x86_64&type=minimal-iso&version=4.13"
+			infraEnv.Status.ISODownloadURL = oldURL
+			infraEnv.Status.CreatedTime = &metav1.Time{Time: metav1.Now().Add(-InfraEnvImageCooldownPeriod)}
+			infraEnv.Status.Conditions = []conditionsv1.Condition{{Type: aiv1beta1.ImageCreatedCondition,
+				Status:  corev1.ConditionTrue,
+				Reason:  "some reason",
+				Message: "Some message",
+			}}
+			SetImageUrl(ppi, *infraEnv)
+			Expect(c.Status().Update(ctx, ppi)).To(BeNil())
+
+			newURL := "https://example.com/images/4b495e3f-6a3d-4742-aedd-7db57912c819?api_key=mykey&arch=x86_64&type=minimal-iso&version=4.13"
+			infraEnv.Status.ISODownloadURL = newURL
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+
+			setInfraEnvIronicConfig()
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "testPPI",
+			}
+			Expect(c.Get(ctx, key, ppi)).To(BeNil())
+
+			Expect(ppi.Status.ImageUrl).To(Equal(newURL))
+			bmhKey := types.NamespacedName{
+				Namespace: bmh.Namespace,
+				Name:      bmh.Name,
+			}
+			Expect(c.Get(ctx, bmhKey, bmh)).To(BeNil())
+			Expect(bmh.Annotations).ToNot(HaveKey("reboot.metal3.io"))
+		})
+
 		It("sets the image on the PPI to the initrd when the PPI doesn't accept ISO format", func() {
 			ppi.Spec.AcceptFormats = []metal3_v1alpha1.ImageFormat{metal3_v1alpha1.ImageFormatInitRD}
 			Expect(c.Update(ctx, ppi)).To(BeNil())

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -971,7 +971,16 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(len(requests)).To(Equal(0))
 		})
 	})
+})
 
+var _ = Describe("mapBMHtoPPI", func() {
+	It("returns a request for the matching object", func() {
+		bmh := &metal3_v1alpha1.BareMetalHost{ObjectMeta: metav1.ObjectMeta{Name: "testBMH", Namespace: testNamespace}}
+		requests := mapBMHtoPPI(context.Background(), bmh)
+		Expect(len(requests)).To(Equal(1))
+		Expect(requests[0].Namespace).To(Equal(bmh.Namespace))
+		Expect(requests[0].Name).To(Equal(bmh.Name))
+	})
 })
 
 func checkImageConditionFailed(c client.Client, ppi *metal3_v1alpha1.PreprovisioningImage, reason string, messageSubstring string) {


### PR DESCRIPTION
The original purpose of the detached annotation was to:
1. Prevent BMO from rebooting hosts that had already been installed back into the discovery ISO when changes were made to the infraenv.
2. Allow management of the hosts by the managed cluster.

When the converged flow is being used, the ISO URL is no longer in the BMH directly and the BMH is marked as provisioned so BMO doesn't reboot the host even if the URL in the preprovisioningimage resource changes. To force a reboot we already need to add a separate annotation to the BMH which will now only be done when the BMH is not marked as provisioned.

Additionally, when installing hosts we don't send the credentials down to the managed cluster so we don't generally expect those hosts to be managed from there.

The detached annotation was also preventing users from taking advantage of day-2 management features such as firmware updates, BMC event monitoring, and power operations. Allowing these hosts to remain under management will ensure these features can be used.

In order for any of this to matter or work the BMHs also need to not be paused by setting the `PAUSE_PROVISIONED_BMHS` to "false" using a configmap.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Manually tested in a dev-scripts environment by provisioning and deprovisioning hosts.
Also requested an image built from this branch to be tested by the telco team requesting the change.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) - need to check on this
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the behavior for adding the "detached" annotation to BareMetalHost resources, ensuring it is only set under appropriate conditions when converged flow is disabled.
- **Refactor**
	- Improved the structure and modularity of the PreprovisioningImage controller for better maintainability and clearer error handling.
- **Tests**
	- Updated and added test cases to verify the new annotation logic and controller behavior, including scenarios for image updates and event mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->