### PR TITLE
MGMT-20664: ironic inspection fails when hub and spoke architectures are different (cherry pick #7723)

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -398,41 +398,37 @@ func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(ctx context.Conte
 	return mapInfraEnvPPI
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromUserOverride(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentImageFromUserOverride(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) string {
 	ironicAgentImage, ok := infraEnv.GetAnnotations()[ironicAgentImageOverrideAnnotation]
 	if ok && ironicAgentImage != "" {
 		log.Infof("Using override ironic agent image (%s) from infraEnv", ironicAgentImage)
-		return &ICCConfig{
-			IronicAgentImage: ironicAgentImage,
-		}
+		return ironicAgentImage
 	}
-
-	return nil
-
+	return ""
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
-	iccConfig, err := r.BMOUtils.getICCConfig(ctx)
+func (r *PreprovisioningImageReconciler) imageMatchesInfraenvArch(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv, ironicImage string) bool {
+	if ironicImage == "" {
+		return false
+	}
+
+	architectures, err := r.OcRelease.GetImageArchitecture(log, ironicImage, infraEnvInternal.PullSecret)
 	if err != nil {
-		log.WithError(err).Info("ICC configuration is not available")
-		return nil
+		log.WithError(err).Info("Failed to get image architecture for ironic agent image")
+		return false
 	}
 
-	var architectures []string
-	architectures, err = r.OcRelease.GetImageArchitecture(log, iccConfig.IronicAgentImage, infraEnvInternal.PullSecret)
-	if err == nil && funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
-		log.Infof("Setting ironic agent image (%s) from ICC config", iccConfig.IronicAgentImage)
-		return iccConfig
+	matches := funk.Contains(architectures, infraEnvInternal.CPUArchitecture)
+	if !matches {
+		log.Infof("CPU architecture (%v) of Ironic agent image (%s) does not match infraEnv arch (%s)",
+			architectures,
+			ironicImage,
+			infraEnvInternal.CPUArchitecture)
 	}
-
-	log.Infof("CPU architecture (%v) of Ironic agent image (%s) from ICC config is not available for infraEnv with arch (%s)",
-		architectures,
-		iccConfig.IronicAgentImage,
-		infraEnvInternal.CPUArchitecture)
-	return nil
+	return matches
 }
 
-func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentImageFromHUB(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) string {
 	image := r.hubIronicAgentImage
 	architectures := r.hubReleaseArchitectures
 	if image == "" {
@@ -440,17 +436,17 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Cont
 		err := r.Get(ctx, types.NamespacedName{Name: "version"}, cv)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get ClusterVersion")
-			return nil
+			return ""
 		}
 		architectures, err = r.OcRelease.GetReleaseArchitecture(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnvInternal.PullSecret)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get release architecture for (%s)", cv.Status.Desired.Image)
-			return nil
+			return ""
 		}
 		image, err = r.OcRelease.GetIronicAgentImage(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnvInternal.PullSecret)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get ironic agent image from release (%s)", cv.Status.Desired.Image)
-			return nil
+			return ""
 		}
 		r.hubIronicAgentImage = image
 		r.hubReleaseArchitectures = architectures
@@ -459,16 +455,14 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Cont
 
 	if !funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
 		log.Warningf("Release image architectures %v do not match infraEnv architecture %s", architectures, infraEnvInternal.CPUArchitecture)
-		return nil
+		return ""
 	}
 
 	log.Infof("Setting ironic agent image (%s) from HUB cluster", image)
-	return &ICCConfig{
-		IronicAgentImage: image,
-	}
+	return image
 }
 
-func (r *PreprovisioningImageReconciler) getIronicDefaultConfig(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
+func (r *PreprovisioningImageReconciler) getIronicAgentDefaultImage(log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) string {
 	var ironicAgentImage string
 	if infraEnvInternal.CPUArchitecture == common.ARM64CPUArchitecture {
 		ironicAgentImage = r.Config.BaremetalIronicAgentImageForArm
@@ -477,37 +471,38 @@ func (r *PreprovisioningImageReconciler) getIronicDefaultConfig(log logrus.Field
 	}
 
 	log.Infof("Setting default ironic agent image (%s)", ironicAgentImage)
-	return &ICCConfig{
-		IronicAgentImage: ironicAgentImage,
-	}
+	return ironicAgentImage
 }
 
 func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv, infraEnvInternal *common.InfraEnv) (*ICCConfig, error) {
-	var iccConfig *ICCConfig
-
-	iccConfig = r.getIronicConfigFromUserOverride(log, infraEnv)
-
-	if iccConfig == nil {
-		iccConfig = r.getIronicConfigFromBMOConfig(ctx, log, infraEnvInternal)
+	iccConfig, err := r.BMOUtils.getICCConfig(ctx)
+	if err != nil {
+		log.WithError(err).Info("ICC configuration is not available")
 	}
 
-	if iccConfig == nil {
-		iccConfig = r.getIronicConfigFromHUB(ctx, log, infraEnvInternal)
-	}
-
-	if iccConfig == nil {
-		iccConfig = r.getIronicDefaultConfig(log, infraEnvInternal)
-	}
-
-	if iccConfig == nil {
-		return nil, fmt.Errorf("Failed to determine ironic config")
-	}
-
-	if iccConfig.IronicBaseURL == "" && iccConfig.IronicInspectorBaseUrl == "" {
-		err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig)
-		if err != nil {
+	if iccConfig != nil {
+		log.Infof("Using ironic URLs from ICC config (Base: %s, Inspector: %s)", iccConfig.IronicBaseURL, iccConfig.IronicInspectorBaseUrl)
+	} else {
+		iccConfig = &ICCConfig{}
+		if err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig); err != nil {
 			return nil, err
 		}
+	}
+
+	if ironicAgentImageUserOverride := r.getIronicAgentImageFromUserOverride(log, infraEnv); ironicAgentImageUserOverride != "" {
+		iccConfig.IronicAgentImage = ironicAgentImageUserOverride
+	} else if iccConfig.IronicAgentImage != "" && r.imageMatchesInfraenvArch(log, infraEnvInternal, iccConfig.IronicAgentImage) {
+		log.Infof("Setting ironic agent image (%s) from ICC config", iccConfig.IronicAgentImage)
+	} else {
+		iccConfig.IronicAgentImage = r.getIronicAgentImageFromHUB(ctx, log, infraEnvInternal)
+	}
+
+	if iccConfig.IronicAgentImage == "" {
+		iccConfig.IronicAgentImage = r.getIronicAgentDefaultImage(log, infraEnvInternal)
+	}
+
+	if iccConfig.IronicAgentImage == "" {
+		return nil, fmt.Errorf("Failed to determine ironic config")
 	}
 
 	log.Infof("Ironic Agent Image is (%s) Ironic URL is (%s) Inspector URL is (%s)",

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -258,6 +258,112 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Get(ctx, key, infraEnv)).To(BeNil())
 			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
 		})
+
+		It("uses ICC config URLs when ICC contains URLs and user override annotation", func() {
+			overrideAgentImage := "ironic-agent-override:latest"
+			iccConfig := &ICCConfig{
+				IronicAgentImage: "ironic-agent-image",
+				IronicBaseURL:    "ironic-base-url",
+			}
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "x86_64"
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(iccConfig, nil)
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(iccConfig.IronicBaseURL))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(overrideAgentImage))
+					Expect(url.QueryUnescape(*internalIgnitionConfig)).To(MatchRegexp(`(?m)^inspection_callback_url\s=\s$`)) // matches inspection_callback_url = <empty>
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
+		It("sets ironic URLs from cluster when ICC config is unavailable and ironic image annotation override is set", func() {
+			overrideAgentImage := "ironic-agent-override:latest"
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "x86_64"
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(ironicServiceIPs[0])))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(ironicInspectorIPs[0])))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(overrideAgentImage))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
+		It("preserves ironic urls from ICC config with user override regardless of architecture mismatch", func() {
+			overrideAgentImage := "ironic-agent-override:latest"
+			iccConfig := &ICCConfig{
+				IronicAgentImage:       "ironic-agent-image",
+				IronicBaseURL:          "ironic-base-url",
+				IronicInspectorBaseUrl: "",
+			}
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "aarch64" // spoke is ARM64
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(iccConfig, nil)
+
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(iccConfig.IronicBaseURL)))
+					Expect(*internalIgnitionConfig).To(ContainSubstring(overrideAgentImage))
+					Expect(url.QueryUnescape(*internalIgnitionConfig)).To(MatchRegexp(`(?m)^inspection_callback_url\s=\s$`)) // matches inspection_callback_url = <empty>
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
+		It("preserves ironic urls from ICC config regardless of architecture mismatch", func() {
+			Expect(c.Create(ctx, clusterVersion)).To(Succeed())
+			iccConfig := &ICCConfig{
+				IronicAgentImage:       "ironic-agent-image",
+				IronicBaseURL:          "ironic-base-url",
+				IronicInspectorBaseUrl: "",
+			}
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+			backendInfraEnv.CPUArchitecture = "aarch64"
+			backendInfraEnv.PullSecret = "secret"
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(iccConfig, nil)
+			mockOcRelease.EXPECT().GetImageArchitecture(gomock.Any(), iccConfig.IronicAgentImage, backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
+			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"aarch64"}, nil)
+			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("hub-ironic-aarch64-image", nil)
+
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
+					Expect(*internalIgnitionConfig).To(ContainSubstring(url.QueryEscape(iccConfig.IronicBaseURL)))
+					Expect(*internalIgnitionConfig).To(ContainSubstring("hub-ironic-aarch64-image"))
+					Expect(url.QueryUnescape(*internalIgnitionConfig)).To(MatchRegexp(`(?m)^inspection_callback_url\s=\s$`))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+
+			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+		})
+
 		It("Wait for InfraEnv cool down", func() {
 			infraEnv.Status.ISODownloadURL = downloadURL
 			infraEnv.Status.CreatedTime = &metav1.Time{Time: time.Now()}
@@ -683,9 +789,10 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			backendInfraEnv.CPUArchitecture = "x86_64"
 			backendInfraEnv.PullSecret = "mypullsecret"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
+
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
 					Expect(internalIgnitionConfig).Should(HaveValue(ContainSubstring(overrideAgentImage)))
 				})


### PR DESCRIPTION
using 5050 port when ironic agent image override is used (#7660)

Co-authored-by: omer-vishlitzky <omer.vishlitzky@gmail.com>

[MGMT-20664](https://issues.redhat.com//browse/MGMT-20664): ironic inspection fails when hub and spoke architectures are different

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
