### PR TITLE
MGMT-20674: Operator may return several ValidationResult

### DIFF
--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -36,15 +36,15 @@ type Operator interface {
 	// GetDependencies provides a list of dependencies of the Operator
 	GetDependencies(cluster *common.Cluster) ([]string, error)
 	// ValidateCluster verifies whether this operator is valid for given cluster
-	ValidateCluster(ctx context.Context, cluster *common.Cluster) (ValidationResult, error)
+	ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]ValidationResult, error)
 	// ValidateHost verifies whether this operator is valid for given host
 	ValidateHost(ctx context.Context, cluster *common.Cluster, hosts *models.Host, additionalOperatorRequirements *models.ClusterHostRequirementsDetails) (ValidationResult, error)
 	// GenerateManifests generates manifests for the operator
 	GenerateManifests(*common.Cluster) (map[string][]byte, []byte, error)
 	// GetHostRequirements provides operator's requirements towards the host
 	GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error)
-	// GetClusterValidationID returns cluster validation ID for the Operator
-	GetClusterValidationID() string
+	// GetClusterValidationIDs returns cluster validation IDs for the Operator
+	GetClusterValidationIDs() []string
 	// GetHostValidationID returns host validation ID for the Operator
 	GetHostValidationID() string
 	// GetProperties provides description of operator properties

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -66,18 +66,18 @@ func (mr *MockOperatorMockRecorder) GetBundleLabels() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleLabels", reflect.TypeOf((*MockOperator)(nil).GetBundleLabels))
 }
 
-// GetClusterValidationID mocks base method.
-func (m *MockOperator) GetClusterValidationID() string {
+// GetClusterValidationIDs mocks base method.
+func (m *MockOperator) GetClusterValidationIDs() []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterValidationID")
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetClusterValidationIDs")
+	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
-// GetClusterValidationID indicates an expected call of GetClusterValidationID.
-func (mr *MockOperatorMockRecorder) GetClusterValidationID() *gomock.Call {
+// GetClusterValidationIDs indicates an expected call of GetClusterValidationIDs.
+func (mr *MockOperatorMockRecorder) GetClusterValidationIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterValidationID", reflect.TypeOf((*MockOperator)(nil).GetClusterValidationID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterValidationIDs", reflect.TypeOf((*MockOperator)(nil).GetClusterValidationIDs))
 }
 
 // GetDependencies mocks base method.
@@ -210,10 +210,10 @@ func (mr *MockOperatorMockRecorder) GetProperties() *gomock.Call {
 }
 
 // ValidateCluster mocks base method.
-func (m *MockOperator) ValidateCluster(arg0 context.Context, arg1 *common.Cluster) (ValidationResult, error) {
+func (m *MockOperator) ValidateCluster(arg0 context.Context, arg1 *common.Cluster) ([]ValidationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateCluster", arg0, arg1)
-	ret0, _ := ret[0].(ValidationResult)
+	ret0, _ := ret[0].([]ValidationResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/operators/authorino/authorino_operator.go
+++ b/internal/operators/authorino/authorino_operator.go
@@ -24,6 +24,11 @@ var Operator = models.MonitoredOperator{
 	},
 }
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDAuthorinoRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDAuthorinoRequirementsSatisfied)
+)
+
 // operator is an Authorino AI OLM operator plugin.
 type operator struct {
 	log       logrus.FieldLogger
@@ -56,22 +61,22 @@ func (o *operator) GetDependencies(c *common.Cluster) (result []string, err erro
 	return
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDAuthorinoRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDAuthorinoRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result.Status = api.Success
-	return
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		ValidationId: clusterValidationID,
+		Status:       api.Success,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -340,15 +340,16 @@ var _ = Describe("CNV operator", func() {
 		cluster.CPUArchitecture = cpuArch
 		for _, v := range ocpVersion {
 			cluster.OpenshiftVersion = v
-			validation, err := operator.ValidateCluster(context.TODO(), &cluster)
+			validations, err := operator.ValidateCluster(context.TODO(), &cluster)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(validations).To(HaveLen(1))
 
-			Expect(validation.Status).To(Equal(expectedApiStatus),
+			Expect(validations[0].Status).To(Equal(expectedApiStatus),
 				fmt.Sprintf("Validate OCP version %s, in %s validatation should be %s", cluster.OpenshiftVersion, cpuArch, expectedApiStatus))
 
 			if expectedApiStatus == api.Failure {
-				Expect(validation.Reasons).To(ContainElements(errorMessage),
-					fmt.Sprintf("Got Error message: %s", validation.Reasons))
+				Expect(validations[0].Reasons).To(ContainElements(errorMessage),
+					fmt.Sprintf("Got Error message: %s", validations[0].Reasons))
 			}
 		}
 	},

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_consts.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_consts.go
@@ -1,8 +1,13 @@
 package fenceagentsremediation
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	operatorName             = "fence-agents-remediation"
 	operatorSubscriptionName = "fence-agents-remediation"
 	operatorNamespace        = "openshift-workload-availability"
 	OperatorFullName         = "Fence Agents Remediation"
+
+	clusterValidationID = string(models.ClusterValidationIDFenceAgentsRemediationRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDFenceAgentsRemediationRequirementsSatisfied)
 )

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
@@ -54,14 +54,14 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{operatorsCommon.NodeHealthcheckOperatorName}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDFenceAgentsRemediationRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDFenceAgentsRemediationRequirementsSatisfied)
+	return hostValidationID
 }
 
 // GetProperties provides description of operator properties

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_validations.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_validations.go
@@ -9,11 +9,11 @@ import (
 )
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}, nil
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/kmm/kmm_operator.go
+++ b/internal/operators/kmm/kmm_operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDKmmRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDKmmRequirementsSatisfied)
+)
+
 var Operator = models.MonitoredOperator{
 	Namespace:        "openshift-kmm",
 	Name:             "kmm",
@@ -65,25 +70,22 @@ func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
 	return result, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDKmmRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDKmmRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result = api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}
