### PR TITLE
[release-ocm-2.13] MGMT-21688: Order pre-nm-config after NM-wait-online to fix race on full ISO

### DIFF
--- a/docs/hive-integration/crds/nmstate.yaml
+++ b/docs/hive-integration/crds/nmstate.yaml
@@ -36,12 +36,13 @@ spec:
       config:
         - destination: 0.0.0.0/0
           next-hop-address: 192.168.126.1
-          next-hop-interface: eth1
+          next-hop-interface: eth0
           table-id: 254
         - destination: 0.0.0.0/0
           next-hop-address: 192.168.140.1
           next-hop-interface: eth1
           table-id: 254
+          metric: 100
   interfaces:
     - name: "eth0"
       macAddress: "02:00:00:80:12:14"

--- a/internal/ignition/templates/pre-network-manager-config-with-nmstatectl.service
+++ b/internal/ignition/templates/pre-network-manager-config-with-nmstatectl.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prepare network manager config content
+After=NetworkManager-wait-online.service
 Before=nmstate.service
-Requires=nmstate.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
This is a manually cherry-pick of https://github.com/openshift/assisted-service/pull/7977

/assign linoyaslan