### PR TITLE
OCPBUGS-59393: Fix IsMachineCidrEqualsToCalculatedCidr validation to handle unnormalized IPv6 addresses

### DIFF
--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -140,8 +140,14 @@ func (v *clusterValidator) isMachineCidrEqualsToCalculatedCidr(c *clusterPreproc
 		c.calculateCidr = cidr
 		machineCidrAvailable := network.IsMachineCidrAvailable(c.cluster)
 		if machineCidrAvailable {
-			if cidr != network.GetMachineCidrById(c.cluster, i) {
-				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", network.GetMachineCidrById(c.cluster, i), c.calculateCidr))
+			userMachineCidr := network.GetMachineCidrById(c.cluster, i)
+			normalizedUserMachineCidr, err := network.NormalizeCIDR(userMachineCidr)
+			if err != nil {
+				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "failed to normalize user machine CIDR %s", userMachineCidr))
+				continue
+			}
+			if cidr != normalizedUserMachineCidr {
+				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", userMachineCidr, c.calculateCidr))
 			}
 		}
 	}

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -670,3 +670,26 @@ func GenerateHostInventoryInterfaceIPV4InMNetIPV6Doesnt(mutateFn func(*models.In
 	Expect(err).To(Not(HaveOccurred()))
 	return string(b)
 }
+
+func GenerateTestInventoryWithUnnormalizedIPv6() string {
+	inventory := &models.Inventory{
+		CPU: &models.CPU{
+			Architecture: models.ClusterCPUArchitectureX8664,
+		},
+		Interfaces: []*models.Interface{
+			{
+				IPV6Addresses: []string{
+					"2A00:8A00:4000:0d80::1/64",
+				},
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		Routes: TestDefaultRouteConfiguration,
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -539,3 +539,15 @@ func ComputeParsedMachineNetworks(mNetworks []*models.MachineNetwork) ([]*net.IP
 	}
 	return machineNetworks, nil
 }
+
+// NormalizeCIDR normalizes a CIDR string to its canonical form.
+func NormalizeCIDR(cidr string) (string, error) {
+	if cidr == "" {
+		return "", nil
+	}
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+	return ipnet.String(), nil
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -1095,3 +1095,32 @@ var _ = Describe("ComputeParsedMachineNetworks", func() {
 	Expect(parsedMachineNetworks).To(Equal(expectedResult))
 
 })
+
+var _ = Describe("NormalizeCIDR", func() {
+	It("Normalizes a CIDR", func() {
+		cidr := "2A00:8A00:4000:0d80::/64"
+		expected := "2a00:8a00:4000:d80::/64"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Normalizes a CIDR - no change", func() {
+		cidr := "192.168.1.0/24"
+		expected := "192.168.1.0/24"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Empty CIDR", func() {
+		cidr := ""
+		expected := ""
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Invalid CIDR", func() {
+		cidr := "invalid"
+		_, err := NormalizeCIDR(cidr)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
The `isMachineCidrEqualsToCalculatedCidr` validation was failing when users provided IPv6 CIDRs with uppercase letters/ leading zeros / both (e.g., `2A00:8A00:4000:0d80::/64`), even when they were functionally equivalent to the calculated CIDR.

This occurred because:
- User-provided CIDRs could contain uppercase letters and leading zeros
- Calculated CIDRs from host inventories are normalized (lowercase, no leading zeros)
- Direct string comparison would fail even for equivalent networks

## Solution
Updated the validation logic to normalize user-provided CIDRs before comparison with the calculate one using `network.NormalizeCIDR()`

**Assisted-by:** flightctl ai-issue-resolver, Cursor

## Testing
To reproduce the bug:
1. Create a Hub cluster
2. Deploy a spoke cluster and configure AgentClusterInstall with machineNetworks, including an IPv6 entry that contains uppercase letters and leading zeros.
3. Set VIPs that also include uppercase letters and leading zeros.
4. Create an NMStateConfig CR with an interface using an IPv6 address in the same format (uppercase and leading zeros).
5. After agents are discovered, check the status of the AgentClusterInstall resource - you should see isMachineCidrEqualsToCalculatedCidr validation failed.

After applying the fix, repeat the steps above - the validation error should no longer appear.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
