### PR TITLE
MGMT-21253: RefreshSchedulableMastersForcedTrue leads to extra reads from DB

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1325,7 +1325,7 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 		}
 
 		// Refresh schedulable masters again after all roles are assigned
-		if internalErr := b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID); internalErr != nil {
+		if internalErr := b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, cluster); internalErr != nil {
 			log.WithError(internalErr).Errorf("Failed to refresh SchedulableMastersForcedTrue while installing cluster <%s>", cluster.ID)
 			return internalErr
 		}
@@ -3489,7 +3489,7 @@ func (b *bareMetalInventory) V2DeregisterHostInternal(ctx context.Context, param
 				log.WithError(err).Warnf("Failed to refresh cluster after de-registerating host <%s>", params.HostID)
 			}
 		}
-		if err := b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *h.ClusterID); err != nil {
+		if err := b.clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *h.ClusterID); err != nil {
 			log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while de-registering host <%s> to cluster <%s>", h.ID, h.ClusterID)
 			return err
 		}
@@ -5679,7 +5679,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 	}
 
 	if host.ClusterID != nil {
-		if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *host.ClusterID); err != nil {
+		if err = b.clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *host.ClusterID); err != nil {
 			log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while registering host <%s> to cluster <%s>", host.ID, host.ClusterID)
 			return installer.NewV2RegisterHostInternalServerError().
 				WithPayload(common.GenerateError(http.StatusInternalServerError, err))
@@ -5937,7 +5937,7 @@ func (b *bareMetalInventory) BindHostInternal(ctx context.Context, params instal
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID); err != nil {
+	if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, cluster); err != nil {
 		log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while binding host <%s> to cluster <%s>", host.ID, host.ClusterID)
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
@@ -5983,7 +5983,7 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 		}
 	}
 
-	if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *host.ClusterID); err != nil {
+	if err = b.clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *host.ClusterID); err != nil {
 		log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while unbinding host <%s> to cluster <%s>", host.ID, host.ClusterID)
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -621,7 +621,7 @@ var _ = Describe("RegisterHost", func() {
 				infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrueWithClusterID(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
 						// validate that host is registered with auto-assign role
@@ -662,7 +662,7 @@ var _ = Describe("RegisterHost", func() {
 			infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 			mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-			mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrueWithClusterID(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
 					// validate that host is registered with auto-assign role
@@ -781,7 +781,7 @@ var _ = Describe("RegisterHost", func() {
 			}).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrueWithClusterID(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		By("trying to register a host bound to day2 cluster")
 		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
@@ -18227,7 +18227,7 @@ var _ = Describe("V2DeregisterHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("Bad Refresh Status"))
-		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrueWithClusterID(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		response := bm.V2DeregisterHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.V2DeregisterHostNoContent{}))
 	})
@@ -18272,7 +18272,7 @@ var _ = Describe("UnbindHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false)
-		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrueWithClusterID(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		response := bm.UnbindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.UnbindHostOK{}))
 	})

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -3955,7 +3955,7 @@ var _ = Describe("Test RefreshSchedulableMastersForcedTrue", func() {
 			createWorkerHost(*cluster.ID, "", db)
 		}
 
-		err := clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID)
+		err := clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *cluster.ID)
 		Expect(err).ToNot(HaveOccurred())
 
 		cluster = getClusterFromDB(*cluster.ID, db)
@@ -3968,7 +3968,7 @@ var _ = Describe("Test RefreshSchedulableMastersForcedTrue", func() {
 			createHost(*cluster.ID, "", db)
 		}
 
-		err := clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID)
+		err := clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *cluster.ID)
 		Expect(err).ToNot(HaveOccurred())
 
 		cluster = getClusterFromDB(*cluster.ID, db)
@@ -3978,7 +3978,7 @@ var _ = Describe("Test RefreshSchedulableMastersForcedTrue", func() {
 	It("schedulableMastersForcedTrue should set a value when the existing value is nil", func() {
 		cluster := createCluster(nil)
 
-		err := clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID)
+		err := clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, *cluster.ID)
 		Expect(err).ToNot(HaveOccurred())
 
 		cluster = getClusterFromDB(*cluster.ID, db)
@@ -3987,7 +3987,7 @@ var _ = Describe("Test RefreshSchedulableMastersForcedTrue", func() {
 
 	It("schedulableMastersForcedTrue should return an error when the cluster does not exists", func() {
 		invalidClusterID := strfmt.UUID(uuid.New().String())
-		err := clusterApi.RefreshSchedulableMastersForcedTrue(ctx, invalidClusterID)
+		err := clusterApi.RefreshSchedulableMastersForcedTrueWithClusterID(ctx, invalidClusterID)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -504,17 +504,31 @@ func (mr *MockAPIMockRecorder) PrepareHostLogFile(ctx, c, host, objectHandler in
 }
 
 // RefreshSchedulableMastersForcedTrue mocks base method.
-func (m *MockAPI) RefreshSchedulableMastersForcedTrue(ctx context.Context, clusterID strfmt.UUID) error {
+func (m *MockAPI) RefreshSchedulableMastersForcedTrue(ctx context.Context, cluster *common.Cluster) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshSchedulableMastersForcedTrue", ctx, clusterID)
+	ret := m.ctrl.Call(m, "RefreshSchedulableMastersForcedTrue", ctx, cluster)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RefreshSchedulableMastersForcedTrue indicates an expected call of RefreshSchedulableMastersForcedTrue.
-func (mr *MockAPIMockRecorder) RefreshSchedulableMastersForcedTrue(ctx, clusterID interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) RefreshSchedulableMastersForcedTrue(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSchedulableMastersForcedTrue", reflect.TypeOf((*MockAPI)(nil).RefreshSchedulableMastersForcedTrue), ctx, clusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSchedulableMastersForcedTrue", reflect.TypeOf((*MockAPI)(nil).RefreshSchedulableMastersForcedTrue), ctx, cluster)
+}
+
+// RefreshSchedulableMastersForcedTrueWithClusterID mocks base method.
+func (m *MockAPI) RefreshSchedulableMastersForcedTrueWithClusterID(ctx context.Context, clusterID strfmt.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshSchedulableMastersForcedTrueWithClusterID", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshSchedulableMastersForcedTrueWithClusterID indicates an expected call of RefreshSchedulableMastersForcedTrueWithClusterID.
+func (mr *MockAPIMockRecorder) RefreshSchedulableMastersForcedTrueWithClusterID(ctx, clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSchedulableMastersForcedTrueWithClusterID", reflect.TypeOf((*MockAPI)(nil).RefreshSchedulableMastersForcedTrueWithClusterID), ctx, clusterID)
 }
 
 // RefreshStatus mocks base method.


### PR DESCRIPTION
This commit fixes the issue where RefreshSchedulableMastersForcedTrue
leads to extra reads from the DB while the cluster object is already
available.
