### PR TITLE
MGMT-20610: Generate manifests for arbiter hosts for chrony and nic reapply

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -238,7 +238,11 @@ func (m *ManifestsGenerator) createChronyManifestContent(c *common.Cluster, role
 }
 
 func (m *ManifestsGenerator) AddChronyManifest(ctx context.Context, log logrus.FieldLogger, cluster *common.Cluster) error {
-	for _, role := range []models.HostRole{models.HostRoleMaster, models.HostRoleWorker} {
+	roles := []models.HostRole{models.HostRoleMaster, models.HostRoleWorker}
+	if common.IsClusterTopologyHighlyAvailableArbiter(cluster) {
+		roles = append(roles, models.HostRoleArbiter)
+	}
+	for _, role := range roles {
 		content, err := m.createChronyManifestContent(cluster, role, log)
 
 		if err != nil {
@@ -591,6 +595,9 @@ func (m *ManifestsGenerator) AddNicReapply(ctx context.Context, log logrus.Field
 	manifestParamsList := []map[string]interface{}{
 		{"ROLE": "master"},
 		{"ROLE": "worker"},
+	}
+	if common.IsClusterTopologyHighlyAvailableArbiter(c) {
+		manifestParamsList = append(manifestParamsList, map[string]interface{}{"ROLE": "arbiter"})
 	}
 	for _, manifestParams := range manifestParamsList {
 		content, err := fillTemplate(manifestParams, nicReapplyManifest, log)

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -319,6 +319,29 @@ var _ = Describe("chrony manifest", func() {
 
 		})
 
+		It("CreateClusterManifest success - TNA cluster", func() {
+			arbiterHost := createHost([]*models.NtpSource{
+				common.TestNTPSourceSynced,
+				common.TestNTPSourceUnsynced,
+			})
+			arbiterHost.Role = models.HostRoleArbiter
+			cluster.Hosts = append(cluster.Hosts, arbiterHost)
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
+				FileName: "50-masters-chrony-configuration.yaml",
+				Folder:   models.ManifestFolderOpenshift,
+			}, nil).Times(1)
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
+				FileName: "50-arbiters-chrony-configuration.yaml",
+				Folder:   models.ManifestFolderOpenshift,
+			}, nil).Times(1)
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
+				FileName: "50-workers-chrony-configuration.yaml",
+				Folder:   models.ManifestFolderOpenshift,
+			}, nil).Times(1)
+			Expect(ntpUtils.AddChronyManifest(ctx, log, cluster)).ShouldNot(HaveOccurred())
+
+		})
+
 		It("CreateClusterManifest failure", func() {
 			fileName := "50-masters-chrony-configuration.yaml"
 			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(nil, errors.Errorf("Failed to create manifest %s", fileName)).Times(1)


### PR DESCRIPTION


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

There are a few manifests we generate for clusters before installing them that are duplicated for each MachineConfigPool.
Because TNA clusters have a new MCP for arbiter nodes, we need to also generate the manifests for it.
Those manifests are:
- chrony configuration
- nic reapply (used when one of the nodes is using iscsi)

## List all the issues related to this PR

Closes [MGMT-20610](https://issues.redhat.com//browse/MGMT-20610)

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
