### PR TITLE
MGMT-21252: Make l3_connected_addresses output deterministic

### DIFF
--- a/internal/network/connectivity_groups.go
+++ b/internal/network/connectivity_groups.go
@@ -3,6 +3,7 @@ package network
 import (
 	"encoding/json"
 	"net"
+	"sort"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/golang-collections/go-datastructures/bitarray"
@@ -633,5 +634,11 @@ func GatherL3ConnectedAddresses(hosts []*models.Host) (map[strfmt.UUID][]string,
 			}
 		}
 	}
+
+	// Sort address lists to ensure deterministic results across multiple function calls
+	for _, addresses := range ret {
+		sort.Strings(addresses)
+	}
+
 	return ret, nil
 }

--- a/internal/network/connectivity_groups_test.go
+++ b/internal/network/connectivity_groups_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/models"
-	"github.com/thoas/go-funk"
 )
 
 type node struct {
@@ -873,15 +872,6 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 			})
 		})
 		Context("L3 connected addresses", func() {
-			expectEquivalentMaps := func(actual, expected map[strfmt.UUID][]string) {
-				Expect(actual).To(HaveLen(len(expected)))
-				for key, actualValue := range actual {
-					expectedValue, ok := expected[key]
-					Expect(ok).To(BeTrue())
-					Expect(actualValue).To(HaveLen(len(expectedValue)))
-					Expect(expectedValue).To(ConsistOf(funk.Map(actualValue, func(s string) interface{} { return s }).([]interface{})...))
-				}
-			}
 			It("3 hosts with empty connectivity reports - no results expected", func() {
 				hosts := []*models.Host{
 					{
@@ -973,11 +963,11 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[0].id: {nodes[0].addressNet1},
 					*nodes[1].id: {nodes[1].addressNet1},
 					*nodes[2].id: {nodes[2].addressNet1},
-				})
+				}))
 			})
 			It("3 hosts with connectivity reports with 2 networks - all host with connected addresses from both networks expected", func() {
 				hosts := []*models.Host{
@@ -1005,11 +995,11 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[0].id: {nodes[0].addressNet1, nodes[0].addressNet2},
 					*nodes[1].id: {nodes[1].addressNet1, nodes[1].addressNet2},
 					*nodes[2].id: {nodes[2].addressNet1, nodes[2].addressNet2},
-				})
+				}))
 			})
 			It("3 hosts with connectivity reports with 2 networks, one direction missing - all hosts with connected addresses from both networks without all addresses expected", func() {
 				hosts := []*models.Host{
@@ -1037,11 +1027,11 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[0].id: {nodes[0].addressNet1, nodes[0].addressNet2},
 					*nodes[1].id: {nodes[1].addressNet1},
 					*nodes[2].id: {nodes[2].addressNet1, nodes[2].addressNet2},
-				})
+				}))
 			})
 			It("4 hosts with connectivity reports with 2 networks - all host with connected addresses from both networks expected", func() {
 				hosts := []*models.Host{
@@ -1080,12 +1070,12 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[0].id: {nodes[0].addressNet1, nodes[0].addressNet2},
 					*nodes[1].id: {nodes[1].addressNet1, nodes[1].addressNet2},
 					*nodes[2].id: {nodes[2].addressNet1, nodes[2].addressNet2},
 					*nodes[3].id: {nodes[3].addressNet1, nodes[3].addressNet2},
-				})
+				}))
 			})
 			It("4 hosts with connectivity reports with 2 networks, one host with single network - hosts with connected addresses from both networks expected", func() {
 				nodes[3].addressNet2 = ""
@@ -1125,12 +1115,12 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[0].id: {nodes[0].addressNet1, nodes[0].addressNet2},
 					*nodes[1].id: {nodes[1].addressNet1, nodes[1].addressNet2},
 					*nodes[2].id: {nodes[2].addressNet1, nodes[2].addressNet2},
 					*nodes[3].id: {nodes[3].addressNet1},
-				})
+				}))
 			})
 			It("4 hosts with connectivity reports with 2 networks, no connectivity to 2 hosts  - expect connected addresses only to the connected hosts", func() {
 				hosts := []*models.Host{
@@ -1167,10 +1157,10 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				}
 				ret, err := GatherL3ConnectedAddresses(hosts)
 				Expect(err).ToNot(HaveOccurred())
-				expectEquivalentMaps(ret, map[strfmt.UUID][]string{
+				Expect(ret).To(Equal(map[strfmt.UUID][]string{
 					*nodes[2].id: {nodes[2].addressNet1, nodes[2].addressNet2},
 					*nodes[3].id: {nodes[3].addressNet1, nodes[3].addressNet2},
-				})
+				}))
 			})
 
 		})


### PR DESCRIPTION
The algorithm adding connected IPs to host relies on [map iterations which are random](https://nathanleclaire.com/blog/2014/04/27/a-surprising-feature-of-golang-that-colored-me-impressed/)
in golang. Therefore, the order to the connected IPs is not
deterministic. This behaviour leads to useless updates to the `connectivity_majority_groups`
field in `clusters` table whereas [we try to prevent that](https://github.com/openshift/assisted-service/blob/master/internal/cluster/cluster.go#L1434-L1443).

This change sorts the slices of the connected IPs to ensure that
multiple calls to this function will have the same result. Test are also
updated to expect the exact same order.