-	return
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/kubedescheduler/kube_descheduler_consts.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_consts.go
@@ -1,8 +1,13 @@
 package kubedescheduler
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	operatorName             = "kube-descheduler"
 	operatorSubscriptionName = "cluster-kube-descheduler-operator"
 	operatorNamespace        = "openshift-kube-descheduler-operator"
 	OperatorFullName         = "Kube Descheduler"
+
+	clusterValidationID = string(models.ClusterValidationIDKubeDeschedulerRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDKubeDeschedulerRequirementsSatisfied)
 )

--- a/internal/operators/kubedescheduler/kube_descheduler_operator.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_operator.go
@@ -54,14 +54,14 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDKubeDeschedulerRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDKubeDeschedulerRequirementsSatisfied)
+	return hostValidationID
 }
 
 // GetProperties provides description of operator properties

--- a/internal/operators/kubedescheduler/kube_descheduler_validations.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_validations.go
@@ -9,11 +9,11 @@ import (
 )
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}, nil
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -8,6 +8,11 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDLsoRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDLsoRequirementsSatisfied)
+)
+
 // lsOperator is an LSO OLM operator plugin; it implements api.Operator
 type lsOperator struct {
 }
@@ -39,19 +44,22 @@ func (l *lsOperator) GetDependencies(cluster *common.Cluster) ([]string, error) 
 	return make([]string, 0), nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (l *lsOperator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDLsoRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (l *lsOperator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (l *lsOperator) GetHostValidationID() string {
-	return string(models.HostValidationIDLsoRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster always return "valid" result
-func (l *lsOperator) ValidateCluster(_ context.Context, _ *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{Status: api.Success, ValidationId: l.GetClusterValidationID(), Reasons: []string{}}, nil
+func (l *lsOperator) ValidateCluster(_ context.Context, _ *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		Status:       api.Success,
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost always return "valid" result

--- a/internal/operators/lvm/lvm_operator_test.go
+++ b/internal/operators/lvm/lvm_operator_test.go
@@ -103,33 +103,33 @@ var _ = Describe("Lvm Operator", func() {
 	)
 
 	Context("ValidateCluster", func() {
-		table.DescribeTable("validate cluster when ", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
+		table.DescribeTable("validate cluster when ", func(cluster *common.Cluster, expectedResult []api.ValidationResult) {
 			res, _ := operator.ValidateCluster(ctx, cluster)
 			Expect(res).Should(Equal(expectedResult))
 		},
 			table.Entry("Control Plane Count 3",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, Hosts: []*models.Host{hostWithSufficientResources, hostWithSufficientResources}, OpenshiftVersion: LvmMinMultiNodeSupportVersion}},
-				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID()},
+				[]api.ValidationResult{{Status: api.Success, ValidationId: operator.GetHostValidationID()}},
 			),
 			table.Entry("Control Plane Count 3 with pre-release version",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, Hosts: []*models.Host{hostWithSufficientResources, hostWithSufficientResources}, OpenshiftVersion: "4.15.0-rc0"}},
-				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID()},
+				[]api.ValidationResult{{Status: api.Success, ValidationId: operator.GetHostValidationID()}},
 			),
 			table.Entry("Control Plane Count 3 with higher than LvmMinMultiNodeSupportVersion",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, Hosts: []*models.Host{hostWithSufficientResources, hostWithSufficientResources}, OpenshiftVersion: "4.15.7"}},
-				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID()},
+				[]api.ValidationResult{{Status: api.Success, ValidationId: operator.GetHostValidationID()}},
 			),
 			table.Entry("Control Plane Count 3 and Openshift version less than LvmMinMultiNodeSupportVersion",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: "4.14.0"}},
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Logical Volume Manager is only supported for highly available openshift with version 4.15.0 or above"}},
+				[]api.ValidationResult{{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Logical Volume Manager is only supported for highly available openshift with version 4.15.0 or above"}}},
 			),
 			table.Entry("Control Plane Count 1 None and Openshift version less than minimal",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: 1, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: "4.10.0"}},
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Logical Volume Manager is only supported for openshift versions 4.11.0 and above"}},
+				[]api.ValidationResult{{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Logical Volume Manager is only supported for openshift versions 4.11.0 and above"}}},
 			),
 			table.Entry("Control Plane Count 1 and Openshift version more than minimal",
 				&common.Cluster{Cluster: models.Cluster{ControlPlaneCount: 1, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: LvmoMinOpenshiftVersion}},
-				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID()},
+				[]api.ValidationResult{{Status: api.Success, ValidationId: operator.GetHostValidationID()}},
 			),
 		)
 	})

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -313,20 +313,22 @@ func (mgr *Manager) ValidateCluster(ctx context.Context, cluster *common.Cluster
 				return nil, err
 			}
 			delete(pendingOperators, clusterOperator.Name)
