### PR TITLE
MGMT-21063: Use mac address to configure dhcp on kargs

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -430,9 +430,9 @@ func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inve
 		dhcp = "dhcp6"
 	}
 
-	netArgs := fmt.Sprintf("ip=%s:%s", nic.Name, dhcp)
-	if !lo.Contains(installerArgs, fmt.Sprintf("ip=%s:%s", nic.Name, dhcp)) {
-		installerArgs = append(installerArgs, "--append-karg", netArgs)
+	netArg := formatNetKarg(nic, dhcp)
+	if !lo.Contains(installerArgs, netArg) {
+		installerArgs = append(installerArgs, "--append-karg", netArg)
 	}
 
 	return installerArgs, nil
@@ -562,12 +562,16 @@ func getDHCPArgPerNIC(network *net.IPNet, nic *models.Interface, ipv6 bool, dual
 		if dualStack {
 			dhcp = "dhcp,dhcp6"
 		}
-		macWithDashes := strings.ReplaceAll(nic.MacAddress, ":", "-")
-		karg := fmt.Sprintf("ip=%s:%s", macWithDashes, dhcp)
-		log.Debugf("Host %s: Added kernel argument %s", hostID, karg)
-		return append(args, "--append-karg", karg), nil
+		netArg := formatNetKarg(nic, dhcp)
+		log.Debugf("Host %s: Added kernel argument %s", hostID, netArg)
+		return append(args, "--append-karg", netArg), nil
 	}
 	return args, nil
+}
+
+func formatNetKarg(nic *models.Interface, arg string) string {
+	macWithDashes := strings.ReplaceAll(nic.MacAddress, ":", "-")
+	return fmt.Sprintf("ip=%s:%s", macWithDashes, arg)
 }
 
 func findAnyInCIDR(network *net.IPNet, addresses []string) (bool, error) {

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -562,8 +562,10 @@ func getDHCPArgPerNIC(network *net.IPNet, nic *models.Interface, ipv6 bool, dual
 		if dualStack {
 			dhcp = "dhcp,dhcp6"
 		}
-		log.Debugf("Host %s: Added kernel argument ip=%s:%s", hostID, nic.Name, dhcp)
-		return append(args, "--append-karg", fmt.Sprintf("ip=%s:%s", nic.Name, dhcp)), nil
+		macWithDashes := strings.ReplaceAll(nic.MacAddress, ":", "-")
+		karg := fmt.Sprintf("ip=%s:%s", macWithDashes, dhcp)
+		log.Debugf("Host %s: Added kernel argument %s", hostID, karg)
+		return append(args, "--append-karg", karg), nil
 	}
 	return args, nil
 }

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2001:db8::a/120"]
 				}
 			]
@@ -1096,14 +1096,14 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth0:dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=01-02-03-04-05-06:dhcp6"]`))
 	})
-	It("ip=<nic>:dhcp6 not added when machine CIDR is IPv6 and no matching interface", func() {
+	It("ip=<nic>:dhcp6 not added whachine CIDR is IPv6 and no matching interface", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "2001:db8::/64"}}
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2002:db8::a/120"]
 				}
 			]
@@ -1118,7 +1118,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/25"]
 				}
 			]
@@ -1126,14 +1126,14 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("ip=<nic>:dhcp added when machine CIDR is IPv4 and multiple addresses", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/24", "192.186.10.10/25"]
 				}
 			]
@@ -1141,18 +1141,18 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("ip=<nic>:dhcp added when machine CIDR is IPv4 and multiple interfaces", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/24"]
 				},
 				{
-					"name": "eth1",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["192.186.10.10/25"]
 				}
 			]
@@ -1160,14 +1160,14 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=07-08-09-0A-0B-0C:dhcp"]`))
 	})
 	It("ip=<nic>:dhcp not added when machine CIDR is IPv4 and no matching interface", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				}
 			]
@@ -1193,7 +1193,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2002:db8::b/120"]
 				}
 			]
@@ -1201,7 +1201,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth0:dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=01-02-03-04-05-06:dhcp6"]`))
 	})
 	It("ip=<nic>:dhcp6 not added when there's no machine CIDR, bootstrap is IPv6, but no matching interface", func() {
 		cluster.Hosts = []*models.Host{
@@ -1219,7 +1219,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2001:db8::b/120"]
 				}
 			]
@@ -1245,7 +1245,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"]
 				}
 			]
@@ -1253,7 +1253,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("ip=<nic>:dhcp not added when there's no machine CIDR, bootstrap is IPv4, but no matching interface", func() {
 		cluster.Hosts = []*models.Host{
@@ -1271,7 +1271,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.10.10/24"]
 				}
 			]
@@ -1288,7 +1288,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"]
 				}
 			]
