### PR TITLE
MGMT-21278: Add metric to track Cluster/Host Monitoring cycle time

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -610,6 +610,11 @@ func (m *Manager) ClusterMonitoring() {
 	m.initMonitorQueryGenerator()
 
 	query := m.monitorQueryGenerator.NewClusterQuery()
+	cycleStartTime := time.Now()
+	isFullScan := query.IsFullScan()
+	defer func() {
+		m.metricAPI.MonitoredClustersCycleDurationMs(ctx, time.Since(cycleStartTime), isFullScan)
+	}()
 	for {
 		clusters, err = query.Next()
 		if err != nil {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -647,6 +647,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 				eventstest.WithClusterIdMatcher(c.ID.String()))).AnyTimes()
 			mockHostAPIIsRequireUserActionResetFalse()
 			mockMetric.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			mockMetric.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 			clusterApi.ClusterMonitoring()
 			after := time.Now().Truncate(10 * time.Millisecond)
 			c = getClusterFromDB(id, db)
@@ -704,6 +705,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 			}
 
 			mockMetric.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(nClusters)
+			mockMetric.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			clusterApi.ClusterMonitoring()
 
 			var count int64
@@ -741,6 +743,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 				Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
 				Expect(err).ShouldNot(HaveOccurred())
 				mockMetric.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				mockMetric.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName))).Times(0)
 				mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).Times(0)
