### PR TITLE
MGMT-20700: Revert "MGMT-20272: Cluster attribute finalizing_stage_started_at show wrong value (#7594)"

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1841,15 +1841,11 @@ func (m *Manager) UpdateFinalizingStage(ctx context.Context, clusterID strfmt.UU
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("cluster is %s, not in one of allowed statuses: %v", swag.StringValue(cls.Status), allowedStatuses))
 	}
 	if cls.Progress == nil || cls.Progress.FinalizingStage != finalizingStage {
-		updates := map[string]interface{}{
-			"progress_finalizing_stage":           finalizingStage,
-			"progress_finalizing_stage_timed_out": false,
-		}
-		// Start timer only in the first finalizing stage
-		if finalizingStage == models.FinalizingStageWaitingForClusterOperators {
-			updates["progress_finalizing_stage_started_at"] = time.Now()
-		}
-		if err = m.db.Model(&common.Cluster{}).Where("id = ?", clusterID.String()).Updates(updates).Error; err != nil {
+		if err = m.db.Model(&common.Cluster{}).Where("id = ?", clusterID.String()).Updates(map[string]interface{}{
+			"progress_finalizing_stage":            finalizingStage,
+			"progress_finalizing_stage_started_at": time.Now(),
+			"progress_finalizing_stage_timed_out":  false,
+		}).Error; err != nil {
 			return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "update finalizing stage for cluster %s", clusterID.String()))
 		}
 		eventgen.SendClusterFinalizingStageUpdatedEvent(ctx, m.eventsHandler, clusterID, string(finalizingStage))

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -4287,39 +4287,18 @@ var _ = Describe("update finalizing stage", func() {
 		Expect(err).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
 		Expect(err.(*common.ApiErrorResponse).Code()).To(BeEquivalentTo(http.StatusBadRequest))
 	})
-	It("finalizing_stage_started_at is set only at the start of the stage", func() {
-		createCluster(models.ClusterStatusFinalizing)
-
-		stages := []models.FinalizingStage{
-			models.FinalizingStageWaitingForClusterOperators,
-			models.FinalizingStageAddingRouterCa,
-		}
-
-		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).Times(2)
-
-		Expect(capi.UpdateFinalizingStage(ctx, clusterID, stages[0])).ToNot(HaveOccurred())
-		cls, err := common.GetClusterFromDB(db, clusterID, common.SkipEagerLoading)
-		Expect(err).ToNot(HaveOccurred())
-		firstStartedAt := cls.Progress.FinalizingStageStartedAt
-
-		time.Sleep(10 * time.Millisecond)
-
-		Expect(capi.UpdateFinalizingStage(ctx, clusterID, stages[1])).ToNot(HaveOccurred())
-		cls, err = common.GetClusterFromDB(db, clusterID, common.SkipEagerLoading)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(cls.Progress.FinalizingStageStartedAt).To(Equal(firstStartedAt))
-	})
-
 	for _, st := range finalizingStages {
 		stage := st
 		It(fmt.Sprintf("success for stage '%s'", stage), func() {
 			createCluster(models.ClusterStatusFinalizing)
 			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).Times(1)
+			start := time.Now()
 			Expect(capi.UpdateFinalizingStage(ctx, clusterID, stage)).ToNot(HaveOccurred())
+			duration := time.Since(start)
 			cls, err := common.GetClusterFromDB(db, clusterID, common.SkipEagerLoading)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cls.Progress.FinalizingStage).To(Equal(stage))
+			Expect(time.Time(cls.Progress.FinalizingStageStartedAt)).To(BeTemporally("~", start, duration+time.Second))
 			Expect(cls.Progress.FinalizingStageTimedOut).To(BeFalse())
 		})
 	}


### PR DESCRIPTION
This reverts commit 324c74eca63dded25474ee0a094c49fb596b8fe2. The commit was based on a misunderstanding and caused https://issues.redhat.com/browse/MGMT-20700. More details could be find on https://issues.redhat.com/browse/MGMT-20272. 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