-			results = append(results, result)
+			results = append(results, result...)
 		}
 	}
 	// Add successful validation result for disabled operators
 	for opName := range pendingOperators {
 		operator := mgr.olmOperators[opName]
-		result := api.ValidationResult{
-			Status:       api.Success,
-			ValidationId: operator.GetClusterValidationID(),
-			Reasons: []string{
-				fmt.Sprintf("%s is disabled", opName),
-			},
+		for _, validationID := range operator.GetClusterValidationIDs() {
+			result := api.ValidationResult{
+				Status:       api.Success,
+				ValidationId: validationID,
+				Reasons: []string{
+					fmt.Sprintf("%s is disabled", opName),
+				},
+			}
+			results = append(results, result)
 		}
-		results = append(results, result)
 	}
 	return results, nil
 }

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -506,7 +506,7 @@ var _ = Describe("Operators manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(22))
 			Expect(results).To(ContainElements(
-				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied), Reasons: []string{}},
+				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 				api.ValidationResult{Status: api.Failure, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied),
 					Reasons: []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDCnvRequirementsSatisfied), Reasons: []string{"cnv is disabled"}},

--- a/internal/operators/mce/mce_operator_test.go
+++ b/internal/operators/mce/mce_operator_test.go
@@ -75,17 +75,17 @@ var _ = Describe("MCE Operator", func() {
 		)
 	})
 	Context("ValidateCluster", func() {
-		table.DescribeTable("validate cluster when ", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
+		table.DescribeTable("validate cluster when ", func(cluster *common.Cluster, expectedResult []api.ValidationResult) {
 			res, _ := operator.ValidateCluster(ctx, cluster)
 			Expect(res).Should(Equal(expectedResult))
 		},
 			table.Entry("Openshift version less than minimal",
 				&common.Cluster{Cluster: models.Cluster{Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: "4.9.0"}},
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{fmt.Sprintf("multicluster engine is only supported for openshift versions %s and above", MceMinOpenshiftVersion)}},
+				[]api.ValidationResult{{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{fmt.Sprintf("multicluster engine is only supported for openshift versions %s and above", MceMinOpenshiftVersion)}}},
 			),
 			table.Entry("Openshift version more than minimal",
 				&common.Cluster{Cluster: models.Cluster{Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: MceMinOpenshiftVersion}},
-				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID()},
+				[]api.ValidationResult{{Status: api.Success, ValidationId: operator.GetHostValidationID()}},
 			),
 		)
 	})

