### PR TITLE
MGMT-21274: Report duration of monitored hosts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -178,6 +178,9 @@ var Options struct {
 
 	// SlowClusterMonitorLogThreshold defines the duration after which clusters that take too long to process will be logged
 	SlowClusterMonitorLogThreshold time.Duration `envconfig:"SLOW_CLUSTER_MONITOR_LOG_THRESHOLD" default:"1s"`
+
+	// SlowHostMonitorLogThreshold defines the duration after which hosts that take too long to process will be logged
+	SlowHostMonitorLogThreshold time.Duration `envconfig:"SLOW_HOST_MONITOR_LOG_THRESHOLD" default:"1s"`
 }
 
 func InitLogs(logLevel, logFormat string) *logrus.Logger {
@@ -323,6 +326,7 @@ func main() {
 			Directories: []string{Options.WorkDir},
 		},
 		ClusterMonitorSlowLogThreshold: Options.SlowClusterMonitorLogThreshold,
+		HostMonitorSlowLogThreshold:    Options.SlowHostMonitorLogThreshold,
 	}
 	diskStatsHelper := metrics.NewOSDiskStatsHelper(log)
 	metricsManager := metrics.NewMetricsManager(prometheusRegistry, eventsHandler, diskStatsHelper, metricsManagerConfig, log)

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -181,8 +181,8 @@ func (m *Manager) clusterHostMonitoring() {
 				log.Debug("Started refreshing host status")
 				err = m.refreshStatusInternal(ctx, host, c, nil, inventoryCache, m.db)
 
-				duration := float64(time.Since(startTime).Milliseconds())
-				m.metricApi.MonitoredHostsDurationMs(duration)
+				duration := time.Since(startTime)
+				m.metricApi.MonitoredHostsDurationMs(ctx, *host.ID, c.ID, duration)
 				if err != nil {
 					log.WithError(err).Error("failed to refresh host state")
 				}
@@ -245,8 +245,8 @@ func (m *Manager) infraEnvHostMonitoring() {
 				if funk.ContainsString(monitorStates, swag.StringValue(host.Status)) {
 					startTime := time.Now()
 					err = m.refreshStatusInternal(ctx, &host.Host, nil, i, inventoryCache, m.db)
-					duration := float64(time.Since(startTime).Milliseconds())
-					m.metricApi.MonitoredHostsDurationMs(duration)
+					duration := time.Since(startTime)
+					m.metricApi.MonitoredHostsDurationMs(ctx, *host.ID, nil, duration)
 					if err != nil {
 						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
 					}

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -88,7 +88,7 @@ var _ = Describe("monitor_disconnection", func() {
 		db.First(&host, "id = ? and cluster_id = ?", host.ID, host.ClusterID)
 
 		mockMetricApi.EXPECT().Duration("HostMonitoring", gomock.Any()).Times(1)
-		mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
+		mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockOperators.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
@@ -249,7 +249,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		It("do not reset with status disconnected", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusDisconnected, models.HostKindHost)
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -264,7 +264,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			otherClusterId := strfmt.UUID(uuid.New().String())
 			addHost(otherClusterId, models.HostRoleAutoAssign, models.HostStatusKnown, models.HostKindHost)
 			addHost(otherClusterId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindHost)
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -276,7 +276,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		It("do not reset with day2 host", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusKnown, models.HostKindAddToExistingClusterHost)
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -306,17 +306,17 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 		}
 
 		It("5 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(5)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(5)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(15)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(15)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(765)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(765)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -334,7 +334,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
 			Expect(db.Model(&host).Update("status", hostStatus).Error).ShouldNot(HaveOccurred())
 
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(expectedCount)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(expectedCount)
 			state.HostMonitoring()
 		},
 			Entry("HostStatusAddedToExistingCluster is not monitored", models.ClusterStatusReady, models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
@@ -459,17 +459,17 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		}
 
 		It("5 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(5)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(5)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(15)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(15)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(765)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(765)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -491,7 +491,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		}
 
 		It("times out Reclaiming hosts", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaiming)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)
@@ -499,7 +499,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 		})
 
 		It("times out ReclaimingRebooting hosts", func() {
-			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any()).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaimingRebooting)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -206,15 +206,15 @@ func (mr *MockAPIMockRecorder) MonitoredClustersDurationMs(ctx, clusterID, durat
 }
 
 // MonitoredHostsDurationMs mocks base method.
-func (m *MockAPI) MonitoredHostsDurationMs(monitoredHostsMillis float64) {
+func (m *MockAPI) MonitoredHostsDurationMs(ctx context.Context, hostID strfmt.UUID, clusterID *strfmt.UUID, duration time.Duration) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MonitoredHostsDurationMs", monitoredHostsMillis)
+	m.ctrl.Call(m, "MonitoredHostsDurationMs", ctx, hostID, clusterID, duration)
 }
 
 // MonitoredHostsDurationMs indicates an expected call of MonitoredHostsDurationMs.
-func (mr *MockAPIMockRecorder) MonitoredHostsDurationMs(monitoredHostsMillis interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) MonitoredHostsDurationMs(ctx, hostID, clusterID, duration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsDurationMs), monitoredHostsMillis)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsDurationMs), ctx, hostID, clusterID, duration)
 }
 
 // ReportHostInstallationMetrics mocks base method.


### PR DESCRIPTION
[MGMT-21274](https://issues.redhat.com//browse/MGMT-21274): Report duration of monitored hosts

Send an event that records how long each host takes to be monitored, making it easy to spot hosts that slow the monitoring loop.

Adds the SLOW_HOST_MONITOR_LOG_THRESHOLD env-var (default 1 s) and unit-tests for the new behaviour.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

How I verified the change:
1. Set the env-var so every pass is considered slow:
   ```
   SLOW_HOST_MONITOR_LOG_THRESHOLD=0ms
   ```
2. Installed a test cluster.

3. Queried the metrics-category events and confirmed `host_monitor.slow_host`
   entries appear:

   ```bash
   curl -s \
     "http://10.1.178.25:8090/api/assisted-install/v2/events?cluster_id=4c951ccb-f47a-4e57-87a5-2af635f73e2e&categories=metrics&message=host_monitor.slow_host&limit=20&order=descending" \
     | jq '.[] | {time: .event_time, host: .host_id, duration_ms: (.props | fromjson | .duration)}'
   ```

   Sample output:

   ```
   {
     "time": "2025-08-13T12:08:22.732Z",
     "host": "30cdadc9-7d35-412f-a5b9-ef902fcf721b",
     "duration_ms": 1
   }
   {
     "time": "2025-08-13T12:05:02.732Z",
     "host": "30cdadc9-7d35-412f-a5b9-ef902fcf721b",
     "duration_ms": 1
   }
   ...
   ```
   
## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
