### PR TITLE
NO-JIRA: Remove refs to shellcheck

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -36,7 +36,6 @@ COPY --from=quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /opt/swagger-
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin
 COPY --from=registry.k8s.io/kustomize/kustomize:v5.6.0 /app/kustomize /usr/bin/
-COPY --from=quay.io/coreos/shellcheck-alpine:v0.5.0 /bin/shellcheck /usr/bin/shellcheck
 
 RUN dnf install -y --enablerepo=crb \
         openssl openssl-devel postgresql nmstate-devel sqlite gcc genisoimage git libvirt-client libvirt-devel java make && \

--- a/ci-images/Dockerfile.lint
+++ b/ci-images/Dockerfile.lint
@@ -1,6 +1,5 @@
 FROM base
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.64.7
-COPY --from=quay.io/coreos/shellcheck-alpine:v0.5.0 /bin/shellcheck /usr/bin/shellcheck
 
 RUN dnf install -y diffutils


### PR DESCRIPTION
The image was removed from quay.io/coreos and this binary is not used during build or lint phases
