### PR TITLE
[release-ocm-2.11] MGMT-20740: Don't require mapping for names matching physical interfaces (PR #6715)

### DIFF
--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -241,15 +241,6 @@ method=disabled
 id=101
 parent=eth1
 `
-		It("vlan only - no underlying interface", func() {
-			err := staticNetworkGenerator.validateInterfaceNamesExistence(nil, []StaticNetworkConfigData{
-				{
-					FileContents: vlanConnection,
-				},
-			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no mac address mapping can be associated with the available network interfaces"))
-		})
 		It("vlan with underlying interface - no mapping", func() {
 			err := staticNetworkGenerator.validateInterfaceNamesExistence(nil, []StaticNetworkConfigData{
 				{
@@ -287,6 +278,85 @@ parent=eth1
 			}, []StaticNetworkConfigData{
 				{
 					FileContents: vlanConnection,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("no mapping for physical interfaces", func() {
+		withPhysicalInterface := `interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+        - ip: 192.0.2.1
+          prefix-length: 24
+  - name: eno12399np0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false`
+		withNoMappedInterfaces := `interfaces:
+  - name: eno12345
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false
+  - name: eno12399np0
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+      dhcp: false`
+		withMacIdentifier := `interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    identifier: mac-address
+    mac-address: f8:75:a4:a4:00:fe
+    ipv4:
+      enabled: false
+      dhcp: false`
+		It("no mapping needed for physical interface", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{
+						{
+							LogicalNicName: "eth0",
+							MacAddress:     "f8:75:a4:a4:00:fe",
+						},
+					},
+					NetworkYaml: withPhysicalInterface,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("at least one mapped interface is required", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{},
+					NetworkYaml:     withNoMappedInterfaces,
+				},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("at least one interface for host"))
+		})
+		It("mac-identifier field is allowed", func() {
+			err := staticNetworkGenerator.ValidateStaticConfigParams([]*models.HostStaticNetworkConfig{
+				{
+					MacInterfaceMap: []*models.MacInterfaceMapItems0{
+						{
+							LogicalNicName: "eth0",
+							MacAddress:     "f8:75:a4:a4:00:fe",
+						},
+					},
+					NetworkYaml: withMacIdentifier,
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This is a manual backport for PR 6715, as requested here - [MGMT-20740](https://issues.redhat.com/browse/MGMT-20740)

* Do not require interface mapping for physical network names

* add support for identifier field, e.g. mac-address

* Move logic to check that interface map is not empty into separate function

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
