### PR TITLE
NO-ISSUE: Remove unused variables from cluster monitor loop

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -591,8 +591,6 @@ func (m *Manager) ClusterMonitoring() {
 	m.log.Debugf("Running ClusterMonitoring")
 	defer commonutils.MeasureOperation("ClusterMonitoring", m.log, m.metricAPI)()
 	var (
-		offset              int
-		limit               = m.MonitorBatchSize
 		clusters            []*common.Cluster
 		clusterAfterRefresh *common.Cluster
 		requestID           = requestid.NewID()
@@ -665,7 +663,6 @@ func (m *Manager) ClusterMonitoring() {
 				m.metricAPI.MonitoredClustersDurationMs(duration)
 			}
 		}
-		offset += limit
 	}
 }
 


### PR DESCRIPTION
This patch removes the unused `offset` and `limit` variables from the cluster monitoring loop. This doesn't have any effect in performance, but it is confusing to have things that aren't used.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