--- a/internal/operators/mtv/config.go
+++ b/internal/operators/mtv/config.go
@@ -1,5 +1,7 @@
 package mtv
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	Name                   = "mtv"
 	FullName               = "OpenShift Migration Toolkit for Virtualization"
@@ -15,6 +17,9 @@ const (
 	// Memory value provided in GIB
 	WorkerMemory int64 = 1
 	WorkerCPU    int64 = 1
+
+	clusterValidationID = string(models.ClusterValidationIDMtvRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDMtvRequirementsSatisfied)
 )
 
 type Config struct {

--- a/internal/operators/mtv/operator_test.go
+++ b/internal/operators/mtv/operator_test.go
@@ -36,7 +36,7 @@ var _ = Describe("MTV Operator", func() {
 		})
 
 		It("should return the right validations ids", func() {
-			Expect(operator.GetClusterValidationID()).To(Equal(string(models.ClusterValidationIDMtvRequirementsSatisfied)))
+			Expect(operator.GetClusterValidationIDs()).To(Equal([]string{string(models.ClusterValidationIDMtvRequirementsSatisfied)}))
 			Expect(operator.GetHostValidationID()).To(Equal(string(models.HostValidationIDMtvRequirementsSatisfied)))
 		})
 

--- a/internal/operators/nmstate/operator.go
+++ b/internal/operators/nmstate/operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDNmstateRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDNmstateRequirementsSatisfied)
+)
+
 type operator struct {
 	log logrus.FieldLogger
 }
@@ -50,29 +55,43 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return make([]string, 0), nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDNmstateRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDNmstateRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster verifies whether this operator is valid for given cluster
-func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	result := []api.ValidationResult{{
+		Status:       api.Success,
+		ValidationId: clusterValidationID,
+	}}
+
 	if !featuresupport.IsFeatureCompatibleWithArchitecture(models.FeatureSupportLevelIDNMSTATE, cluster.OpenshiftVersion, cluster.CPUArchitecture) {
-		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{fmt.Sprintf(
-			"%s is not supported for %s CPU architecture.", o.GetFullName(), cluster.CPUArchitecture)}}, nil
+		result[0].Status = api.Failure
+		result[0].Reasons = []string{fmt.Sprintf("%s is not supported for %s CPU architecture.", o.GetFullName(), cluster.CPUArchitecture)}
+
+		return result, nil
 	}
 
-	if ok, _ := common.BaseVersionLessThan(NmstateMinOpenshiftVersion, cluster.OpenshiftVersion); ok {
-		message := fmt.Sprintf("%s is only supported for openshift versions %s and above", o.GetFullName(), NmstateMinOpenshiftVersion)
-		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+	ok, err := common.BaseVersionLessThan(NmstateMinOpenshiftVersion, cluster.OpenshiftVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compare openshift versions: %w", err)
 	}
 
-	return api.ValidationResult{Status: api.Success, ValidationId: o.GetClusterValidationID(), Reasons: []string{}}, nil
+	if ok {
+		result[0].Status = api.Failure
+		result[0].Reasons = []string{fmt.Sprintf("%s is only supported for openshift versions %s and above", o.GetFullName(), NmstateMinOpenshiftVersion)}
+
+		return result, nil
+	}
+
+	return result, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and cpu

--- a/internal/operators/nmstate/operator_test.go
+++ b/internal/operators/nmstate/operator_test.go
@@ -21,7 +21,7 @@ var _ = Describe("NMState Operator", func() {
 		})
 
 		It("should return the right validations ids", func() {
-			Expect(operator.GetClusterValidationID()).To(Equal(string(models.ClusterValidationIDNmstateRequirementsSatisfied)))
+			Expect(operator.GetClusterValidationIDs()).To(Equal([]string{string(models.ClusterValidationIDNmstateRequirementsSatisfied)}))
 			Expect(operator.GetHostValidationID()).To(Equal(string(models.HostValidationIDNmstateRequirementsSatisfied)))
 		})
 

--- a/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
+++ b/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDNodeFeatureDiscoveryRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDNodeFeatureDiscoveryRequirementsSatisfied)
+)
+
 var Operator = models.MonitoredOperator{
 	Namespace:        "openshift-nfd",
 	Name:             "node-feature-discovery",
@@ -64,25 +69,22 @@ func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
 	return make([]string, 0), nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDNodeFeatureDiscoveryRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDNodeFeatureDiscoveryRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result = api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		ValidationId: clusterValidationID,
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}
-	return
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/nodehealthcheck/node_healthcheck_consts.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_consts.go
@@ -1,7 +1,12 @@
 package nodehealthcheck
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	operatorSubscriptionName = "node-healthcheck-operator"
 	operatorNamespace        = "openshift-workload-availability"
 	OperatorFullName         = "Node Healthcheck"
