### PR TITLE
MGMT-19854: Fix Agent deletion across namespaces and prevent duplicate host IDs

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -187,6 +187,7 @@ type InstallerInternals interface {
 	GetInfraEnvInternal(ctx context.Context, params installer.GetInfraEnvParams) (*common.InfraEnv, error)
 	V2UpdateHostInstallProgressInternal(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) error
 	CreateHostInKubeKeyNamespace(ctx context.Context, kubeKey types.NamespacedName, host *models.Host) error
+	GetHostByIdInternal(ctx context.Context, hostId string) (*common.Host, error)
 }
 
 //go:generate mockgen --build_flags=--mod=mod -package bminventory -destination mock_crd_utils.go . CRDUtils
@@ -6902,4 +6903,8 @@ func extractMirroredRegistriesFromConfig(log logrus.FieldLogger, mirrorRegistryC
 		sourceRegistries = append(sourceRegistries, registry)
 	}
 	return sourceRegistries
+}
+
+func (b *bareMetalInventory) GetHostByIdInternal(ctx context.Context, hostId string) (*common.Host, error) {
+	return common.GetHostFromDBbyHostId(b.db, strfmt.UUID(hostId))
 }

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -187,6 +187,21 @@ func (mr *MockInstallerInternalsMockRecorder) GetCredentialsInternal(arg0, arg1 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsInternal", reflect.TypeOf((*MockInstallerInternals)(nil).GetCredentialsInternal), arg0, arg1)
 }
 
+// GetHostByIdInternal mocks base method.
+func (m *MockInstallerInternals) GetHostByIdInternal(arg0 context.Context, arg1 string) (*common.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostByIdInternal", arg0, arg1)
+	ret0, _ := ret[0].(*common.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostByIdInternal indicates an expected call of GetHostByIdInternal.
+func (mr *MockInstallerInternalsMockRecorder) GetHostByIdInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostByIdInternal", reflect.TypeOf((*MockInstallerInternals)(nil).GetHostByIdInternal), arg0, arg1)
+}
+
 // GetHostByKubeKey mocks base method.
 func (m *MockInstallerInternals) GetHostByKubeKey(arg0 types.NamespacedName) (*common.Host, error) {
 	m.ctrl.T.Helper()

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -155,13 +155,15 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Restoring the Host according to values from Agent
-			if err = r.restoreHostByAgent(ctx, agent); err != nil {
+			var result ctrl.Result
+			result, err = r.restoreHostByAgent(ctx, log, agent, origAgent)
+			if err != nil {
 				log.WithError(err).Errorf("failed to restore Host %s according to the Agent", agent.Name)
-				return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+				return result, err
 			}
 			// Requeuing as the associated Host should exist now
 			log.Infof("Restored a Host for agent %s", agent.Name)
-			return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}, nil
+			return result, nil
 		} else {
 			log.WithError(err).Errorf("failed to retrieve Host %s from backend", agent.Name)
 			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
@@ -1875,12 +1877,12 @@ func (r *AgentReconciler) updateHostInstallProgress(ctx context.Context, host *m
 	return err
 }
 
-func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, agent *aiv1beta1.Agent) error {
+func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, log logrus.FieldLogger, agent, origAgent *aiv1beta1.Agent) (ctrl.Result, error) {
 	// Get InfraEnv
 	infraEnvName, exist := agent.Labels[aiv1beta1.InfraEnvNameLabel]
 	if !exist {
 		r.Log.Errorf("Failed to find infraEnv name for agent %s in namespace %s", agent.Name, agent.Namespace)
-		return errors.New("Missing InfraEnv name label")
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, errors.New("Missing InfraEnv name label")
 	}
 	key := types.NamespacedName{
 		Name:      infraEnvName,
@@ -1890,10 +1892,10 @@ func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, agent *aiv1bet
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			r.Log.WithError(err).Errorf("InfraEnv with name '%s' is missing", infraEnvName)
-			return err
+			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 		}
 		r.Log.WithError(err).Errorf("Failed to get InfraEnv with name '%s'", infraEnvName)
-		return err
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 	}
 
 	// Get associated cluster if available
@@ -1908,18 +1910,36 @@ func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, agent *aiv1bet
 		if err != nil {
 			r.Log.WithError(err).Errorf("Failed to get cluster (name: %s namespace: %s)",
 				agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
-			return err
+			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 		}
 		clusterID = cluster.ID
+	}
+
+	// Check if a host with the same ID already exists (regardless of namespace)
+	// This prevents duplicate hosts and reports conflicts
+	existingHost, err := r.Installer.GetHostByIdInternal(ctx, agent.Name)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		r.Log.WithError(err).Errorf("Failed to check for existing host with ID %s", agent.Name)
+		return r.updateStatus(ctx, log, agent, origAgent, nil, nil, err, true)
+	} else if err == nil && existingHost != nil {
+		errMsg := fmt.Sprintf("Host with ID %s already exists in namespace %s. Agent creation conflicts with existing host.",
+			agent.Name, existingHost.KubeKeyNamespace)
+		r.Log.Error(errMsg)
+		return r.updateStatus(ctx, log, agent, origAgent, nil, nil, errors.New(errMsg), false)
 	}
 
 	host, err := createNewHost(agent, clusterID, *infraEnv.ID)
 	if err != nil {
 		r.Log.WithError(err).Errorf("Failed to create Host with name '%s'", agent.Name)
-		return err
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 	}
 
