### PR TITLE
NO-ISSUE: Simplify PreprovisioningImage controller setup

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -364,11 +364,9 @@ func (r *PreprovisioningImageReconciler) findInfraEnvForPreprovisioningImage(ctx
 }
 
 func (r *PreprovisioningImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	mapInfraEnvPPI := r.mapInfraEnvPPI()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metal3_v1alpha1.PreprovisioningImage{}).
-		Watches(&metal3_v1alpha1.PreprovisioningImage{}, &handler.EnqueueRequestForObject{}).
-		Watches(&aiv1beta1.InfraEnv{}, handler.EnqueueRequestsFromMapFunc(mapInfraEnvPPI)).
+		Watches(&aiv1beta1.InfraEnv{}, handler.EnqueueRequestsFromMapFunc(r.mapInfraEnvPPI)).
 		Watches(&metal3_v1alpha1.BareMetalHost{}, handler.EnqueueRequestsFromMapFunc(mapBMHtoPPI)).
 		Complete(r)
 }
@@ -382,41 +380,38 @@ func mapBMHtoPPI(ctx context.Context, a client.Object) []reconcile.Request {
 	}}
 }
 
-func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(ctx context.Context, a client.Object) []reconcile.Request {
-	mapInfraEnvPPI := func(ctx context.Context, a client.Object) []reconcile.Request {
-		log := logutil.FromContext(ctx, r.Log).WithFields(
-			logrus.Fields{
-				"infra_env":           a.GetName(),
-				"infra_env_namespace": a.GetNamespace(),
-			})
-		infraEnv := &aiv1beta1.InfraEnv{}
+func (r *PreprovisioningImageReconciler) mapInfraEnvPPI(ctx context.Context, a client.Object) []reconcile.Request {
+	log := logutil.FromContext(ctx, r.Log).WithFields(
+		logrus.Fields{
+			"infra_env":           a.GetName(),
+			"infra_env_namespace": a.GetNamespace(),
+		})
+	infraEnv := &aiv1beta1.InfraEnv{}
 
-		if err := r.Get(ctx, types.NamespacedName{Name: a.GetName(), Namespace: a.GetNamespace()}, infraEnv); err != nil {
-			return []reconcile.Request{}
-		}
-
-		images, err := r.findPreprovisioningImagesByInfraEnv(ctx, infraEnv)
-		if err != nil {
-			log.WithError(err).Infof("failed getting InfraEnv related preprovisioningImages %s/%s ", a.GetNamespace(), a.GetName())
-			return []reconcile.Request{}
-		}
-		if len(images) == 0 {
-			return []reconcile.Request{}
-		}
-
-		reconcileRequests := []reconcile.Request{}
-
-		for i := range images {
-			reconcileRequests = append(reconcileRequests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: images[i].Namespace,
-					Name:      images[i].Name,
-				},
-			})
-		}
-		return reconcileRequests
+	if err := r.Get(ctx, types.NamespacedName{Name: a.GetName(), Namespace: a.GetNamespace()}, infraEnv); err != nil {
+		return []reconcile.Request{}
 	}
-	return mapInfraEnvPPI
+
+	images, err := r.findPreprovisioningImagesByInfraEnv(ctx, infraEnv)
+	if err != nil {
+		log.WithError(err).Infof("failed getting InfraEnv related preprovisioningImages %s/%s ", a.GetNamespace(), a.GetName())
+		return []reconcile.Request{}
+	}
+	if len(images) == 0 {
+		return []reconcile.Request{}
+	}
+
+	reconcileRequests := []reconcile.Request{}
+
+	for i := range images {
+		reconcileRequests = append(reconcileRequests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: images[i].Namespace,
+				Name:      images[i].Name,
+			},
+		})
+	}
+	return reconcileRequests
 }
 
 func (r *PreprovisioningImageReconciler) getIronicAgentImageFromUserOverride(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) string {

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -1062,7 +1062,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			Expect(c.Create(ctx, ppi)).To(BeNil())
 
-			requests := pr.mapInfraEnvPPI()(ctx, infraEnv)
+			requests := pr.mapInfraEnvPPI(ctx, infraEnv)
 
 			Expect(len(requests)).To(Equal(1))
 		})
@@ -1073,7 +1073,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			ppi2 := newPreprovisioningImage("testPPI2", testNamespace, InfraEnvLabel, "testInfraEnv", bmh.Name)
 			Expect(c.Create(ctx, ppi2)).To(BeNil())
 
-			requests := pr.mapInfraEnvPPI()(ctx, infraEnv)
+			requests := pr.mapInfraEnvPPI(ctx, infraEnv)
 
 			Expect(len(requests)).To(Equal(2))
 		})
@@ -1084,7 +1084,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			ppi2 := newPreprovisioningImage("testPPI2", testNamespace, InfraEnvLabel, "someOtherInfraEnv", bmh.Name)
 			Expect(c.Create(ctx, ppi2)).To(BeNil())
 
-			requests := pr.mapInfraEnvPPI()(ctx, infraEnv)
+			requests := pr.mapInfraEnvPPI(ctx, infraEnv)
 
 			Expect(len(requests)).To(Equal(1))
 		})
@@ -1093,7 +1093,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			infraEnv.Status.ISODownloadURL = downloadURL
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 
-			requests := pr.mapInfraEnvPPI()(ctx, infraEnv)
+			requests := pr.mapInfraEnvPPI(ctx, infraEnv)
 
 			Expect(len(requests)).To(Equal(0))
 		})


### PR DESCRIPTION
 * Remove redundant Watches() on PreprovisioningImage
 * Use inline mapInfraEnvPPI function

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? ZTP
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal logic for improved maintainability. No changes to user-facing features or behavior.
- **Tests**
  - Updated tests to align with internal refactoring, ensuring continued reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->