+
+	clusterValidationID = string(models.ClusterValidationIDNodeHealthcheckRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDNodeHealthcheckRequirementsSatisfied)
 )

--- a/internal/operators/nodehealthcheck/node_healthcheck_operator.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_operator.go
@@ -62,14 +62,14 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{operatorscommon.SelfNodeRemediationOperatorName}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDNodeHealthcheckRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDNodeHealthcheckRequirementsSatisfied)
+	return hostValidationID
 }
 
 // GetProperties provides description of operator properties

--- a/internal/operators/nodehealthcheck/node_healthcheck_validations.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_validations.go
@@ -9,11 +9,11 @@ import (
 )
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}, nil
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/nodemaintenance/node_maintenance_consts.go
+++ b/internal/operators/nodemaintenance/node_maintenance_consts.go
@@ -1,8 +1,13 @@
 package nodemaintenance
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	operatorName             = "node-maintenance"
 	operatorSubscriptionName = "node-maintenance-operator"
 	operatorNamespace        = "openshift-workload-maintenance"
 	OperatorFullName         = "Node Maintenance Operator"
+
+	clusterValidationID = string(models.ClusterValidationIDNodeMaintenanceRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDNodeMaintenanceRequirementsSatisfied)
 )

--- a/internal/operators/nodemaintenance/node_maintenance_operator.go
+++ b/internal/operators/nodemaintenance/node_maintenance_operator.go
@@ -54,14 +54,14 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDNodeMaintenanceRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDNodeMaintenanceRequirementsSatisfied)
+	return hostValidationID
 }
 
 // GetProperties provides description of operator properties

--- a/internal/operators/nodemaintenance/node_maintenance_validations.go
+++ b/internal/operators/nodemaintenance/node_maintenance_validations.go
@@ -9,11 +9,11 @@ import (
 )
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}, nil
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/odf/consts.go
+++ b/internal/operators/odf/consts.go
@@ -1,9 +1,14 @@
 package odf
 
+import "github.com/openshift/assisted-service/models"
+
 type odfDeploymentMode string
 
 const (
 	compactMode  odfDeploymentMode = "Compact"  // only masters, control plane nodes will run ODF
 	standardMode odfDeploymentMode = "Standard" // at least 3 masters and 3 workers, workers will run ODF
 	unknown      odfDeploymentMode = "Unknown"  // none of the above, the mode is not determined yet
+
+	clusterValidationID = string(models.ClusterValidationIDOdfRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDOdfRequirementsSatisfied)
 )

--- a/internal/operators/odf/odf_operator.go
+++ b/internal/operators/odf/odf_operator.go
@@ -83,21 +83,29 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{lso.Operator.Name}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDOdfRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDOdfRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster verifies whether this operator is valid for given cluster
-func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
 	status, message := o.validateRequirements(&cluster.Cluster)
+	result := []api.ValidationResult{{
+		Status:       status,
+		ValidationId: clusterValidationID,
+	}}
 
