### PR TITLE
MGMT-19704: Separate pod for monitor

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,6 +181,8 @@ var Options struct {
 
 	// SlowHostMonitorLogThreshold defines the duration after which hosts that take too long to process will be logged
 	SlowHostMonitorLogThreshold time.Duration `envconfig:"SLOW_HOST_MONITOR_LOG_THRESHOLD" default:"1s"`
+
+	StartMonitors bool `envconfig:"START_MONITORS" default:"true"`
 }
 
 func InitLogs(logLevel, logFormat string) *logrus.Logger {
@@ -427,15 +429,17 @@ func main() {
 		failOnError(cerr, "Failed to create kubernetes cluster config")
 		k8sClient = kubernetes.NewForConfigOrDie(cfg)
 
-		startupLeader = leader.NewElector(k8sClient, leader.Config{LeaseDuration: 5 * time.Second,
-			RetryInterval: 2 * time.Second, Namespace: Options.LeaderConfig.Namespace, RenewDeadline: 4 * time.Second},
-			"assisted-service-migration-helper",
-			log.WithField("pkg", "migrationLeader"))
-
-		lead = leader.NewElector(k8sClient, Options.LeaderConfig, "assisted-service-leader-election-helper",
-			log.WithField("pkg", "monitor-runner"))
-
-		failOnError(lead.StartLeaderElection(context.Background()), "Failed to start leader")
+		if Options.StartMonitors {
+			lead = leader.NewElector(k8sClient, Options.LeaderConfig, "assisted-service-leader-election-helper",
+				log.WithField("pkg", "monitor-runner"))
+			failOnError(lead.StartLeaderElection(context.Background()), "Failed to start leader")
+		} else {
+			startupLeader = leader.NewElector(k8sClient, leader.Config{LeaseDuration: 5 * time.Second,
+				RetryInterval: 2 * time.Second, Namespace: Options.LeaderConfig.Namespace, RenewDeadline: 4 * time.Second},
+				"assisted-service-migration-helper",
+				log.WithField("pkg", "migrationLeader"))
+			failOnError(autoMigrationWithLeader(startupLeader, db, log), "Failed auto migration process")
+		}
 
 		ocpClient, err = k8sclient.NewK8SClient("", log)
 		failOnError(err, "Failed to create client for OCP")
@@ -450,11 +454,11 @@ func main() {
 			failOnError(err, "Failed to create client for OCP")
 		}
 
+		failOnError(autoMigrationWithLeader(startupLeader, db, log), "Failed auto migration process")
+
 	default:
 		log.Fatalf("not supported deploy target %s", Options.DeployTarget)
 	}
-
-	failOnError(autoMigrationWithLeader(startupLeader, db, log), "Failed auto migration process")
 
 	Options.UploaderConfig.AssistedServiceVersion = versions.GetRevision()
 	Options.UploaderConfig.Versions = Options.Versions
@@ -478,15 +482,21 @@ func main() {
 	clusterEventsUploader.Start()
 	defer clusterEventsUploader.Stop()
 
-	clusterStateMonitor := thread.New(
-		log.WithField("pkg", "cluster-monitor"), "Cluster State Monitor", Options.ClusterStateMonitorInterval, clusterApi.ClusterMonitoring)
-	clusterStateMonitor.Start()
-	defer clusterStateMonitor.Stop()
+	var backgroundThreads []*thread.Thread
 
-	hostStateMonitor := thread.New(
-		log.WithField("pkg", "host-monitor"), "Host State Monitor", Options.HostStateMonitorInterval, hostApi.HostMonitoring)
-	hostStateMonitor.Start()
-	defer hostStateMonitor.Stop()
+	if Options.StartMonitors {
+		clusterStateMonitor := thread.New(
+			log.WithField("pkg", "cluster-monitor"), "Cluster State Monitor", Options.ClusterStateMonitorInterval, clusterApi.ClusterMonitoring)
+		clusterStateMonitor.Start()
+		defer clusterStateMonitor.Stop()
+		backgroundThreads = append(backgroundThreads, clusterStateMonitor)
+
+		hostStateMonitor := thread.New(
+			log.WithField("pkg", "host-monitor"), "Host State Monitor", Options.HostStateMonitorInterval, hostApi.HostMonitoring)
+		hostStateMonitor.Start()
+		defer hostStateMonitor.Stop()
+		backgroundThreads = append(backgroundThreads, hostStateMonitor)
+	}
 
 	failOnError(
 		versions.AddReleaseImagesToDBIfNeeded(db, releaseImagesArray, startupLeader, log, Options.EnableKubeAPI, Options.ReleaseSourcesConfig.ReleaseSources),
@@ -613,7 +623,7 @@ func main() {
 
 	h = gziphandler.GzipHandler(h)
 	h = app.WithMetricsResponderMiddleware(h)
-	h = app.WithHealthMiddleware(h, []*thread.Thread{hostStateMonitor, clusterStateMonitor},
+	h = app.WithHealthMiddleware(h, backgroundThreads,
 		log.WithField("pkg", "healthcheck"), Options.LivenessValidationTimeout)
 	h = requestid.Middleware(h)
 	h = spec.WithSpecMiddleware(h)

--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -31,6 +31,24 @@ objects:
   metadata:
     labels:
       prometheus: app-sre
+    name: servicemonitor-assisted-monitors-${NAMESPACE}
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: assisted-svc
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        app: assisted-monitor
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
     name: servicemonitor-assisted-installer-postgres-${NAMESPACE}
   spec:
     endpoints:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -230,11 +230,32 @@ parameters:
   value: "1002"
 - name: TNA_CLUSTERS_SUPPORT
   value: "false"
+- name: MONITORS_REPLICAS_COUNT
+  value: "1"
+- name: MONITORS_MEMORY_LIMIT
+  value: "2.55G"
+  required: false
+- name: MONITORS_CPU_LIMIT
+  value: "500m"
+  required: false
+- name: MONITORS_EPHEMERAL_STORAGE_LIMIT
+  value: "6G"
+  required: false
+- name: MONITORS_MEMORY_REQUEST
+  value: "1.7G"
+  required: false
+- name: MONITORS_CPU_REQUEST
+  value: "300m"
+  required: false
+- name: MONITORS_EPHEMERAL_STORAGE_REQUEST
+  value: "5G"
+  required: false
 apiVersion: v1
 kind: Template
 metadata:
   name: assisted-installer
 objects:
+
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -512,6 +533,8 @@ objects:
                 value: ${AMD_SUPPORTED_GPUS}
               - name: TNA_CLUSTERS_SUPPORT
                 value: ${TNA_CLUSTERS_SUPPORT}
+              - name: START_MONITORS
+                value: "false"
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"
@@ -528,6 +551,264 @@ objects:
           - name: envoy-config
             configMap:
               name: ${ENVOY_CONFIGMAP_NAME}
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: assisted-monitors
+  spec:
+    selector:
+      matchLabels:
+        app: assisted-monitors
+    replicas: ${{MONITORS_REPLICAS_COUNT}}
+    template:
+      metadata:
+        labels:
+          app: assisted-monitors
+      spec:
+        serviceAccountName: assisted-monitors
+        containers:
+          - name: assisted-monitors
+            image: ${ASSISTED_SERVICE_IMAGE}:${IMAGE_TAG}
+            imagePullPolicy: Always
+            resources:
+              limits:
+                cpu: ${{MONITORS_CPU_LIMIT}}
+                memory: ${MONITORS_MEMORY_LIMIT}
+                ephemeral-storage: ${MONITORS_EPHEMERAL_STORAGE_LIMIT}
+              requests:
+                cpu: ${MONITORS_CPU_REQUEST}
+                memory: ${MONITORS_MEMORY_REQUEST}
+                ephemeral-storage: ${MONITORS_EPHEMERAL_STORAGE_REQUEST}
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: 8090
+              initialDelaySeconds: ${{LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 8090
+              initialDelaySeconds: ${{READINESS_PROBE_INITIAL_DELAY_SECONDS}}
+            env:
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: aws_secret_access_key
+                    name: assisted-installer-s3
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    key: aws_access_key_id
+                    name: assisted-installer-s3
+              - name: S3_REGION
+                valueFrom:
+                  secretKeyRef:
+                    key: aws_region
+                    name: assisted-installer-s3
+              - name: S3_BUCKET
+                valueFrom:
+                  secretKeyRef:
+                    key: bucket
+                    name: assisted-installer-s3
+              - name: S3_ENDPOINT_URL
+                valueFrom:
+                  secretKeyRef:
+                    key: endpoint
+                    name: assisted-installer-s3
+              - name: S3_USE_SSL
+                value: ${S3_USE_SSL}
+              - name: ENABLE_SKIP_MCO_REBOOT
+                value: ${ENABLE_SKIP_MCO_REBOOT}
+              - name: ENABLE_SOFT_TIMEOUTS
+                value: ${ENABLE_SOFT_TIMEOUTS}
+              - name: MIN_VERSION_FOR_NMSTATE_SERVICE
+                value: ${MIN_VERSION_FOR_NMSTATE_SERVICE}
+              - name: DB_HOST
+                valueFrom:
+                  secretKeyRef:
+                    key: db.host
+                    name: assisted-installer-rds
+              - name: DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    key: db.name
+                    name: assisted-installer-rds
+              - name: DB_PASS
+                valueFrom:
+                  secretKeyRef:
+                    key: db.password
+                    name: assisted-installer-rds
+              - name: DB_PORT
+                valueFrom:
+                  secretKeyRef:
+                    key: db.port
+                    name: assisted-installer-rds
+              - name: DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    key: db.user
+                    name: assisted-installer-rds
+              - name: OCM_SERVICE_CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    key: ocm-service.clientId
+                    name: assisted-installer-sso
+              - name: OCM_SERVICE_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    key: ocm-service.clientSecret
+                    name: assisted-installer-sso
+              - name: KAFKA_BOOTSTRAP_SERVER
+                valueFrom:
+                  secretKeyRef:
+                    key: ${KAFKA_BOOTSTRAP_SERVER_SECRET_KEY}
+                    name: ${KAFKA_BOOTSTRAP_SERVER_SECRET_NAME}
+              - name: KAFKA_CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    key: ${KAFKA_USERNAME_SECRET_KEY}
+                    name: ${KAFKA_USERNAME_SECRET_NAME}
+              - name: KAFKA_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    key: ${KAFKA_PASSWORD_SECRET_KEY}
+                    name: ${KAFKA_PASSWORD_SECRET_NAME}
+              - name: ENABLE_EVENT_STREAMING
+                value: ${ENABLE_EVENT_STREAMING}
+              - name: KAFKA_EVENT_STREAM_TOPIC
+                value: ${KAFKA_EVENT_STREAM_TOPIC}
+              - name: KAFKA_SASL_MECHANISM
+                value: ${KAFKA_SASL_MECHANISM}
+              - name: NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: SERVICE_BASE_URL
+                value: ${SERVICE_BASE_URL}
+              - name: IMAGE_SERVICE_BASE_URL
+                value: ${IMAGE_SERVICE_BASE_URL}
+              - name: BASE_DNS_DOMAINS
+                value: ${BASE_DNS_DOMAINS}
+              - name: OS_IMAGES
+                value: ${OS_IMAGES}
+              - name: RELEASE_IMAGES
+                value: ${RELEASE_IMAGES}
+              - name: MUST_GATHER_IMAGES
+                value: ${MUST_GATHER_IMAGES}
+              - name: AUTH_TYPE
+                value: ${AUTH_TYPE}
+              - name: JWKS_URL
+                value: ${JWKS_URL}
+              - name: ALLOWED_DOMAINS
+                value: ${ALLOWED_DOMAINS}
+              - name: OCM_BASE_URL
+                value: ${OCM_BASE_URL}
+              - name: HW_VALIDATOR_REQUIREMENTS
+                value: ${HW_VALIDATOR_REQUIREMENTS}
+              - name: INSTALLER_IMAGE
+                value: ${INSTALLER_IMAGE}
+              - name: SELF_VERSION
+                value: ${ASSISTED_SERVICE_IMAGE}:${IMAGE_TAG}
+              - name: CONTROLLER_IMAGE
+                value: ${CONTROLLER_IMAGE}
+              - name: AGENT_DOCKER_IMAGE
+                value: ${AGENT_DOCKER_IMAGE}
+              - name: LOG_LEVEL
+                value: ${LOG_LEVEL}
+              - name: INSTALL_RH_CA
+                value: ${INSTALL_RH_CA}
+              - name: REGISTRY_CREDS
+                value: ${REGISTRY_CREDS}
+              - name: RELEASE_TAG
+                value: ${RELEASE_TAG}
+              - name: AGENT_TIMEOUT_START
+                value: ${AGENT_TIMEOUT_START}
+              - name: AWS_SHARED_CREDENTIALS_FILE
+                value: /etc/.aws/credentials
+              - name: ADMIN_USERS
+                value: ${ADMIN_USERS}
+              - name: LIVENESS_VALIDATION_TIMEOUT
+                value: ${LIVENESS_VALIDATION_TIMEOUT}
+              - name: PUBLIC_CONTAINER_REGISTRIES
+                value: ${PUBLIC_CONTAINER_REGISTRIES}
+              - name: CHECK_CLUSTER_VERSION
+                value: ${CHECK_CLUSTER_VERSION}
+              - name: IPV6_SUPPORT
+                value: ${IPV6_SUPPORT}
+              - name: ENABLE_SINGLE_NODE_DNSMASQ
+                value: ${ENABLE_SINGLE_NODE_DNSMASQ}
+              - name: DB_MAX_IDLE_CONNECTIONS
+                value: ${DB_MAX_IDLE_CONNECTIONS}
+              - name: DB_MAX_OPEN_CONNECTIONS
+                value: ${DB_MAX_OPEN_CONNECTIONS}
+              - name: DISABLED_HOST_VALIDATIONS
+                value: ${DISABLED_HOST_VALIDATIONS}
+              - name: DISABLED_STEPS
+                value: ${DISABLED_STEPS}
+              - name: ENABLE_AUTO_ASSIGN
+                value: ${ENABLE_AUTO_ASSIGN}
+              - name: DISK_ENCRYPTION_SUPPORT
+                value: ${DISK_ENCRYPTION_SUPPORT}
+              - name: MAX_GC_INFRAENVS_PER_INTERVAL
+                value: ${MAX_GC_INFRAENVS_PER_INTERVAL}
+              - name: INFRAENV_DELETION_WORKER_INTERVAL
+                value: ${INFRAENV_DELETION_WORKER_INTERVAL}
+              - name: INFRAENV_DELETED_INACTIVE_AFTER
+                value: ${INFRAENV_DELETED_INACTIVE_AFTER}
+              - name: CNV_SNO_INSTALL_HPP
+                value: ${CNV_SNO_INSTALL_HPP}
+              - name: ENABLE_ORG_TENANCY
+                value: ${ENABLE_ORG_TENANCY}
+              - name: ENABLE_ORG_BASED_FEATURE_GATES
+                value: ${ENABLE_ORG_BASED_FEATURE_GATES}
+              - name: ISO_IMAGE_TYPE
+                value: ${ISO_IMAGE_TYPE}
+              - name: ENABLE_UPGRADE_AGENT
+                value: ${ENABLE_UPGRADE_AGENT}
+              - name: WORK_DIR
+                value: ${WORK_DIR}
+              - name: ENABLE_REJECT_UNKNOWN_FIELDS
+                value: ${ENABLE_REJECT_UNKNOWN_FIELDS}
+              - name: ENABLE_DATA_COLLECTION
+                value: ${ENABLE_DATA_COLLECTION}
+              - name: DEPLOYMENT_TYPE
+                value: ${DEPLOYMENT_TYPE}
+              - name: INSTALLER_CACHE_CAPACITY
+                value: ${INSTALLER_CACHE_CAPACITY}
+              - name: ENABLE_OKD_SUPPORT
+                value: ${ENABLE_OKD_SUPPORT}
+              - name: RELEASE_SOURCES
+                value: ${RELEASE_SOURCES}
+              - name: OPENSHIFT_RELEASE_SYNCER_INTERVAL
+                value: ${OPENSHIFT_RELEASE_SYNCER_INTERVAL}
+              - name: OPENSHIFT_SUPPORT_LEVEL_API_BASE_URL
+                value: ${OPENSHIFT_SUPPORT_LEVEL_API_BASE_URL}
+              - name: IGNORED_OPENSHIFT_VERSIONS
+                value: ${IGNORED_OPENSHIFT_VERSIONS}
+              - name: NVIDIA_SUPPORTED_GPUS
+                value: ${NVIDIA_SUPPORTED_GPUS}
+              - name: AMD_SUPPORTED_GPUS
+                value: ${AMD_SUPPORTED_GPUS}
+              - name: TNA_CLUSTERS_SUPPORT
+                value: ${TNA_CLUSTERS_SUPPORT}
+              - name: START_MONITORS
+                value: "true"
+            volumeMounts:
+              - name: route53-creds
+                mountPath: "/etc/.aws"
+                readOnly: true
+              - name: workdir-volume
+                mountPath: ${WORK_DIR}
+        volumes:
+          - name: workdir-volume
+            emptyDir: {}
+          - name: route53-creds
+            secret:
+              secretName: route53-creds
+              optional: true
+
+
 - apiVersion: v1
   kind: Service
   metadata:
@@ -542,6 +823,7 @@ objects:
         targetPort: ${{SVC_TARGET_PORT}}
     selector:
       app: assisted-service
+
 - apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:
@@ -553,6 +835,7 @@ objects:
     selector:
       matchLabels:
         app: assisted-service
+
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
Currently we run the API server and the background monitors in the same processes and pods. This makes it more difficult to understand the performance characteristics of those two things, and it also means that when the monitors need to be restarted the in-flight API requests need to be aborted. To improve that this moves the monitors to a different pod. This is done trying to minimize code changes:

- A new `START_MONITORS` environment variable is added to control if the monitors are started. This is set to `false` in the existing pods pods, and to `true` in the new ones.

- The leader election used for the monitors is only started in the new pods, i.e., when `START_MONITORS` is `true`.

- The leader election used for applying migrations is only started in the old pods, i.e., when `START_MONITORS` is `false`.

The new pods are started by a new `assisted-monitors` deployment that is almost identical to the existing deployment, it even starts the API lister, but it doesn't have an Envoy sidecar and it the API port isn't exposed.

In the future the logic of `main.go` should probably be also separated: one for the API server and another for the monitors, but that will require much larger changes that we don't want to do now.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-19704

- [ ] New Feature <!-- new functionality -->
- [X ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I tried to deploy this manually to an OpenShift cluster, but the template requires many parameters and secrets that are difficult to reproduce, so I wasn't able to. Is there any way to test this other than to deploy to the integration or stage environments?

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