-	return r.Installer.CreateHostInKubeKeyNamespace(ctx, key, host)
+	err = r.Installer.CreateHostInKubeKeyNamespace(ctx, key, host)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+	}
+
+	return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}, nil
 }
 
 func createNewHost(agent *v1beta1.Agent, clusterID *strfmt.UUID, infraEnvID strfmt.UUID) (*models.Host, error) {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -4713,6 +4713,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
+		// Mock that no existing host is found
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
 		Expect(err).To(BeNil())
@@ -4753,6 +4756,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		}
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Mock that no existing host is found
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, nil, infraEnvId)
@@ -4797,6 +4803,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		clusterId := *backEndCluster.ID
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Mock that no existing host is found
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -4864,6 +4873,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		clusterId := *backEndCluster.ID
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Mock that no existing host is found
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -4994,6 +5006,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
+			// Mock that no existing host is found
+			mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+
 			// Create Host
 			host, err := createNewHost(agent, &clusterId, infraEnvId)
 			Expect(err).To(BeNil())
@@ -5050,6 +5065,9 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
+			// Mock that no existing host is found
+			mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+
 			// Create Host
 			host, err := createNewHost(agent, &clusterId, infraEnvId)
 			Expect(err).To(BeNil())
@@ -5079,6 +5097,78 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			Expect(c.Get(ctx, key, agent)).To(BeNil())
 			Expect(agent.Status.Progress.CurrentStage).To(BeEmpty())
 		})
+	})
+
+	It("should report error when Agent is recreated in different namespace", func() {
+		agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{})
+		agent.ObjectMeta.Labels = map[string]string{
+			v1beta1.InfraEnvNameLabel: "infraEnvName",
+		}
+		Expect(c.Create(ctx, agent)).To(BeNil())
+
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		infraEnvKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "infraEnvName",
+		}
+		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvId}}
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		hostId := strfmt.UUID(agent.Name)
+		existingHost := &common.Host{
+			Host: models.Host{
+				ID:         &hostId,
+				InfraEnvID: infraEnvId,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+			KubeKeyNamespace: "other-namespace",
+		}
+
+		// Host not found in namespace
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Check for host by ID only - conflict detected
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(existingHost, nil).Times(1)
+
+		// Reconcile Agent - should handle conflict via status condition, not error
+		result, err := hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{})) // User error, no requeue
+
+		// Verify Agent status condition is set
+		agent = &v1beta1.Agent{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "agent", Namespace: testNamespace}, agent)).To(BeNil())
+		specSyncedCond := conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition)
+		Expect(specSyncedCond).ToNot(BeNil())
+		Expect(specSyncedCond.Status).To(Equal(corev1.ConditionFalse))
+		Expect(specSyncedCond.Message).To(ContainSubstring("already exists in namespace other-namespace"))
+	})
+
+	It("should create new host if no existing host found", func() {
+		agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{})
+		agent.ObjectMeta.Labels = map[string]string{
+			v1beta1.InfraEnvNameLabel: "infraEnvName",
+		}
+		Expect(c.Create(ctx, agent)).To(BeNil())
+
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		infraEnvKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "infraEnvName",
+		}
+		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvId}}
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Host not found in namespace
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Check for host by ID only - not found
+		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Create new host
+		mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(gomock.Any(), infraEnvKey, gomock.Any()).Return(nil).Times(1)
+
+		// Reconcile Agent
+		result, err := hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
 	})
 })
 


### PR DESCRIPTION
- Update agent finalizer to delete hosts regardless of namespace
- Block Agent creation when host ID already exists in different namespace
- Update Agent status conditions to report conflicts


https://issues.redhat.com/browse/MGMT-19854