-	return api.ValidationResult{Status: status, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+	if message != "" {
+		result[0].Reasons = []string{message}
+	}
+
+	return result, nil
 }
 
 func (o *operator) StorageClassName() string {

--- a/internal/operators/odf/odf_operator_test.go
+++ b/internal/operators/odf/odf_operator_test.go
@@ -965,123 +965,131 @@ var _ = Describe("Odf Operator", func() {
 	})
 
 	Context("ValidateCluster", func() {
-		table.DescribeTable("unknown mode scenario: validateCluster when", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
-			result, _ := operator.ValidateCluster(ctx, cluster)
-			Expect(result).To(Equal(expectedResult))
-		},
+		table.DescribeTable(
+			"unknown mode scenario: validateCluster when",
+
+			func(cluster *common.Cluster, expectedResult []api.ValidationResult) {
+				result, _ := operator.ValidateCluster(ctx, cluster)
+				Expect(result).To(Equal(expectedResult))
+			},
+
 			table.Entry("there is a single master",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 
 			table.Entry("there are two masters and one worker",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithNoDisk, workerWithTwoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 
 			table.Entry("there are 3 masters and 2 workers",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithNoDisk, masterWithLessDiskSize, workerWithTwoDisk, workerWithInvalidInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 
 			table.Entry("there are 4 masters and 2 workers",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithNoDisk, masterWithLessDiskSize, masterWithOneDisk, workerWithTwoDisk, workerWithInvalidInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 
 			table.Entry("missing inventory",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithNoDisk, masterWithLessDiskSize, masterWithOneDisk, workerWithTwoDisk, masterWithNoInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 
 			table.Entry("invalid inventory",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithNoDisk, masterWithLessDiskSize, masterWithOneDisk, workerWithTwoDisk, workerWithInvalidInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"The cluster must either have no dedicated worker nodes or at least three. Add or remove hosts, or change their roles configurations to meet the requirement."},
-				},
+				}},
 			),
 		)
 
-		table.DescribeTable("compact mode scenario: validateCluster when", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
-			result, _ := operator.ValidateCluster(ctx, cluster)
-			Expect(result).To(Equal(expectedResult))
-		},
+		table.DescribeTable(
+			"compact mode scenario: validateCluster when",
+
+			func(cluster *common.Cluster, expectedResult []api.ValidationResult) {
+				result, _ := operator.ValidateCluster(ctx, cluster)
+				Expect(result).To(Equal(expectedResult))
+			},
+
 			table.Entry("there are 2 masters and 1 auto-assign",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, autoAssignHost,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are 3 masters - sufficient resources",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDisk, masterWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are 4 masters - sufficient resources",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are 5 masters - sufficient resources",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			// host's validation will fail
@@ -1089,95 +1097,99 @@ var _ = Describe("Odf Operator", func() {
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithOneDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters doesn't have eligible disk",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithOneDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters is missing inventory",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithNoInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Pending,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Missing Inventory in some of the hosts"},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters has invalid inventory",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithThreeDisk, masterWithThreeDiskSizeOfOneZero, masterWithInvalidInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Failed to parse the inventory of some of the hosts"},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - not enough resources",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDiskSizeOfOneZero, masterWithThreeDiskSizeOfOneZero, masterWithNoDisk, masterWithNoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Insufficient resources to deploy ODF in compact mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of 25 GB minimum and an installation disk."},
-				},
+				}},
 			),
 
 			table.Entry("there is an arbiter with missing inventory",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithLessDiskSize, arbiterWithNoInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Pending,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Missing Inventory in some of the hosts"},
-				},
+				}},
 			),
 
 			table.Entry("there are 2 masters and 1 arbiter",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithLessDiskSize, arbiterWithTwoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Compact Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there is an arbiter with only one disk",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
 					masterWithThreeDisk, masterWithLessDiskSize, arbiterWithOneDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Insufficient resources to deploy ODF in compact mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of 25 GB minimum and an installation disk."},
-				},
+				}},
 			),
 		)
 
