### PR TITLE
Set AIUI_CHAT_API_URL for podman deployment

### DIFF
--- a/deploy/podman/configmap-disconnected.yml
+++ b/deploy/podman/configmap-disconnected.yml
@@ -53,3 +53,5 @@ data:
     -----BEGIN CERTIFICATE-----
     <your cert goes here>
     -----END CERTIFICATE-----
+  # Dummy values, doesn't do anything
+  AIUI_CHAT_API_URL: http://localhost:12121

--- a/deploy/podman/configmap.yml
+++ b/deploy/podman/configmap.yml
@@ -31,4 +31,5 @@ data:
   SERVICE_BASE_URL: http://127.0.0.1:8090
   STORAGE: filesystem
   ENABLE_UPGRADE_AGENT: "true"
-
+  # Dummy values, doesn't do anything
+  AIUI_CHAT_API_URL: http://localhost:12121

--- a/deploy/podman/configmap_tls.yml
+++ b/deploy/podman/configmap_tls.yml
@@ -35,3 +35,5 @@ data:
   SERVICE_BASE_URL: https://127.0.0.1:8090
   STORAGE: filesystem
   ENABLE_UPGRADE_AGENT: "true"
+  # Dummy values, doesn't do anything
+  AIUI_CHAT_API_URL: http://localhost:12121


### PR DESCRIPTION
The nginx configuration for the UI doesn't start well without it. Set
dummy URL to make it at-least parse the config

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md