### PR TITLE
ACM-21902: Merge system ca-bundle into spoke client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -352,11 +352,12 @@ func main() {
 	var startupLeader leader.ElectorInterface
 
 	mirrorRegistriesBuilder := mirrorregistries.New(Options.ForceInsecurePolicyJson)
+	sys := system.NewLocalSystemInfo()
 	releaseHandler := oc.NewRelease(
 		&executer.CommonExecuter{},
 		oc.Config{MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay},
 		mirrorRegistriesBuilder,
-		system.NewLocalSystemInfo(),
+		sys,
 	)
 
 	versionHandler, versionsAPIHandler, err := createVersionHandlers(
@@ -650,7 +651,7 @@ func main() {
 				InsecureIPXEURLs:    generateInsecureIPXEURLs,
 			}).SetupWithManager(ctrlMgr), "unable to create controller InfraEnv")
 
-			spokeClientFactory, err := spoke_k8s_client.NewFactory(log, nil)
+			spokeClientFactory, err := spoke_k8s_client.NewFactory(log, nil, sys)
 			failOnError(err, "unable to create spoke client factory")
 
 			cluster_client := ctrlMgr.GetClient()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -30,6 +30,7 @@ import (
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/controller/controllers"
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
+	"github.com/openshift/assisted-service/internal/system"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -177,7 +178,7 @@ func main() {
 	}
 
 	log := logrus.New()
-	spokeClientFactory, err := spoke_k8s_client.NewFactory(log, nil)
+	spokeClientFactory, err := spoke_k8s_client.NewFactory(log, nil, system.NewLocalSystemInfo())
 	if err != nil {
 		log.WithError(err).Error("failed to create spoke client factory")
 		os.Exit(1)

--- a/internal/spoke_k8s_client/factory_test.go
+++ b/internal/spoke_k8s_client/factory_test.go
@@ -3,24 +3,106 @@ package spoke_k8s_client
 import (
 	"net/http"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/system"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+)
 
-	"github.com/openshift/assisted-service/internal/common"
+const testCert string = `-----BEGIN CERTIFICATE-----
+MIIFPjCCAyagAwIBAgIUBCE1YX2zJ0R/3NURq2XQaciEuVQwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjIxMTI3MjM0MjAyWhcNMzIx
+MTI0MjM0MjAyWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAKY589W+Xifs9SfxofBI1r1/NKsMUVPvg3ZtDIPQ
+EeNKf5OgtSOVFcoEmkS7ZWNTIu4Kd1WBf/rG+F5lm/aTTa3j720Q+fS+gsveGQPz
+7taUpU/TjHHzoCqjjhaYMr4gIJ3jkpTXUWG5/vka/oNykSxkGCuZw1gyXHNujA8L
+DJYY8VNUHPl5MmXGaT++6yEN4WdB2f7R/MmEaH6KnGo/LjhMeiVmDsIxHZ/xW9OR
+izPklnUi78NfZJSxiknoV6CnQShNijLEq6nQowYQ1lQuNWs6sTM28I0BYWk+gDUz
+NOWkVqSHFRMzGmpqYJs7JQiv0g33VN/92dwdP/kZc9sAYRqDaI6hplOZrD/OEsbG
+lmN90x/o42wotJeBDN1hHlJ1JeRjR1Vk8XUfOmaTuOPzooKIM0h9K6Ah6u3lRQtE
+n68yxn0sGD8yw6EydS5FD9zzvA6rgXBSsvpMFjk/N/FmnIzD4YinLEiflfub1O0M
+9thEOX9IaOh00U2eGsRa/MOJcCZ5TUOgxVlv15ATUPHo1MW8QkmYOVx4BoM/Bw0J
+0HibIU8VUw2AV1tupRdQma7Qg5gyjdx2doth78IG5+LkX95fSyz60Kf9l1xBQHNA
+kVyzkXlx8jmdm53CeFvHVOrVrLuA2Dk+t21TNL1uFGgQ0iLxItCf1O6F6B78QqhI
+YLOdAgMBAAGjgYMwgYAwHQYDVR0OBBYEFE6DFh3+wGzA8dOYBTL9Z0CyxLJ/MB8G
+A1UdIwQYMBaAFE6DFh3+wGzA8dOYBTL9Z0CyxLJ/MA8GA1UdEwEB/wQFMAMBAf8w
+LQYDVR0RBCYwJIILZXhhbXBsZS5jb22CD3d3dy5leGFtcGxlLm5ldIcECgAAATAN
+BgkqhkiG9w0BAQsFAAOCAgEAoj+elkYHrek6DoqOvEFZZtRp6bPvof61/VJ3kP7x
+HZXp5yVxvGOHt61YRziGLpsFbuiDczk0V61ZdozHUOtZ0sWB4VeyO1pAjfd/JwDI
+CK6olfkSO78WFQfdG4lNoSM9dQJyEIEZ1sbvuUL3RHDBd9oEKue+vsstlM9ahdoq
+fpTTFq4ENGCAIDvaqKIlpjKsAMrsTO47CKPVh2HUpugfVGKeBRsW1KAXFoC2INS5
+7BY3h60jFFW6bz0v+FnzW96Mt2VNW+i/REX6fBaR4m/QfG81rA2EEmhxCGrany+N
+6DUkwiJxcqBMH9jA2yVnF7BgwG2C3geBqXTTlvVQJD8GOktkvgLjlHcYqO1pI7B3
+wP9F9ZF+w39jXwGMGBg8+/aQz1RjP2bOb18n7d0bc4/pbbkVAmE4sq4qMneFZAVE
+uj9S2Jna3ut08ZP05Ych5vCGX4VJ8gNNgrJju2PJVBl8NNyDfHKeHfWSOR9uOMjT
+vqK6iRD9xqu/oLJyrlAuOL8ZxRpeqjxF/g8NYYV/fvv8apaX58ua9qYAFQVGf590
+mmjOozzn9VBqKenVmfwzen5v78CBSgS4Hd72Qp42rLCNgqI8gyQa2qZzaNjLP/wI
+pBpFC21fkybGYPkislPQ3EI69ZGRafWDBjlFFTS3YkDM98tqTZD+JG4STY+ivHhK
+gmY=
+-----END CERTIFICATE-----`
+
+const testCert2 string = `-----BEGIN CERTIFICATE-----
+MIIFPjCCAyagAwIBAgIUV3ZmDsSwF6/E2CPhFChz3w14OLMwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjIxMTI3MjM0MjMwWhcNMzIx
+MTI0MjM0MjMwWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBALxURtV3Wd8NEFIplXSZpIdx5I0jFU8thmb2vZON
+oNxr31OsHYqkA07RpGSmyn+hv03OI9g4AzuMGs48XoPxZGtWUr0wany1LDDW8t/J
+PytYeZyXAJM0zl6/AlzSzYRPk22LykdzVBQosUeRP42a2xWEdDRkJqxxBHQ0eLiC
+9g32w57YomhbgCR2OnUxzVmMuQmk987WG7u3/ssSBPEuIebOoX+6G3uLaw/Ka6zQ
+XGzRgFq3mskPVfw3exQ46WZfgu6PtG5zxKmty75fNPPwdyw+lwm3u8pH5jpJYvOZ
+RHbk7+nxWxLxe5r3FzaNeWskb24J9x53nQzwfcF0MtuRvMycO1i/3e5Y4TanEmmu
+GbUOKlJxyaFQaVa2udWAxZ8w1W5u4aKrBprXEAXXDghXbxrgRry2zPO1vqZ/aLH8
+YKnHLifjdsNMxrA3nsKAViY0erwYmTF+c551gxkW7vZCtJStzDcMVM16U76jato7
+fNb64VUtviVCWeHvh7aTpxENPCh6T8eGh3K4HUESTNpBggs3TXhF1yEcS+aKVJ3z
+6CZcke1ph/vpMt/684xx8tICp2KMWbwk3nIBaMw84hrVZyKFgpW/gZOE+ktV91zw
+LF1oFn+2F8PwGSphBwhBE0uoyFRNmUXiPsHUyEh7kF7EU5gb1sxTzM5sWCNm6nIS
+QRlXAgMBAAGjgYMwgYAwHQYDVR0OBBYEFHuAjvmIDJX76uWtnfirReeBU+f2MB8G
+A1UdIwQYMBaAFHuAjvmIDJX76uWtnfirReeBU+f2MA8GA1UdEwEB/wQFMAMBAf8w
+LQYDVR0RBCYwJIILZXhhbXBsZS5jb22CD3d3dy5leGFtcGxlLm5ldIcECgAAATAN
+BgkqhkiG9w0BAQsFAAOCAgEACn2BTzH89jDBHAy1rREJY8nYhH8GQxsPQn3MZAjA
+OiAQRSqqaduYdM+Q6X3V/A8n2vtS1vjs2msQwg6uNN/yNNgdo+Nobj74FmF+kwaf
+hodvMJ7z+MyeuxONYL/rbolc8N031nPWim8HTQsS/hxiiwqMHzgz6hQou1OFPwTJ
+QdhsfXgqbNRiMkF/UxLfIDEP8J5VAEzVJlyrGUrUOuaMU6TZ+tx1VbNQm3Xum5GW
+UgtmE36wWp/M1VeNSsm3GOQRlyWFGmE0sgA95IxLRMgL1mpd8IS3iU6TVZLx0+sA
+Bly38R1z8Vcwr1vOurQ8g76Epdet2ZkQNQBwvgeVvnCsoy4CQf2AvDzKgEeTdXMM
+WdO6UnG2+PgJ6YQHyfCB34mjPqrJul/0YwWo/p+PxSHRKdJZJTKzZPi1sPuxA2iO
+YiJIS94ZRlkPxrD4pYdGiXPigC+0motT6cYxQ8SKTVOs7aEax/xQngrcQPLNXTgn
+LtoT4hLCJpP7PTLgL91Dvu/dUMR4SEUNojUBul67D5fIjD0sZvJFZGd78apl/gdf
+PxkCHm4A07Zwl/x+89Ia73mk+y8O2u+CGh7oDrO565ADxKj6/UhxhVKmV9DG1ono
+AjGUGkvXVVvurf5CwGxpwT/G5UXpSK+314eMVxz5s3yDb2J2J2rvIk6ROPxBK0ws
+Sj8=
+-----END CERTIFICATE-----`
+
+var (
+	controller     *gomock.Controller
+	mockSystemInfo *system.MockSystemInfo
 )
 
 var _ = Describe("Factory", func() {
 	Describe("Creation", func() {
+
+		BeforeEach(func() {
+			controller = gomock.NewController(GinkgoT())
+			mockSystemInfo = system.NewMockSystemInfo(controller)
+		})
+
 		It("Can't be created without a logger", func() {
-			client, err := NewFactory(nil, nil)
+			client, err := NewFactory(nil, nil, mockSystemInfo)
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(client).To(BeNil())
+		})
+
+		It("Can't be created without system info", func() {
+			client, err := NewFactory(logger, nil, nil)
+			Expect(err).To(MatchError("sys is mandatory"))
 			Expect(client).To(BeNil())
 		})
 	})
@@ -29,6 +111,9 @@ var _ = Describe("Factory", func() {
 		DescribeTable(
 			"Fails if secret doesn't contain a valid kubeconfig",
 			func(data map[string][]byte, matcher OmegaMatcher) {
+				controller = gomock.NewController(GinkgoT())
+				mockSystemInfo = system.NewMockSystemInfo(controller)
+
 				// Create the secret:
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +126,7 @@ var _ = Describe("Factory", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Create the factory:
-				factory, err := NewFactory(logger, nil)
+				factory, err := NewFactory(logger, nil, mockSystemInfo)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Check the error:
@@ -81,13 +166,17 @@ var _ = Describe("Factory", func() {
 			)
 
 			BeforeEach(func() {
-				// Create the kubeconfig:
+				controller = gomock.NewController(GinkgoT())
+				mockSystemInfo = system.NewMockSystemInfo(controller)
+
+				// Create the kubeconfig with testCert as the CA data:
 				kubeconfig := common.Dedent(`
 					apiVersion: v1
 					kind: Config
 					clusters:
 					- name: mycluster
 					  cluster:
+					    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZQakNDQXlhZ0F3SUJBZ0lVQkNFMVlYMnpKMFIvM05VUnEyWFFhY2lFdVZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZqRVVNQklHQTFVRUF3d0xaWGhoYlhCc1pTNWpiMjB3SGhjTk1qSXhNVEkzTWpNME1qQXlXaGNOTXpJeApNVEkwTWpNME1qQXlXakFXTVJRd0VnWURWUVFEREF0bGVHRnRjR3hsTG1OdmJUQ0NBaUl3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dJUEFEQ0NBZ29DZ2dJQkFLWTU4OVcrWGlmczlTZnhvZkJJMXIxL05Lc01VVlB2ZzNadERJUFEKRWVOS2Y1T2d0U09WRmNvRW1rUzdaV05USXU0S2QxV0JmL3JHK0Y1bG0vYVRUYTNqNzIwUStmUytnc3ZlR1FQego3dGFVcFUvVGpISHpvQ3FqamhhWU1yNGdJSjNqa3BUWFVXRzUvdmthL29OeWtTeGtHQ3VadzFneVhITnVqQThMCkRKWVk4Vk5VSFBsNU1tWEdhVCsrNnlFTjRXZEIyZjdSL01tRWFINktuR28vTGpoTWVpVm1Ec0l4SFoveFc5T1IKaXpQa2xuVWk3OE5mWkpTeGlrbm9WNkNuUVNoTmlqTEVxNm5Rb3dZUTFsUXVOV3M2c1RNMjhJMEJZV2srZ0RVegpOT1drVnFTSEZSTXpHbXBxWUpzN0pRaXYwZzMzVk4vOTJkd2RQL2taYzlzQVlScURhSTZocGxPWnJEL09Fc2JHCmxtTjkweC9vNDJ3b3RKZUJETjFoSGxKMUplUmpSMVZrOFhVZk9tYVR1T1B6b29LSU0waDlLNkFoNnUzbFJRdEUKbjY4eXhuMHNHRDh5dzZFeWRTNUZEOXp6dkE2cmdYQlNzdnBNRmprL04vRm1uSXpENFlpbkxFaWZsZnViMU8wTQo5dGhFT1g5SWFPaDAwVTJlR3NSYS9NT0pjQ1o1VFVPZ3hWbHYxNUFUVVBIbzFNVzhRa21ZT1Z4NEJvTS9CdzBKCjBIaWJJVThWVXcyQVYxdHVwUmRRbWE3UWc1Z3lqZHgyZG90aDc4SUc1K0xrWDk1ZlN5ejYwS2Y5bDF4QlFITkEKa1Z5emtYbHg4am1kbTUzQ2VGdkhWT3JWckx1QTJEayt0MjFUTkwxdUZHZ1EwaUx4SXRDZjFPNkY2Qjc4UXFoSQpZTE9kQWdNQkFBR2pnWU13Z1lBd0hRWURWUjBPQkJZRUZFNkRGaDMrd0d6QThkT1lCVEw5WjBDeXhMSi9NQjhHCkExVWRJd1FZTUJhQUZFNkRGaDMrd0d6QThkT1lCVEw5WjBDeXhMSi9NQThHQTFVZEV3RUIvd1FGTUFNQkFmOHcKTFFZRFZSMFJCQ1l3SklJTFpYaGhiWEJzWlM1amIyMkNEM2QzZHk1bGVHRnRjR3hsTG01bGRJY0VDZ0FBQVRBTgpCZ2txaGtpRzl3MEJBUXNGQUFPQ0FnRUFvaitlbGtZSHJlazZEb3FPdkVGWlp0UnA2YlB2b2Y2MS9WSjNrUDd4CkhaWHA1eVZ4dkdPSHQ2MVlSemlHTHBzRmJ1aURjemswVjYxWmRvekhVT3RaMHNXQjRWZXlPMXBBamZkL0p3REkKQ0s2b2xma1NPNzhXRlFmZEc0bE5vU005ZFFKeUVJRVoxc2J2dVVMM1JIREJkOW9FS3VlK3Zzc3RsTTlhaGRvcQpmcFRURnE0RU5HQ0FJRHZhcUtJbHBqS3NBTXJzVE80N0NLUFZoMkhVcHVnZlZHS2VCUnNXMUtBWEZvQzJJTlM1CjdCWTNoNjBqRkZXNmJ6MHYrRm56Vzk2TXQyVk5XK2kvUkVYNmZCYVI0bS9RZkc4MXJBMkVFbWh4Q0dyYW55K04KNkRVa3dpSnhjcUJNSDlqQTJ5Vm5GN0Jnd0cyQzNnZUJxWFRUbHZWUUpEOEdPa3RrdmdMamxIY1lxTzFwSTdCMwp3UDlGOVpGK3czOWpYd0dNR0JnOCsvYVF6MVJqUDJiT2IxOG43ZDBiYzQvcGJia1ZBbUU0c3E0cU1uZUZaQVZFCnVqOVMySm5hM3V0MDhaUDA1WWNoNXZDR1g0Vko4Z05OZ3JKanUyUEpWQmw4Tk55RGZIS2VIZldTT1I5dU9NalQKdnFLNmlSRDl4cXUvb0xKeXJsQXVPTDhaeFJwZXFqeEYvZzhOWVlWL2Z2djhhcGFYNTh1YTlxWUFGUVZHZjU5MAptbWpPb3p6bjlWQnFLZW5WbWZ3emVuNXY3OENCU2dTNEhkNzJRcDQyckxDTmdxSThneVFhMnFaemFOakxQL3dJCnBCcEZDMjFma3liR1lQa2lzbFBRM0VJNjlaR1JhZldEQmpsRkZUUzNZa0RNOTh0cVRaRCtKRzRTVFkraXZIaEsKZ21ZPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
 					    server: https://mylb:32132
 					users:
 					- name: myuser
@@ -123,7 +212,13 @@ var _ = Describe("Factory", func() {
 				}
 			})
 
+			AfterEach(func() {
+				controller.Finish()
+			})
+
 			It("Replaces API server address for hosted clusters", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte(testCert2), nil).Times(1)
+
 				// Prepare a cluster deployment with the  'agentClusterRef' label, as that is what marks
 				// it as a hosted cluster.
 				clusterDeployment.Labels["agentClusterRef"] = "mycluster"
@@ -147,6 +242,7 @@ var _ = Describe("Factory", func() {
 					func(http.RoundTripper) http.RoundTripper {
 						return transport
 					},
+					mockSystemInfo,
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -167,6 +263,8 @@ var _ = Describe("Factory", func() {
 			})
 
 			It("Doesn't replace API server address for regular clusters", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte(testCert2), nil).Times(1)
+
 				// Prepare a cluster deployment without the 'agentClusterRef' label, as that is what
 				// marks it as a hosted cluster:
 				delete(clusterDeployment.Labels, "agentClusterRef")
@@ -187,6 +285,7 @@ var _ = Describe("Factory", func() {
 					func(http.RoundTripper) http.RoundTripper {
 						return transport
 					},
+					mockSystemInfo,
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -207,6 +306,8 @@ var _ = Describe("Factory", func() {
 			})
 
 			It("Doesn't replace API server address if no cluster deployment is passed", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte(testCert2), nil).Times(1)
+
 				// For this test we need to create the factory with a transport wrapper that verifies
 				// that the address hasn't been changed. Note also that this transport will always
 				// return an error, as we dont really care about the rest of the processing.
@@ -223,6 +324,7 @@ var _ = Describe("Factory", func() {
 					func(http.RoundTripper) http.RoundTripper {
 						return transport
 					},
+					mockSystemInfo,
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -240,6 +342,78 @@ var _ = Describe("Factory", func() {
 				}
 				err = client.Get(ctx, configMapKey, configMap)
 				Expect(err).To(MatchError(ContainSubstring("myerror")))
+			})
+
+			It("System CA bundle has 1 cert that's not in the kubeconfig", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte(testCert2), nil).Times(1)
+
+				// Transport wrapper to capture and assert RootCAs content
+				called := false
+				wrapper := func(rt http.RoundTripper) http.RoundTripper {
+					called = true
+					tr, ok := rt.(*http.Transport)
+					Expect(ok).To(BeTrue())
+					Expect(tr.TLSClientConfig).ToNot(BeNil())
+					Expect(tr.TLSClientConfig.RootCAs).ToNot(BeNil())
+					// Expect 2 subjects: one from kubeconfig and one from system bundle
+					Expect(len(tr.TLSClientConfig.RootCAs.Subjects())).To(Equal(2))
+					return rt
+				}
+
+				factory, err := NewFactory(logger, wrapper, mockSystemInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = factory.CreateFromSecret(clusterDeployment, kubeconfigSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(called).To(BeTrue())
+			})
+
+			It("System CA bundle has 1 cert that is in the kubeconfig", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte(testCert), nil).Times(1)
+
+				// Transport wrapper to capture and assert RootCAs content
+				called := false
+				wrapper := func(rt http.RoundTripper) http.RoundTripper {
+					called = true
+					tr, ok := rt.(*http.Transport)
+					Expect(ok).To(BeTrue())
+					Expect(tr.TLSClientConfig).ToNot(BeNil())
+					Expect(tr.TLSClientConfig.RootCAs).ToNot(BeNil())
+					// Expect 1 subjects: one from kubeconfig
+					Expect(len(tr.TLSClientConfig.RootCAs.Subjects())).To(Equal(1))
+					return rt
+				}
+
+				factory, err := NewFactory(logger, wrapper, mockSystemInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = factory.CreateFromSecret(clusterDeployment, kubeconfigSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(called).To(BeTrue())
+			})
+
+			It("System CA bundle is empty", func() {
+				mockSystemInfo.EXPECT().GetSystemCABundle().Return([]byte{}, nil).Times(1)
+
+				// Transport wrapper to capture and assert RootCAs content
+				called := false
+				wrapper := func(rt http.RoundTripper) http.RoundTripper {
+					called = true
+					tr, ok := rt.(*http.Transport)
+					Expect(ok).To(BeTrue())
+					Expect(tr.TLSClientConfig).ToNot(BeNil())
+					Expect(tr.TLSClientConfig.RootCAs).ToNot(BeNil())
+					// Expect 1 subjects: one from kubeconfig
+					Expect(len(tr.TLSClientConfig.RootCAs.Subjects())).To(Equal(1))
+					return rt
+				}
+
+				factory, err := NewFactory(logger, wrapper, mockSystemInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = factory.CreateFromSecret(clusterDeployment, kubeconfigSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(called).To(BeTrue())
 			})
 		})
 	})

--- a/internal/system/mock_system.go
+++ b/internal/system/mock_system.go
@@ -47,3 +47,18 @@ func (mr *MockSystemInfoMockRecorder) FIPSEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FIPSEnabled", reflect.TypeOf((*MockSystemInfo)(nil).FIPSEnabled))
 }
+
+// GetSystemCABundle mocks base method.
+func (m *MockSystemInfo) GetSystemCABundle() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSystemCABundle")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSystemCABundle indicates an expected call of GetSystemCABundle.
+func (mr *MockSystemInfoMockRecorder) GetSystemCABundle() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemCABundle", reflect.TypeOf((*MockSystemInfo)(nil).GetSystemCABundle))
+}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -3,6 +3,8 @@ package system
 import (
 	"os"
 	"strings"
+
+	"github.com/openshift/assisted-service/internal/common"
 )
 
 const (
@@ -12,6 +14,7 @@ const (
 //go:generate mockgen -source=system.go -package=system -destination=mock_system.go
 type SystemInfo interface {
 	FIPSEnabled() (bool, error)
+	GetSystemCABundle() ([]byte, error)
 }
 
 type fileReader func(name string) ([]byte, error)
@@ -43,4 +46,8 @@ func (s *localSystemInfo) FIPSEnabled() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (s *localSystemInfo) GetSystemCABundle() ([]byte, error) {
+	return s.fileReader(common.SystemCertificateBundlePath)
 }


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

When running inside of MCE/ACM, performing some day2 operations require the use of the cluster's kubeconfig which we create when installing the cluster. But that kubeconfig has self generated CA data, and users can change the certificate of the clster's API to one that was signed by their CA. That causes the issue: "tls: failed to verify certificate: x509: certificate signed by unknown authority".
To fix this we will read the our own system ca-bundle (created as a configmap by the AgentServiceConfig controller running in the infrastructure-operator and then mounted into assisted-service) and merge it with the CA data that exists in the kubeconfig.

I tested this by doing the following:
- Deploy a hub cluster with MCE, without my custom image
- Use MCE to install a spoke cluster
- Change the spoke cluster's API certificate with a new self signed CA
- Add the new self signed CA to the hub cluster's ca-bundle
- Make sure assisted-service can curl the spoke cluster's API without TLS issues
- Try to use MCE to add a new node to the spoke cluster and see that assisted-service gets a TLS issue during the installation
- Change assisted-service's image to my custom one
- See that the node's installation continues with no TLS issues

## List all the issues related to this PR

Closes [ACM-21902](https://issues.redhat.com//browse/ACM-21902)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
