### PR TITLE
MGMT-20726: Allow prefix for PVC and secret naming

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -90,6 +90,8 @@ const (
 
 	configmapAnnotation                 = "unsupported.agent-install.openshift.io/assisted-service-configmap"
 	imageServiceSkipVerifyTLSAnnotation = "unsupported.agent-install.openshift.io/assisted-image-service-skip-verify-tls"
+	pvcPrefixAnnotation                 = "unsupported.agent-install.openshift.io/assisted-service-pvc-prefix"
+	secretsPrefixAnnotation             = "unsupported.agent-install.openshift.io/assisted-service-secrets-prefix"
 
 	assistedConfigHashAnnotation                 = "agent-install.openshift.io/config-hash"
 	mirrorConfigHashAnnotation                   = "agent-install.openshift.io/mirror-hash"
@@ -925,7 +927,7 @@ func newImageServiceIPXERoute(ctx context.Context, log logrus.FieldLogger, asc A
 func newAgentLocalAuthSecret(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      agentLocalAuthSecretName,
+			Name:      getSecretName(asc.Object.GetAnnotations(), agentLocalAuthSecretName),
 			Namespace: asc.namespace,
 			Labels: map[string]string{
 				BackupLabel: BackupLabelValue,
@@ -960,7 +962,7 @@ func newAgentLocalAuthSecret(ctx context.Context, log logrus.FieldLogger, asc AS
 func newPostgresSecret(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      databaseName,
+			Name:      getSecretName(asc.Object.GetAnnotations(), databaseName),
 			Namespace: asc.namespace,
 			Labels: map[string]string{
 				BackupLabel: BackupLabelValue,
@@ -1582,10 +1584,10 @@ func newImageServiceStatefulSet(ctx context.Context, log logrus.FieldLogger, asc
 			}
 			setAnnotation(&statefulSet.ObjectMeta, osImagesAdditionalParamsConfigHashAnnotation, osImagesAdditionalParamsConfigHash)
 			if secret.Data[osImageAdditionalParamsHeadersKey] != nil {
-				container.Env = append(container.Env, newSecretEnvVar(osImageAdditionalParamsHeadersEnvVar, osImageAdditionalParamsHeadersKey, asc.spec.OSImageAdditionalParamsRef.Name))
+				container.Env = append(container.Env, newStaticSecretEnvVar(osImageAdditionalParamsHeadersEnvVar, osImageAdditionalParamsHeadersKey, asc.spec.OSImageAdditionalParamsRef.Name))
 			}
 			if secret.Data[osImageAdditionalParamsQueryParamsKey] != nil {
-				container.Env = append(container.Env, newSecretEnvVar(osImageAdditionalParamsQueryParamsEnvVar, osImageAdditionalParamsQueryParamsKey, asc.spec.OSImageAdditionalParamsRef.Name))
+				container.Env = append(container.Env, newStaticSecretEnvVar(osImageAdditionalParamsQueryParamsEnvVar, osImageAdditionalParamsQueryParamsKey, asc.spec.OSImageAdditionalParamsRef.Name))
 			}
 		}
 
@@ -1776,15 +1778,15 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 
 	envSecrets := []corev1.EnvVar{
 		// database
-		newSecretEnvVar("DB_HOST", "db.host", databaseName),
-		newSecretEnvVar("DB_NAME", "db.name", databaseName),
-		newSecretEnvVar("DB_PASS", "db.password", databaseName),
-		newSecretEnvVar("DB_PORT", "db.port", databaseName),
-		newSecretEnvVar("DB_USER", "db.user", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "DB_HOST", "db.host", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "DB_NAME", "db.name", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "DB_PASS", "db.password", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "DB_PORT", "db.port", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "DB_USER", "db.user", databaseName),
 
 		// local auth secret
-		newSecretEnvVar("EC_PUBLIC_KEY_PEM", "ec-public-key.pem", agentLocalAuthSecretName),
-		newSecretEnvVar("EC_PRIVATE_KEY_PEM", "ec-private-key.pem", agentLocalAuthSecretName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "EC_PUBLIC_KEY_PEM", "ec-public-key.pem", agentLocalAuthSecretName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "EC_PRIVATE_KEY_PEM", "ec-private-key.pem", agentLocalAuthSecretName),
 	}
 
 	if exposeIPXEHTTPRoute(asc.spec) {
@@ -1829,7 +1831,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			Name: "bucket-filesystem",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: serviceName,
+					ClaimName: getPVCName(asc.Object.GetAnnotations(), serviceName),
 				},
 			},
 		},
@@ -1837,7 +1839,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			Name: "postgresdb",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: databaseName,
+					ClaimName: getPVCName(asc.Object.GetAnnotations(), databaseName),
 				},
 			},
 		},
@@ -1969,9 +1971,9 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 			},
 		},
 		Env: []corev1.EnvVar{
-			newSecretEnvVar("POSTGRESQL_DATABASE", "db.name", databaseName),
-			newSecretEnvVar("POSTGRESQL_USER", "db.user", databaseName),
-			newSecretEnvVar("POSTGRESQL_PASSWORD", "db.password", databaseName),
+			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_DATABASE", "db.name", databaseName),
+			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_USER", "db.user", databaseName),
+			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_PASSWORD", "db.password", databaseName),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -2141,6 +2143,20 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 	return deployment, mutateFn, nil
 }
 