-		table.DescribeTable("standard mode scenario: validateCluster when", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
-			result, _ := operator.ValidateCluster(ctx, cluster)
-			Expect(result).To(Equal(expectedResult))
-		},
+		table.DescribeTable(
+			"standard mode scenario: validateCluster when",
+
+			func(cluster *common.Cluster, expectedResult []api.ValidationResult) {
+				result, _ := operator.ValidateCluster(ctx, cluster)
+				Expect(result).To(Equal(expectedResult))
+			},
+
 			// Will fail host validation
 			table.Entry("there are 3 masters, 3 workers and 1 auto-assign",
 				&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Hosts: []*models.Host{
@@ -1189,11 +1201,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					autoAssignHost,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are 3 masters and 3 workers - sufficient resources",
@@ -1205,11 +1217,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are 4 masters and 4 workers - sufficient resources",
@@ -1223,11 +1235,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters doesn't have eligible disk",
@@ -1240,11 +1252,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithNoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			// host's validation will fail
@@ -1258,11 +1270,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithNoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters is missing inventory",
@@ -1274,11 +1286,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough workers - one of the workers is missing inventory",
@@ -1290,11 +1302,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithNoInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Pending,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Missing Inventory in some of the hosts"},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - one of the masters has invalid inventory",
@@ -1306,11 +1318,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough workers - one of the workers has invalid inventory",
@@ -1322,11 +1334,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithInvalidInventory,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Failed to parse the inventory of some of the hosts"},
-				},
+				}},
 			),
 
 			table.Entry("there are enough masters - not enough resources",
@@ -1338,11 +1350,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 
 			table.Entry("there are enough workers - not enough resources",
@@ -1354,11 +1366,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithNoDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Failure,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"Insufficient resources to deploy ODF in standard mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of 25 GB minimum and an installation disk."},
-				},
+				}},
 			),
 
 			table.Entry("there are 2 masters, 1 arbiter and 3 workers",
@@ -1370,11 +1382,11 @@ var _ = Describe("Odf Operator", func() {
 					workerWithThreeDisk,
 					workerWithThreeDisk,
 				}}},
-				api.ValidationResult{
+				[]api.ValidationResult{{
 					Status:       api.Success,
 					ValidationId: operator.GetHostValidationID(),
 					Reasons:      []string{"ODF Requirements for Standard Deployment are satisfied."},
-				},
+				}},
 			),
 		)
 	})

--- a/internal/operators/osc/operator.go
+++ b/internal/operators/osc/operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDOscRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDOscRequirementsSatisfied)
+)
+
 type operator struct {
 	log    logrus.FieldLogger
 	config *Config
@@ -52,29 +57,47 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return make([]string, 0), nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDOscRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDOscRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster verifies whether this operator is valid for given cluster
-func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	result := []api.ValidationResult{{
+		Status:       api.Success,
+		ValidationId: clusterValidationID,
+	}}
+
 	if !featuresupport.IsFeatureCompatibleWithArchitecture(models.FeatureSupportLevelIDOSC, cluster.OpenshiftVersion, cluster.CPUArchitecture) {
-		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{fmt.Sprintf(
-			"%s is not supported for %s CPU architecture.", o.GetFullName(), cluster.CPUArchitecture)}}, nil
+		result[0].Status = api.Failure
+		result[0].Reasons = []string{
+			fmt.Sprintf("%s is not supported for %s CPU architecture.", o.GetFullName(), cluster.CPUArchitecture),
+		}
+
+		return result, nil
 	}
 
-	if ok, _ := common.BaseVersionLessThan(OscMinOpenshiftVersion, cluster.OpenshiftVersion); ok {
-		message := fmt.Sprintf("%s is only supported for openshift versions %s and above", o.GetFullName(), OscMinOpenshiftVersion)
-		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+	ok, err := common.BaseVersionLessThan(OscMinOpenshiftVersion, cluster.OpenshiftVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compare openshift versions: %w", err)
 	}
 
-	return api.ValidationResult{Status: api.Success, ValidationId: o.GetClusterValidationID(), Reasons: []string{}}, nil
+	if ok {
+		result[0].Status = api.Failure
+		result[0].Reasons = []string{
+			fmt.Sprintf("%s is only supported for openshift versions %s and above", o.GetFullName(), OscMinOpenshiftVersion),
+		}
+
+		return result, nil
+	}
+
+	return result, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and cpu

--- a/internal/operators/osc/operator_test.go
+++ b/internal/operators/osc/operator_test.go
@@ -30,7 +30,7 @@ var _ = Describe("OSC Operator", func() {
 		})
 
 		It("should return the right validations ids", func() {
-			Expect(operator.GetClusterValidationID()).To(Equal(string(models.ClusterValidationIDOscRequirementsSatisfied)))
+			Expect(operator.GetClusterValidationIDs()).To(Equal([]string{string(models.ClusterValidationIDOscRequirementsSatisfied)}))
 			Expect(operator.GetHostValidationID()).To(Equal(string(models.HostValidationIDOscRequirementsSatisfied)))
 		})
 

--- a/internal/operators/pipelines/pipelines_operator.go
+++ b/internal/operators/pipelines/pipelines_operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDPipelinesRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDPipelinesRequirementsSatisfied)
+)
+
 var Operator = models.MonitoredOperator{
 	Namespace:        "openshift-operators",
 	Name:             "pipelines",
@@ -65,25 +70,22 @@ func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
 	return result, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDPipelinesRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDPipelinesRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result = api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		ValidationId: clusterValidationID,
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}
-	return
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/selfnoderemediation/self_node_remediation_consts.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_consts.go
@@ -1,7 +1,12 @@
 package selfnoderemediation
 
