### PR TITLE
MGMT-21312: Index hosts by cluster id

### DIFF
--- a/internal/migrations/20250728120000_add_host_by_cluster_id_index.go
+++ b/internal/migrations/20250728120000_add_host_by_cluster_id_index.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addHostsByClusterIdIndex() *gormigrate.Migration {
+	migrate := func(db *gorm.DB) error {
+		db.Exec(`create index if not exists hosts_by_cluster_id on hosts (cluster_id)`)
+		return db.Error
+	}
+
+	rollback := func(db *gorm.DB) error {
+		db.Exec(`drop index if exists hosts_by_cluster_id`)
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20250728120000",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -46,6 +46,7 @@ func post() []*gormigrate.Migration {
 		updateOciToExternalPlatformType(),
 		dropClusterPlatformIsExternal(),
 		updateNewColumnControlPlaneCountValueForExistingClusterRecords(),
+		addHostsByClusterIdIndex(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })


### PR DESCRIPTION
This patch adds a new `hosts_by_cluster_id` index that accelerates fetch of hosts for a specific cluster. This is an operation that we perform very frequently, and currently it requires a sequential scan of the hosts tables.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
