### PR TITLE
MGMT-20651: Assisted Service panics if both installation_disk_id and installation-disk_path are empty

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -143,7 +143,11 @@ func GetHostInstallationDisk(host *models.Host) (*models.Disk, error) {
 		return nil, err
 	}
 
-	return GetDiskByInstallationPath(inventory.Disks, GetHostInstallationPath(host)), nil
+	installationDisk := GetDiskByInstallationPath(inventory.Disks, GetHostInstallationPath(host))
+	if installationDisk == nil {
+		return nil, fmt.Errorf("installation disk not found for host %s", host.ID)
+	}
+	return installationDisk, nil
 }
 
 func GetDiskByInstallationPath(disks []*models.Disk, installationPath string) *models.Disk {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2165,6 +2165,98 @@ var _ = Describe("Refresh Host", func() {
 
 	})
 
+	Context("Installation disk error handling in status info", func() {
+		BeforeEach(func() {
+			pr.EXPECT().IsHostSupported(commontesting.EqPlatformType(models.PlatformTypeVsphere), gomock.Any()).Return(false, nil).AnyTimes()
+			mockDefaultClusterHostRequirements(mockHwValidator)
+			mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("").AnyTimes() // Empty installation path
+		})
+
+		It("should handle missing installation disk gracefully during reboot timeout without panicking", func() {
+			hostCheckInAt := strfmt.DateTime(time.Now())
+			srcState := models.HostStatusInstallingInProgress
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
+
+			host.Inventory = hostutil.GenerateMasterInventory()
+
+			host.InstallationDiskID = ""
+			host.InstallationDiskPath = ""
+			host.Role = models.HostRoleMaster
+			host.CheckedInAt = hostCheckInAt
+
+			progress := models.HostProgressInfo{
+				CurrentStage:   models.HostStageRebooting,
+				StageStartedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
+				StageUpdatedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
+			}
+			host.Progress = &progress
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			cluster = hostutil.GenerateTestCluster(clusterId)
+			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
+
+			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
+				eventstest.WithHostIdMatcher(hostId.String()),
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
+				eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusInstallingPendingUserAction))))
+
+			err := hapi.RefreshStatus(ctx, &host, db)
+			Expect(err).ToNot(HaveOccurred())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+
+			expectedStatusInfo := strings.Replace(statusRebootTimeout, "$INSTALLATION_DISK", "", 1)
+			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(expectedStatusInfo))
+		})
+
+		It("should handle missing installation disk with non-matching disk ID gracefully", func() {
+			hostCheckInAt := strfmt.DateTime(time.Now())
+			srcState := models.HostStatusInstallingInProgress
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
+
+			host.Inventory = hostutil.GenerateMasterInventory()
+			host.InstallationDiskID = "/dev/disk/by-id/non-existent-disk"
+			host.InstallationDiskPath = ""
+			host.Role = models.HostRoleMaster
+			host.CheckedInAt = hostCheckInAt
+
+			progress := models.HostProgressInfo{
+				CurrentStage:   models.HostStageRebooting,
+				StageStartedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
+				StageUpdatedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
+			}
+			host.Progress = &progress
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			cluster = hostutil.GenerateTestCluster(clusterId)
+			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
+
+			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
+				eventstest.WithHostIdMatcher(hostId.String()),
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
+				eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusInstallingPendingUserAction))))
+
+			err := hapi.RefreshStatus(ctx, &host, db)
+			Expect(err).ToNot(HaveOccurred())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+
+			expectedStatusInfo := strings.Replace(statusRebootTimeout, "$INSTALLATION_DISK", "", 1)
+			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(expectedStatusInfo))
+		})
+
+	})
+
 	Context("Validate host", func() {
 		BeforeEach(func() {
 			pr.EXPECT().IsHostSupported(commontesting.EqPlatformType(models.PlatformTypeVsphere), gomock.Any()).Return(false, nil).AnyTimes()


### PR DESCRIPTION
Previously, if the host's installation disk wasn't found, the code would panic when trying to use a nil value. This PR adds a check in `GetHostInstallationDisk` to return an error if the disk is missing.
Also, in `replaceMacros`, we now handle this error properly by logging a warning and replacing `$INSTALLATION_DISK` with an empty string instead of crashing.



## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @gamli75 @rccrdpccl 