+import "github.com/openshift/assisted-service/models"
+
 const (
 	operatorSubscriptionName = "self-node-remediation"
 	operatorNamespace        = "openshift-workload-availability"
 	OperatorFullName         = "Self Node Remediation"
+
+	clusterValidationID = string(models.ClusterValidationIDSelfNodeRemediationRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDSelfNodeRemediationRequirementsSatisfied)
 )

--- a/internal/operators/selfnoderemediation/self_node_remediation_operator.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_operator.go
@@ -54,14 +54,14 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 	return []string{operatorsCommon.NodeHealthcheckOperatorName}, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the Operator
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDSelfNodeRemediationRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the Operator
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the Operator
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDSelfNodeRemediationRequirementsSatisfied)
+	return hostValidationID
 }
 
 // GetProperties provides description of operator properties

--- a/internal/operators/selfnoderemediation/self_node_remediation_validations.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_validations.go
@@ -9,11 +9,11 @@ import (
 )
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}, nil
+		ValidationId: clusterValidationID,
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/serverless/serverless_operator.go
+++ b/internal/operators/serverless/serverless_operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDServerlessRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDServerlessRequirementsSatisfied)
+)
+
 var Operator = models.MonitoredOperator{
 	Namespace:        "openshift-serverless",
 	Name:             "serverless",
@@ -65,25 +70,22 @@ func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
 	return result, nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDServerlessRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDServerlessRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result = api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		ValidationId: clusterValidationID,
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}
-	return
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.

--- a/internal/operators/servicemesh/servicemesh_operator.go
+++ b/internal/operators/servicemesh/servicemesh_operator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	clusterValidationID = string(models.ClusterValidationIDServicemeshRequirementsSatisfied)
+	hostValidationID    = string(models.HostValidationIDServicemeshRequirementsSatisfied)
+)
+
 var Operator = models.MonitoredOperator{
 	Namespace:        "openshift-operators",
 	Name:             "servicemesh",
@@ -64,25 +69,22 @@ func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
 	return make([]string, 0), nil
 }
 
-// GetClusterValidationID returns cluster validation ID for the operator.
-func (o *operator) GetClusterValidationID() string {
-	return string(models.ClusterValidationIDServicemeshRequirementsSatisfied)
+// GetClusterValidationIDs returns cluster validation IDs for the operator.
+func (o *operator) GetClusterValidationIDs() []string {
+	return []string{clusterValidationID}
 }
 
 // GetHostValidationID returns host validation ID for the operator.
 func (o *operator) GetHostValidationID() string {
-	return string(models.HostValidationIDServicemeshRequirementsSatisfied)
+	return hostValidationID
 }
 
 // ValidateCluster checks if the cluster satisfies the requirements to install the operator.
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (result api.ValidationResult,
-	err error) {
-	result.ValidationId = o.GetClusterValidationID()
-	result = api.ValidationResult{
+func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) ([]api.ValidationResult, error) {
+	return []api.ValidationResult{{
+		ValidationId: clusterValidationID,
 		Status:       api.Success,
-		ValidationId: o.GetClusterValidationID(),
-	}
-	return
+	}}, nil
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and CPU.


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

For Saas we are looking for a way to display a warning when openshiftai operator is selected but there is no supported GPU. The current implementation with the frontend is to return a dedicated validation-id that is then flagged as a "soft validation" by the front end

Currently openshift-ai already returns a validation (related to the number of worker). This PR changes the interface to allow operators to return multiple ClusterValidationID so that one is blocking (# of workers) and one is a soft validation (absence of supported GPU)

While implementing I also noted some suspicious lines. I will open a thread for each of them

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