+func getSecretName(annotations map[string]string, secretID string) string {
+	if prefix, ok := annotations[secretsPrefixAnnotation]; ok {
+		return prefix + secretID
+	}
+	return secretID
+}
+
+func getPVCName(annotations map[string]string, pvcID string) string {
+	if prefix, ok := annotations[pvcPrefixAnnotation]; ok {
+		return prefix + pvcID
+	}
+	return pvcID
+}
+
 func copyEnv(config map[string]string, key string) {
 	if value, ok := os.LookupEnv(key); ok {
 		config[key] = value
@@ -2266,7 +2282,7 @@ func getVersionKey(openshiftVersion string) (string, error) {
 	return fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1]), nil
 }
 
-func newSecretEnvVar(name, key, secretName string) corev1.EnvVar {
+func newStaticSecretEnvVar(name, key, secretName string) corev1.EnvVar {
 	return corev1.EnvVar{
 		Name: name,
 		ValueFrom: &corev1.EnvVarSource{
@@ -2278,6 +2294,10 @@ func newSecretEnvVar(name, key, secretName string) corev1.EnvVar {
 			},
 		},
 	}
+}
+
+func newSecretEnvVar(annotations map[string]string, name, key, secretName string) corev1.EnvVar {
+	return newStaticSecretEnvVar(name, key, getSecretName(annotations, secretName))
 }
 
 func newInfraEnvWebHook(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1017,6 +1017,94 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 		})
 	})
 
+	Context("with secrets prefix annotation on AgentServiceConfig", func() {
+		It("should create prefixed secret and references to it", func() {
+			asc := newASCDefault()
+			asc.ObjectMeta.Annotations = map[string]string{"unsupported.agent-install.openshift.io/assisted-service-secrets-prefix": "my-prefix-"}
+
+			ascr = newTestReconciler(asc, ingressCM, route, imageRoute, clusterTrustedCM)
+			_, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := &corev1.Secret{}
+			Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: "my-prefix-postgres", Namespace: testNamespace}, secret)).To(Succeed())
+
+			found := &appsv1.Deployment{}
+			Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
+
+			Expect(found.Spec.Template.Spec.Containers[0].Env).To(
+				ContainElement(
+					corev1.EnvVar{
+						Name: "DB_HOST",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key: "db.host",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "my-prefix-postgres",
+								},
+							},
+						},
+					},
+				),
+			)
+
+			Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: "my-prefix-assisted-servicelocal-auth", Namespace: testNamespace}, secret)).To(Succeed())
+			Expect(found.Spec.Template.Spec.Containers[0].Env).To(
+				ContainElement(
+					corev1.EnvVar{
+						Name: "EC_PUBLIC_KEY_PEM",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key: "ec-public-key.pem",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "my-prefix-assisted-servicelocal-auth",
+								},
+							},
+						},
+					},
+				),
+			)
+		})
+	})
+
+	Context("with PVC prefix annotation on AgentServiceConfig", func() {
+		It("should create prefixed PVC names", func() {
+			asc := newASCDefault()
+			asc.ObjectMeta.Annotations = map[string]string{"unsupported.agent-install.openshift.io/assisted-service-pvc-prefix": "my-prefix-"}
+
+			ascr = newTestReconciler(asc, ingressCM, route, imageRoute, clusterTrustedCM)
+			_, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
+			Expect(err).NotTo(HaveOccurred())
+			found := &appsv1.Deployment{}
+			Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
+
+			Expect(found.Spec.Template.Spec.Volumes).To(
+				ContainElement(
+					corev1.Volume{
+						Name: "bucket-filesystem",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "my-prefix-assisted-service",
+							},
+						},
+					},
+				),
+			)
+			Expect(found.Spec.Template.Spec.Volumes).To(
+				ContainElement(
+					corev1.Volume{
+						Name: "postgresdb",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "my-prefix-postgres",
+							},
+						},
+					},
+				),
+			)
+		})
+	})
+
 })
 
 var _ = Describe("newImageServiceService", func() {


### PR DESCRIPTION
Allow prefix naming for secrets and PVC. This might be useful as we use very common names for secrets and PVC, and it might conflicts with other resources deployed in the same namespace.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
