### PR TITLE
MGMT-20664: ironic inspection fails when hub and spoke architectures are different

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -428,25 +428,25 @@ func (r *PreprovisioningImageReconciler) getIronicAgentImageFromUserOverride(log
 	return ""
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
-	iccConfig, err := r.BMOUtils.getICCConfig(ctx)
+func (r *PreprovisioningImageReconciler) imageMatchesInfraenvArch(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv, ironicImage string) bool {
+	if ironicImage == "" {
+		return false
+	}
+
+	architectures, err := r.OcRelease.GetImageArchitecture(log, ironicImage, infraEnvInternal.PullSecret)
 	if err != nil {
-		log.WithError(err).Info("ICC configuration is not available")
-		return nil
+		log.WithError(err).Info("Failed to get image architecture for ironic agent image")
+		return false
 	}
 
-	var architectures []string
-	architectures, err = r.OcRelease.GetImageArchitecture(log, iccConfig.IronicAgentImage, infraEnvInternal.PullSecret)
-	if err == nil && funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
-		log.Infof("Setting ironic agent image (%s) from ICC config", iccConfig.IronicAgentImage)
-		return iccConfig
+	matches := funk.Contains(architectures, infraEnvInternal.CPUArchitecture)
+	if !matches {
+		log.Infof("CPU architecture (%v) of Ironic agent image (%s) does not match infraEnv arch (%s)",
+			architectures,
+			ironicImage,
+			infraEnvInternal.CPUArchitecture)
 	}
-
-	log.Infof("CPU architecture (%v) of Ironic agent image (%s) from ICC config is not available for infraEnv with arch (%s)",
-		architectures,
-		iccConfig.IronicAgentImage,
-		infraEnvInternal.CPUArchitecture)
-	return nil
+	return matches
 }
 
 func (r *PreprovisioningImageReconciler) getIronicAgentImageFromHUB(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) string {
@@ -496,8 +496,14 @@ func (r *PreprovisioningImageReconciler) getIronicAgentDefaultImage(log logrus.F
 }
 
 func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv, infraEnvInternal *common.InfraEnv) (*ICCConfig, error) {
-	iccConfig := r.getIronicConfigFromBMOConfig(ctx, log, infraEnvInternal)
-	if iccConfig == nil {
+	iccConfig, err := r.BMOUtils.getICCConfig(ctx)
+	if err != nil {
+		log.WithError(err).Info("ICC configuration is not available")
+	}
+
+	if iccConfig != nil {
+		log.Infof("Using ironic URLs from ICC config (Base: %s, Inspector: %s)", iccConfig.IronicBaseURL, iccConfig.IronicInspectorBaseUrl)
+	} else {
 		iccConfig = &ICCConfig{}
 		if err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig); err != nil {
 			return nil, err
@@ -506,9 +512,9 @@ func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, lo
 
 	if ironicAgentImageUserOverride := r.getIronicAgentImageFromUserOverride(log, infraEnv); ironicAgentImageUserOverride != "" {
 		iccConfig.IronicAgentImage = ironicAgentImageUserOverride
-	}
-
-	if iccConfig.IronicAgentImage == "" {
+	} else if iccConfig.IronicAgentImage != "" && r.imageMatchesInfraenvArch(log, infraEnvInternal, iccConfig.IronicAgentImage) {
+		log.Infof("Setting ironic agent image (%s) from ICC config", iccConfig.IronicAgentImage)
+	} else {
 		iccConfig.IronicAgentImage = r.getIronicAgentImageFromHUB(ctx, log, infraEnvInternal)
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20664

Currently in mixed-architecture deployments with ironic agent image override, we incorrectly discard the ICC config when hub and spoke architectures are different, causing fallback to the default `fillServiceUrls` method. This change preserves ironic urls from ICC regardless of image architecture compatibility by separating url concerns from image selection.