### PR TITLE
AGENT-1303: Wait for cluster creation when creating InfraEnv

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/cmd/agentbasedinstaller"
+	"github.com/openshift/assisted-service/models"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift/assisted-service/client"
@@ -160,11 +161,15 @@ func registerInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 		log.Fatal("Failed to get pull secret: ", err.Error())
 	}
 
-	modelsCluster, err := agentbasedinstaller.GetCluster(ctx, log, bmInventory)
-	if err != nil {
-		log.Fatal("Failed to find cluster when registering infraenv: ", err)
-	} else {
-		log.Infof("Reference to cluster id: %s", modelsCluster.ID.String())
+	var modelsCluster *models.Cluster
+	for modelsCluster == nil {
+		modelsCluster, err = agentbasedinstaller.GetCluster(ctx, log, bmInventory)
+		if err != nil {
+			log.Info("Failed to find cluster when registering infraenv: ", err)
+			time.Sleep(1 * time.Second)
+		} else {
+			log.Infof("Reference to cluster id: %s", modelsCluster.ID.String())
+		}
 	}
 
 	modelsInfraEnv, err := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,


### PR DESCRIPTION
When creating the InfraEnv in ABI, instead of exiting with an error if the Cluster has not been created, poll the API until it is. Previously we would exit with an error code and systemd would restart the whole process instead.