### PR TITLE
NO-ISSUE: Fix the nmstate example

### DIFF
--- a/docs/hive-integration/crds/nmstate.yaml
+++ b/docs/hive-integration/crds/nmstate.yaml
@@ -36,12 +36,13 @@ spec:
       config:
         - destination: 0.0.0.0/0
           next-hop-address: 192.168.126.1
-          next-hop-interface: eth1
+          next-hop-interface: eth0
           table-id: 254
         - destination: 0.0.0.0/0
           next-hop-address: 192.168.140.1
           next-hop-interface: eth1
           table-id: 254
+          metric: 100
   interfaces:
     - name: "eth0"
       macAddress: "02:00:00:80:12:14"


### PR DESCRIPTION
The error occurred because there were two conflicting default routes (0.0.0.0/0) both pointing to the same interface (eth1) but with different next-hop addresses:
- Route 1: 192.168.126.1 via eth1
- Route 2: 192.168.140.1 via eth1 This created a conflict because nmstate couldn't determine which route to use for the default gateway.

The change fixes the issue by:
- Changing the first route to use eth0 instead of eth1, which makes sense since eth0 has the IP address 192.168.126.30 that corresponds to the 192.168.126.1 gateway.
- Adding a metric value: Added metric: 100 to the second route to establish a clear priority order, making it a backup route.

Found and fixed with Cursor

Likely caused by this change in nmstate:
https://github.com/nmstate/nmstate/commit/48b139c87f9d9b2f248e27e6b8aa964b483ed176

Resolves https://issues.redhat.com/browse/MGMT-21701

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
