### PR TITLE
Allow empty osImages list in AgentServiceConfig

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -277,6 +277,13 @@ func main() {
 	}
 	failOnError(json.Unmarshal([]byte(Options.OsImages), &osImagesArray),
 		"Failed to parse OS_IMAGES json %s", Options.OsImages)
+
+	// Allow empty OS images array when using qcow2 bootstrapping (e.g., with OACP)
+	// This prevents ISO downloads when they're not needed
+	if len(osImagesArray) == 0 && Options.OsImages == "[]" {
+		log.Info("OS_IMAGES is explicitly set to empty array - no OS images will be managed (suitable for qcow2 bootstrapping)")
+	}
+
 	osImages, err := versions.NewOSImages(osImagesArray)
 	failOnError(err, "Failed to initialize OSImages")
 

--- a/internal/versions/osimages.go
+++ b/internal/versions/osimages.go
@@ -25,9 +25,12 @@ type OSImages interface {
 type osImageList models.OsImages
 
 func NewOSImages(images models.OsImages) (OSImages, error) {
+	// Allow empty OS images array when using qcow2 bootstrapping (e.g., with OACP)
+	// This prevents ISO downloads when they're not needed
 	if len(images) == 0 {
-		return nil, errors.New("No OS images provided")
+		return osImageList(images), nil // Return valid empty implementation
 	}
+
 	for _, osImage := range images {
 		if err := validateOSImage(osImage); err != nil {
 			return nil, err


### PR DESCRIPTION
When the openshift assisted CAPI provider use qcow2 to bootstrap baremetal server, there is no need to fetch openshift live iso.

The idea is: if AgentServiceConfig has an annotation  agent-install.openshift.io/disable-iso-downloads: "true", the osImage will be set to an empty list regardless of the osImages input. InfraEnv controller is updated accordingly to allow the empty osImage.

A related PR in [assisted-image-service](https://github.com/openshift/assisted-image-service/pull/474)


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
