### PR TITLE
MGMT-21688: Order pre-nm-config after NM-wait-online to fix race on full ISO

### DIFF
--- a/internal/ignition/templates/pre-network-manager-config-with-nmstatectl.service
+++ b/internal/ignition/templates/pre-network-manager-config-with-nmstatectl.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prepare network manager config content
+After=NetworkManager-wait-online.service
 Before=nmstate.service
-Requires=nmstate.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
**The Issue:**
During boot from full ISO, a race was identified on hosts with a large number of network interfaces. The pre-network-manager-config service, which is responsible for copying the nmstate+nmpolicy yamls to /etc/nmstate + running the nmstatectl service command, could be invoked before the NetworkManager had finished its initial auto-activation of all discovered NICs. This simultaneous activity, our service calling nmstatectl service while NetworkManager was also configuring interfaces, could lead to unpredictable failures in applying the desired configuration.

**Solution:**
This change modifies the systemd unit file for the pre-network-manager-config.service to introduce a proper ordering dependency. Specifically, it adds After=NetworkManager-wait-online.service to the service's [Unit] section.
The NetworkManager-wait-online.service is a systemd gatekeeper that only completes after NetworkManager has finished its initial activation of all auto-configured interfaces and the network has reached a stable state.
By adding this After= dependency, we guarantee that our custom pre-network-manager-config service will only execute after this initial network setup is complete.

**Testing:**
I couldn't reproduce the issue locally, so I collaborated with @mcornea to test the image on his environment where the bug occurs. He confirmed the fix is working. I've also confirmed there are no regressions on my side.

/cc @danielerez @jhernand 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