@@ -792,6 +795,7 @@ var _ = Describe("lease timeout event", func() {
 			mockEvents, mockEventsUploader, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 		mockMetric.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockMetric.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockMetric.EXPECT().Duration("ClusterMonitoring", gomock.Any()).AnyTimes()
 		mockNoChangeInOperatorDependencies(mockOperators)
 		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
@@ -930,6 +934,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			mockEvents, mockEventsUploader, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil, false, nil)
 
 		mockMetric.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockMetric.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockMetric.EXPECT().Duration("ClusterMonitoring", gomock.Any()).AnyTimes()
 		mockNoChangeInOperatorDependencies(mockOperators)
 		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
@@ -2347,6 +2352,7 @@ var _ = Describe("Majority groups", func() {
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 
 		mockMetricApi.EXPECT().MonitoredClustersDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockMetricApi.EXPECT().MonitoredClustersCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		mockMetricApi.EXPECT().Duration("ClusterMonitoring", gomock.Any()).AnyTimes()
 		mockNoChangeInOperatorDependencies(mockOperators)
 		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{

--- a/internal/common/monitor_query_generator.go
+++ b/internal/common/monitor_query_generator.go
@@ -20,6 +20,7 @@ type MonitorInitialQueryBuilder func(db *gorm.DB) *gorm.DB
 
 type MonitorQuery interface {
 	Next() ([]*Cluster, error)
+	IsFullScan() bool
 }
 
 type fullQuery struct {
@@ -48,6 +49,10 @@ func (f *fullQuery) Next() ([]*Cluster, error) {
 		f.lastId = clusters[len(clusters)-1].ID.String()
 	}
 	return clusters, nil
+}
+
+func (f *fullQuery) IsFullScan() bool {
+	return true
 }
 
 /*
@@ -125,6 +130,10 @@ func (t *timedQuery) Next() ([]*Cluster, error) {
 	return clusters, nil
 }
 
+func (t *timedQuery) IsFullScan() bool {
+	return false
+}
+
 type MonitorClusterQueryGenerator struct {
 	lastInvokeTime    time.Time
 	calls             int64
@@ -181,6 +190,7 @@ func (m *MonitorClusterQueryGenerator) NewClusterQuery() MonitorQuery {
 
 type MonitorInfraEnvQuery interface {
 	Next() ([]*InfraEnv, error)
+	IsFullScan() bool
 }
 
 type dbQuery interface {
@@ -274,6 +284,11 @@ func (f *infraEnvQuery) Next() ([]*InfraEnv, error) {
 		}
 	}
 	return infraEnvs, nil
+}
+
+func (f *infraEnvQuery) IsFullScan() bool {
+	_, isFullDb := f.dbQuery.(*fullDbQuery)
+	return isFullDb
 }
 
 type MonitorInfraEnvQueryGenerator struct {

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -149,9 +149,13 @@ func (m *Manager) clusterHostMonitoring() {
 		clusters  []*common.Cluster
 		err       error
 	)
-
 	m.resetRoleAssignmentIfNotAllRolesAreSet()
 	query := m.monitorClusterQueryGenerator.NewClusterQuery()
+	cycleStartTime := time.Now()
+	isFullScan := query.IsFullScan()
+	defer func() {
+		m.metricApi.MonitoredHostsCycleDurationMs(ctx, time.Since(cycleStartTime), isFullScan)
+	}()
 	for {
 		if clusters, err = query.Next(); err != nil {
 			m.log.WithError(err).Error("Getting clusters")

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -89,6 +89,7 @@ var _ = Describe("monitor_disconnection", func() {
 
 		mockMetricApi.EXPECT().Duration("HostMonitoring", gomock.Any()).Times(1)
 		mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockOperators.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
@@ -250,6 +251,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusDisconnected, models.HostKindHost)
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -265,6 +267,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			addHost(otherClusterId, models.HostRoleAutoAssign, models.HostStatusKnown, models.HostKindHost)
 			addHost(otherClusterId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindHost)
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -277,6 +280,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			var count int64
 			registerClusterWithAutoAssignHostInStatus(models.HostStatusKnown, models.HostKindAddToExistingClusterHost)
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			state.HostMonitoring()
 			Expect(db.Model(&models.Host{}).Where("suggested_role = ?", models.HostRoleAutoAssign).Count(&count).Error).
 				ShouldNot(HaveOccurred())
@@ -307,16 +311,19 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 
 		It("5 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(5)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(15)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(765)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -335,6 +342,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			Expect(db.Model(&host).Update("status", hostStatus).Error).ShouldNot(HaveOccurred())
 
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(expectedCount)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			state.HostMonitoring()
 		},
 			Entry("HostStatusAddedToExistingCluster is not monitored", models.ClusterStatusReady, models.HostStatusAddedToExistingCluster, models.LogsStateCompleted, 0),
@@ -460,16 +468,19 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 
 		It("5 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(5)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(5)
 		})
 
 		It("15 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(15)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(15)
 		})
 
 		It("765 hosts all disconnected", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(765)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			registerAndValidateDisconnected(765)
 		})
 	})
@@ -492,6 +503,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 
 		It("times out Reclaiming hosts", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaiming)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)
@@ -500,6 +512,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 
 		It("times out ReclaimingRebooting hosts", func() {
 			mockMetricApi.EXPECT().MonitoredHostsDurationMs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetricApi.EXPECT().MonitoredHostsCycleDurationMs(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			hostID := createTimeoutHostWithStatus(models.HostStatusReclaimingRebooting)
 			state.HostMonitoring()
 			h := hostutil.GetHostFromDB(hostID, infraEnvID, db)

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -40,6 +40,8 @@ const (
 	counterFilesystemUsagePercentage              = "assisted_installer_filesystem_usage_percentage"
 	histogramMonitoredHostsDurationMs             = "assisted_installer_monitored_hosts_duration_ms"
 	histogramMonitoredClustersDurationMs          = "assisted_installer_monitored_clusters_duration_ms"
+	histogramMonitoredClustersCycleDurationMs     = "assisted_installer_monitored_clusters_cycle_duration_ms"
+	histogramMonitoredHostsCycleDurationMs        = "assisted_installer_monitored_hosts_cycle_duration_ms"
 	counterInstallerReleaseCache                  = "assisted_installer_release_cache"
 	counterInstallerReleaseCacheEviction          = "assisted_installer_release_cache_eviction"
 )
@@ -64,6 +66,8 @@ const (
 	counterDescriptionFilesystemUsagePercentage              = "The percentage of the filesystem usage by the service"
 	histogramDescriptionMonitoredHostsDurationMs             = "Histogram/sum/count of monitored hosts duration (ms)"
 	histogramDescriptionMonitoredClustersDurationMs          = "Histogram/sum/count of monitored clusters duration (ms)"
+	histogramDescriptionMonitoredClustersCycleDurationMs     = "Histogram/sum/count of full monitoring cycle duration (ms) with fullscan label"
+	histogramDescriptionMonitoredHostsCycleDurationMs        = "Histogram/sum/count of full monitoring cycle duration (ms) with fullscan label"
 	counterDescriptionInstallerReleaseCache                  = "Counts the cache hit status for the labelled release"
 	counterDescriptionInstallerReleaseCacheEviction          = "Counts the number of times that at least one release was evicted"
 )
@@ -85,6 +89,7 @@ const (
 	labelCacheHit              = "hit"
 	labelReleaseID             = "releaseId"
 	labelSuccess               = "success"
+	labelFullScan              = "fullscan"
 )
 
 type API interface {
@@ -102,6 +107,8 @@ type API interface {
 	FileSystemUsage(usageInPercentage float64)
 	MonitoredHostsDurationMs(ctx context.Context, hostID strfmt.UUID, clusterID *strfmt.UUID, duration time.Duration)
 	MonitoredClustersDurationMs(ctx context.Context, clusterID strfmt.UUID, duration time.Duration)
+	MonitoredClustersCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool)
+	MonitoredHostsCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool)
 	InstallerCacheGetReleaseCached(releaseId string, cacheHit bool)
 	InstallerCacheReleaseEvicted(success bool)
 }
@@ -130,6 +137,8 @@ type MetricsManager struct {
 	serviceLogicFilesystemUsagePercentage              *prometheus.GaugeVec
 	serviceLogicMonitoredHostsDurationMs               *prometheus.HistogramVec
 	serviceLogicMonitoredClustersDurationMs            *prometheus.HistogramVec
+	serviceLogicMonitoredClustersCycleDurationMs       *prometheus.HistogramVec
+	serviceLogicMonitoredHostsCycleDurationMs          *prometheus.HistogramVec
 	serviceLogicInstallerReleaseCache                  *prometheus.CounterVec
 	serviceLogicInstallerReleaseEvicted                *prometheus.CounterVec
 
@@ -308,6 +317,24 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler eventsapi.H
 			Buckets:   []float64{10, 100, 200, 500, 1000, 10000, 30000},
 		}, []string{}),
 
+		serviceLogicMonitoredClustersCycleDurationMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      histogramMonitoredClustersCycleDurationMs,
+			Help:      histogramDescriptionMonitoredClustersCycleDurationMs,
+			Buckets: []float64{1000, 10000, 30000, 60000, 120000, 180000,
+				240000, 300000, 360000, 420000, 480000, 540000, 600000},
+		}, []string{labelFullScan}),
+
+		serviceLogicMonitoredHostsCycleDurationMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      histogramMonitoredHostsCycleDurationMs,
+			Help:      histogramDescriptionMonitoredHostsCycleDurationMs,
+			Buckets: []float64{1000, 10000, 30000, 60000, 120000, 180000,
+				240000, 300000, 360000, 420000, 480000, 540000, 600000},
+		}, []string{labelFullScan}),
+
 		serviceLogicInstallerReleaseCache: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
@@ -347,6 +374,8 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler eventsapi.H
 		m.serviceLogicFilesystemUsagePercentage,
 		m.serviceLogicMonitoredHostsDurationMs,
 		m.serviceLogicMonitoredClustersDurationMs,
+		m.serviceLogicMonitoredClustersCycleDurationMs,
+		m.serviceLogicMonitoredHostsCycleDurationMs,
 		m.serviceLogicInstallerReleaseCache,
 		m.serviceLogicInstallerReleaseEvicted,
 	)
@@ -526,6 +555,14 @@ func (m *MetricsManager) MonitoredClustersDurationMs(ctx context.Context, cluste
 		m.handler.V2AddMetricsEvent(ctx, &clusterID, nil, nil, "", models.EventSeverityInfo, "cluster_monitor.slow_cluster", time.Now(),
 			"duration", duration.Milliseconds())
 	}
+}
+
+func (m *MetricsManager) MonitoredClustersCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool) {
+	m.serviceLogicMonitoredClustersCycleDurationMs.WithLabelValues(fmt.Sprintf("%t", fullScan)).Observe(float64(duration.Milliseconds()))
+}
+
+func (m *MetricsManager) MonitoredHostsCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool) {
+	m.serviceLogicMonitoredHostsCycleDurationMs.WithLabelValues(fmt.Sprintf("%t", fullScan)).Observe(float64(duration.Milliseconds()))
 }
 
 func bytesToGib(bytes int64) int64 {

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -193,6 +193,18 @@ func (mr *MockAPIMockRecorder) InstallerCacheReleaseEvicted(success interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallerCacheReleaseEvicted", reflect.TypeOf((*MockAPI)(nil).InstallerCacheReleaseEvicted), success)
 }
 
+// MonitoredClustersCycleDurationMs mocks base method.
+func (m *MockAPI) MonitoredClustersCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MonitoredClustersCycleDurationMs", ctx, duration, fullScan)
+}
+
+// MonitoredClustersCycleDurationMs indicates an expected call of MonitoredClustersCycleDurationMs.
+func (mr *MockAPIMockRecorder) MonitoredClustersCycleDurationMs(ctx, duration, fullScan interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredClustersCycleDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredClustersCycleDurationMs), ctx, duration, fullScan)
+}
+
 // MonitoredClustersDurationMs mocks base method.
 func (m *MockAPI) MonitoredClustersDurationMs(ctx context.Context, clusterID strfmt.UUID, duration time.Duration) {
 	m.ctrl.T.Helper()
@@ -203,6 +215,18 @@ func (m *MockAPI) MonitoredClustersDurationMs(ctx context.Context, clusterID str
 func (mr *MockAPIMockRecorder) MonitoredClustersDurationMs(ctx, clusterID, duration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredClustersDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredClustersDurationMs), ctx, clusterID, duration)
+}
+
+// MonitoredHostsCycleDurationMs mocks base method.
+func (m *MockAPI) MonitoredHostsCycleDurationMs(ctx context.Context, duration time.Duration, fullScan bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MonitoredHostsCycleDurationMs", ctx, duration, fullScan)
+}
+
+// MonitoredHostsCycleDurationMs indicates an expected call of MonitoredHostsCycleDurationMs.
+func (mr *MockAPIMockRecorder) MonitoredHostsCycleDurationMs(ctx, duration, fullScan interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsCycleDurationMs", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsCycleDurationMs), ctx, duration, fullScan)
 }
 
 // MonitoredHostsDurationMs mocks base method.


### PR DESCRIPTION
Track the duration of cluster/host monitoring cycles, distinguishing between full and partial scans. Added histogram metric `service_assisted_installer_monitored_clusters_cycle_duration_ms{fullscan=true|false}` to provide insights into cycle performance.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
