### PR TITLE
MGMT-20722: Remove installer binaries from page cache during Cleanup

### DIFF
--- a/internal/ignition/installmanifests.go
+++ b/internal/ignition/installmanifests.go
@@ -224,7 +224,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte)
 	defer func() {
 		e := release.Cleanup(ctx)
 		if e != nil {
-			err = errors.Wrapf(err, "unable to clean up release due to error: %s", e.Error())
+			log.WithError(e).Warnf("Failed to clean up installer release %s", release.Path)
 		}
 	}()
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Following slack discussion, enforce installer binaries to be move out from the page cache to limit memory consumption. This is the first naive implementation that calls systematically fadvise. If the test is conclusive, we might consider a smarter approach that keep some installer binaries in the page cache up to a given limit.

I didn't find it useful to add such call after extracting the binary since the binary is going to be called right after being extracted, and `Cleanup` is called systematically. The edge case would be if later we logic after extracting the binary and this logic fail. Then the binary might live longer in the page cache. That sounds unlikely tho

It's always "fixing" the error management in `internal/ignition/installmanifests.go`. Since the return value is not named in the signature, `err = errors.Wrapf(err, ...` was just ignored

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
