### PR TITLE
OCPBUGS-56596: Include AdditionalTrustBundlePolicy in installConfig

### DIFF
--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -703,6 +703,18 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(string(result.CPUPartitioningMode)).Should(Equal("AllNodes"))
 	})
 
+	It("AdditionalTrustBundlePolicy config overrides", func() {
+		var result installcfg.InstallerConfigBaremetal
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		cluster.InstallConfigOverrides = `{"additionalTrustBundlePolicy":"Always"}`
+		data, err := installConfig.GetInstallConfig(&cluster, clusterInfraenvs, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = json.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		// test that overrides worked
+		Expect(string(result.AdditionalTrustBundlePolicy)).Should(Equal("Always"))
+	})
+
 	It("Baremetal host BMC configuration overrides", func() {
 		var result installcfg.InstallerConfigBaremetal
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -210,6 +210,16 @@ const (
 	CPUPartitioningAllNodes CPUPartitioningMode = "AllNodes"
 )
 
+// PolicyType is for usage polices that are applied to additionalTrustBundle.
+type PolicyType string
+
+const (
+	// PolicyProxyOnly  enables use of AdditionalTrustBundle when http/https proxy is configured.
+	PolicyProxyOnly PolicyType = "Proxyonly"
+	// PolicyAlways ignores all conditions and uses AdditionalTrustBundle.
+	PolicyAlways PolicyType = "Always"
+)
+
 type InstallerConfigBaremetal struct {
 	APIVersion string `json:"apiVersion"`
 	BaseDomain string `json:"baseDomain"`
@@ -245,6 +255,8 @@ type InstallerConfigBaremetal struct {
 	PullSecret            string              `json:"pullSecret"`
 	SSHKey                string              `json:"sshKey"`
 	AdditionalTrustBundle string              `json:"additionalTrustBundle,omitempty"`
+	// This field is only needed for installConfig overrides. It defaults to Proxyonly.
+	AdditionalTrustBundlePolicy PolicyType `json:"additionalTrustBundlePolicy,omitempty"`
 	// The ImageContentSources field is deprecated. Please use ImageDigestSources.
 	DeprecatedImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 	ImageDigestSources            []ImageDigestSource  `json:"imageDigestSources,omitempty"`


### PR DESCRIPTION
The agent-based installer added support for setting the AdditionalTrustBundlePolicy in install-config-overrides, however the field was not included in the installConfig definition. This results in the overrides not being set (the failure was silently ignored due to agent-installer bug
https://issues.redhat.com/browse/OCPBUGS-56913).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
