### PR TITLE
OCPBUGS-59393: dual stack installation fails due to ipv6 miscalculation

### DIFF
--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -140,8 +140,14 @@ func (v *clusterValidator) isMachineCidrEqualsToCalculatedCidr(c *clusterPreproc
 		c.calculateCidr = cidr
 		machineCidrAvailable := network.IsMachineCidrAvailable(c.cluster)
 		if machineCidrAvailable {
-			if cidr != network.GetMachineCidrById(c.cluster, i) {
-				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", network.GetMachineCidrById(c.cluster, i), c.calculateCidr))
+			userMachineCidr := network.GetMachineCidrById(c.cluster, i)
+			normalizedUserMachineCidr, err := network.NormalizeCIDR(userMachineCidr)
+			if err != nil {
+				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "failed to normalize user machine CIDR %s", userMachineCidr))
+				continue
+			}
+			if cidr != normalizedUserMachineCidr {
+				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", userMachineCidr, c.calculateCidr))
 			}
 		}
 	}

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -539,3 +539,15 @@ func ComputeParsedMachineNetworks(mNetworks []*models.MachineNetwork) ([]*net.IP
 	}
 	return machineNetworks, nil
 }
+
+// NormalizeCIDR normalizes a CIDR string to its canonical form.
+func NormalizeCIDR(cidr string) (string, error) {
+	if cidr == "" {
+		return "", nil
+	}
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+	return ipnet.String(), nil
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -1095,3 +1095,32 @@ var _ = Describe("ComputeParsedMachineNetworks", func() {
 	Expect(parsedMachineNetworks).To(Equal(expectedResult))
 
 })
+
+var _ = Describe("NormalizeCIDR", func() {
+	It("Normalizes a CIDR", func() {
+		cidr := "2A00:8A00:4000:0d80::/64"
+		expected := "2a00:8a00:4000:d80::/64"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Normalizes a CIDR - no change", func() {
+		cidr := "192.168.1.0/24"
+		expected := "192.168.1.0/24"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Empty CIDR", func() {
+		cidr := ""
+		expected := ""
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Invalid CIDR", func() {
+		cidr := "invalid"
+		_, err := NormalizeCIDR(cidr)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
This PR addresses the issue described in [OCPBUGS-59393](https://issues.redhat.com/browse/OCPBUGS-59393).

**Summary:** dual stack installation fails due to ipv6 miscalculation

**Description:** Description of problem:
{code:none}
    Customer is using using GitOps ZTP and SiteConfig v1 for scale-in/scale-out ops on dual stack ipv4/ipv6 spoke clusters.

Scale-in was successful, but the scale-out failed with AgentInstaller complaining about ipv6 Cluster Machine CIDR vs calculated CIDR mismatch{code}
Version-Release number of selected component (if applicable):
{code:none}
OCP 4.18.6 + ACM 2.13.2 + Dual Stack ipv4/ipv6 Spoke Clusters{code}
How reproducible:
{code:none}
always{code}
Steps to Reproduce:
{code:none}
1. In the siteconfig the machine network was defined as follows:      

machineNetwork:
        - cidr: 100.104.168.64/27
        - cidr: 2A00:8A00:4000:0d80::/64

....and here is how the node's networking is defined:
[..]
     - name: infra-bond.94
                  type: vlan
                  state: up
                  mtu: 9000
                  ipv6:
                    enabled: true
                    autoconf: false
                    dhcp: false
                    address:
                      - ip: 2A00:8A00:4000:0d80::76
                        prefix-length: 64
                  ipv4:
                    enabled: true
                    dhcp: false
                    address:
                      - ip: "100.104.168.76"
                        prefix-length: 27
                  vlan:
                    base-iface: infra-bond
                    id: 94

2. scale in a node and then try to scale out it again{code}
Actual results:
{code:none}
     - id: machine-cidr-equals-to-calculated-cidr
      message: "1 error occurred:\n\t* The Cluster Machine CIDR 2A00:8A00:4000:0d80::/64
        is different than the calculated CIDR 2a00:8a00:4000:d80::/64.\n\n"{code}
Expected results:
{code:none}
    Installation to succeed{code}
Additional info:
{code:none}
    Baremetal env{code}

**Assignee:** Linoy Hadad (lhadad@redhat.com)