@@ -1306,7 +1306,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"]
 				}
 			]
@@ -1322,7 +1322,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "ens3",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"]
 				}
 			]
@@ -1330,7 +1330,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--copy-network","--append-karg","ip=ens3:dhcp"]`))
+		Expect(args).To(Equal(`["--copy-network","--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("existing args updated with ip=<nic>:dhcp6 when machine CIDR is IPv6", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "2001:db8::/120"}}
@@ -1338,7 +1338,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2001:db8::b/120"]
 				}
 			]
@@ -1346,7 +1346,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=eth1:dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=01-02-03-04-05-06:dhcp6"]`))
 	})
 	It("existing args updated with ip=<nic>:dhcp,dhcp6 dual stuck", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}, {Cidr: "2001:db8::/120"}}
@@ -1354,7 +1354,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"],
 					"ipv6_addresses":["2001:db8::b/120"]
 				}
@@ -1363,7 +1363,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=eth1:dhcp,dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=01-02-03-04-05-06:dhcp,dhcp6"]`))
 	})
 	It("existing args updated with ip=<nic>:dhcp when machine CIDR is IPv4", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
@@ -1371,7 +1371,7 @@ var _ = Describe("construct host install arguments", func() {
 		host.Inventory = `{
 			"interfaces":[
 				{
-					"name": "eth2",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["192.186.10.10/24"]
 				}
 			]
@@ -1379,7 +1379,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=eth2:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("don't add ip arg if ip=dhcp added by user", func() {
 		kargs := `["--append-karg","ip=dhcp"]`

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -799,7 +799,7 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				}
 			]
@@ -807,7 +807,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Debug info: Unmarshalled Inventory: %+v, Host's Inventory: %s", inventory, host.Inventory))
-		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp"]`), fmt.Sprintf("Debug info: Actual args returned: %s", args))
+		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp"]`), fmt.Sprintf("Debug info: Actual args returned: %s", args))
 	})
 	It("multipath iSCSI installation disk with 2 different nics", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
@@ -837,11 +837,11 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth0",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				},
 				{
-					"name": "eth1",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["10.56.20.81/25"]
 				}
 			]
@@ -849,7 +849,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Debug info: Unmarshalled Inventory: %+v, Host's Inventory: %s", inventory, host.Inventory))
-		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth0:dhcp","--append-karg","ip=eth1:dhcp"]`), fmt.Sprintf("Debug info: Actual args returned: %s", args))
+		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp","--append-karg","ip=07-08-09-0A-0B-0C:dhcp"]`), fmt.Sprintf("Debug info: Actual args returned: %s", args))
 	})
 	It("non-multipath installation disk", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
@@ -866,7 +866,7 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				}
 			]
@@ -894,11 +894,11 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				},
 				{
-					"name": "eth2",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["10.56.21.80/25"]
 				}
 			]
@@ -906,7 +906,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("iSCSI installation disk - Host IPv6 address", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}
@@ -926,11 +926,11 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv6_addresses":["2002:db8::1/64"]
 				},
 				{
-					"name": "eth2",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["10.56.21.80/25"]
 				}
 			]
@@ -938,7 +938,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp6"]`))
 	})
 	It("iSCSI installation disk - IP configuration is not appended if user already added it", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
@@ -956,11 +956,11 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				},
 				{
-					"name": "eth2",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["10.56.21.80/25"]
 				}
 			]
@@ -984,7 +984,7 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				}
 			]
@@ -1008,7 +1008,7 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				}
 			]
@@ -1043,11 +1043,11 @@ var _ = Describe("construct host install arguments", func() {
 			],
 			"interfaces":[
 				{
-					"name": "eth1",
+					"mac_address": "01:02:03:04:05:06",
 					"ipv4_addresses":["10.56.20.80/25"]
 				},
 				{
-					"name": "eth2",
+					"mac_address": "07:08:09:0A:0B:0C",
 					"ipv4_addresses":["10.56.21.80/25"]
 				}
 			]
@@ -1055,7 +1055,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=eth1:dhcp"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
 	})
 	It("Raid installation disk - Host IPv4 address", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}


### PR DESCRIPTION
The NIC name is sensible to PCI enumeration and some hardware may not
enumerate the devices in the same order after a reboot, which leads to a
different NIC name, and RHCOS goes to emergency mode.

This change refers to the NIC using its MAC address which is not
subject to change.

This issue has been observed on Oracle Cloud baremetal, but I think it can
affect offer hardware vendors as well.
