### PR TITLE
[release-ocm-2.12] :  Fix IsMachineCidrEqualsToCalculatedCidr validation to handle unnormalized IPv6 addresses (#7923)

### DIFF
--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -137,8 +137,14 @@ func (v *clusterValidator) isMachineCidrEqualsToCalculatedCidr(c *clusterPreproc
 		c.calculateCidr = cidr
 		machineCidrAvailable := network.IsMachineCidrAvailable(c.cluster)
 		if machineCidrAvailable {
-			if cidr != network.GetMachineCidrById(c.cluster, i) {
-				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", network.GetMachineCidrById(c.cluster, i), c.calculateCidr))
+			userMachineCidr := network.GetMachineCidrById(c.cluster, i)
+			normalizedUserMachineCidr, err := network.NormalizeCIDR(userMachineCidr)
+			if err != nil {
+				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "failed to normalize user machine CIDR %s", userMachineCidr))
+				continue
+			}
+			if cidr != normalizedUserMachineCidr {
+				multiErr = multierror.Append(multiErr, errors.Errorf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", userMachineCidr, c.calculateCidr))
 			}
 		}
 	}

--- a/internal/cluster/validator_test.go
+++ b/internal/cluster/validator_test.go
@@ -668,3 +668,86 @@ var _ = Describe("skipNetworkHostPrefixCheck", func() {
 		Expect(skipped).Should(Equal(true))
 	})
 })
+
+var _ = Describe("isMachineCidrEqualsToCalculatedCidr", func() {
+	var (
+		validator clusterValidator
+		clusterID strfmt.UUID
+	)
+
+	BeforeEach(func() {
+		clusterID = strfmt.UUID(uuid.New().String())
+		validator = clusterValidator{log: logrus.New()}
+	})
+
+	Context("Normalized CIDR", func() {
+		var (
+			hosts []*models.Host
+		)
+		BeforeEach(func() {
+			// Create hosts with IPv6 interfaces with Uppercase and leading zero
+			newId := func() strfmt.UUID {
+				return strfmt.UUID(uuid.New().String())
+			}
+			newIdPtr := func() *strfmt.UUID {
+				ret := newId()
+				return &ret
+			}
+			hosts = []*models.Host{
+				{
+					ClusterID:  &clusterID,
+					InfraEnvID: clusterID,
+					ID:         newIdPtr(),
+					Inventory:  common.GenerateTestInventoryWithUnnormalizedIPv6(),
+				},
+			}
+		})
+		It("should pass validation when machine CIDR contains IPv6 with uppercase and leading zeros", func() {
+			// User provides:
+			// Interface IP: "2A00:8A00:4000:0d80::1/64" (uppercase, leading zeros)
+			// VIP: "2A00:8A00:4000:0d80::77"
+			// Calculated CIDR becomes: "2a00:8a00:4000:d80::/64" (normalized by net.ParseCIDR)
+
+			preprocessContext := &clusterPreprocessContext{
+				clusterId:               clusterID,
+				hasHostsWithInventories: true,
+				cluster: &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: []*models.MachineNetwork{{Cidr: "2A00:8A00:4000:0d80::/64"}},                // User provided - unnormalized with uppercase and leading zeros
+						APIVips:         []*models.APIVip{{ClusterID: clusterID, IP: "2A00:8A00:4000:0d80::77"}},     // VIP in same network
+						IngressVips:     []*models.IngressVip{{ClusterID: clusterID, IP: "2A00:8A00:4000:0d80::88"}}, // Ingress VIP in same network
+						Hosts:           hosts,
+					},
+				},
+			}
+
+			status, msg := validator.isMachineCidrEqualsToCalculatedCidr(preprocessContext)
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(msg).To(Equal("The Cluster Machine CIDR is equivalent to the calculated CIDR."))
+		})
+
+		It("should fail validation when machine CIDR contains invalid format and cannot be normalized", func() {
+			// Test the error case when NormalizeCIDR fails with invalid input
+			// This ensures our error handling works correctly
+
+			preprocessContext := &clusterPreprocessContext{
+				clusterId:               clusterID,
+				hasHostsWithInventories: true,
+				cluster: &common.Cluster{
+					Cluster: models.Cluster{
+						ID:              &clusterID,
+						MachineNetworks: []*models.MachineNetwork{{Cidr: "invalid-ipv6-cidr"}}, // Invalid CIDR that will cause normalization to fail
+						APIVips:         []*models.APIVip{{ClusterID: clusterID, IP: "2A00:8A00:4000:0d80::77"}},
+						IngressVips:     []*models.IngressVip{{ClusterID: clusterID, IP: "2A00:8A00:4000:0d80::88"}},
+						Hosts:           hosts,
+					},
+				},
+			}
+
+			status, msg := validator.isMachineCidrEqualsToCalculatedCidr(preprocessContext)
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(msg).To(ContainSubstring("failed to normalize user machine CIDR invalid-ipv6-cidr"))
+		})
+	})
+})

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -645,3 +645,26 @@ func FormatStaticConfigHostYAML(nicPrimary, nicSecondary, ip4Master, ip4Secondar
 	output, _ := yaml.Marshal(staticNetworkConfig)
 	return &models.HostStaticNetworkConfig{MacInterfaceMap: macInterfaceMap, NetworkYaml: string(output)}
 }
+
+func GenerateTestInventoryWithUnnormalizedIPv6() string {
+	inventory := &models.Inventory{
+		CPU: &models.CPU{
+			Architecture: models.ClusterCPUArchitectureX8664,
+		},
+		Interfaces: []*models.Interface{
+			{
+				IPV6Addresses: []string{
+					"2A00:8A00:4000:0d80::1/64",
+				},
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		Routes: TestDefaultRouteConfiguration,
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -448,3 +448,15 @@ func UpdateVipsTables(db *gorm.DB, cluster *common.Cluster, apiVipUpdated bool, 
 
 	return nil
 }
+
+// NormalizeCIDR normalizes a CIDR string to its canonical form.
+func NormalizeCIDR(cidr string) (string, error) {
+	if cidr == "" {
+		return "", nil
+	}
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+	return ipnet.String(), nil
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -1012,3 +1012,32 @@ var _ = Describe("GetVips", func() {
 		})
 	})
 })
+
+var _ = Describe("NormalizeCIDR", func() {
+	It("Normalizes a CIDR", func() {
+		cidr := "2A00:8A00:4000:0d80::/64"
+		expected := "2a00:8a00:4000:d80::/64"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Normalizes a CIDR - no change", func() {
+		cidr := "192.168.1.0/24"
+		expected := "192.168.1.0/24"
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Empty CIDR", func() {
+		cidr := ""
+		expected := ""
+		actual, err := NormalizeCIDR(cidr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+	It("Invalid CIDR", func() {
+		cidr := "invalid"
+		_, err := NormalizeCIDR(cidr)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
This is a manual cherry-pick of #7923 