### PR TITLE
MGMT-21450: Allow OpenshiftAI installation on SNO cluster

### DIFF
--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -47,7 +47,6 @@ func (feature *SnoFeature) getIncompatibleFeatures(string) []models.FeatureSuppo
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDVIPAUTOALLOC,
-		models.FeatureSupportLevelIDOPENSHIFTAI,
 		models.FeatureSupportLevelIDUSERMANAGEDLOADBALANCER,
 		models.FeatureSupportLevelIDNODEHEALTHCHECK,
 		models.FeatureSupportLevelIDSELFNODEREMEDIATION,

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -93,7 +93,6 @@ func (feature *LvmFeature) getIncompatibleFeatures(OCPVersion string) []models.F
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDODF,
-		models.FeatureSupportLevelIDOPENSHIFTAI,
 	}
 	if isEqual, _ := common.BaseVersionLessThan("4.15", OCPVersion); isEqual {
 		incompatibleFeatures = append(incompatibleFeatures,
@@ -603,10 +602,6 @@ func (f *OpenShiftAIFeature) getIncompatibleArchitectures(_ *string) []models.Ar
 
 func (f *OpenShiftAIFeature) getIncompatibleFeatures(string) []models.FeatureSupportLevelID {
 	return []models.FeatureSupportLevelID{
-		// These aren't directly incompatible with OpenShift AI, rather with ODF, but the feature support
-		// mechanism doesn't currently understand operator dependencies, so we need to add these explicitly.
-		models.FeatureSupportLevelIDLVM,
-		models.FeatureSupportLevelIDSNO,
 		models.FeatureSupportLevelIDEXTERNALPLATFORMOCI,
 	}
 }

--- a/internal/featuresupport/features_olm_operators_test.go
+++ b/internal/featuresupport/features_olm_operators_test.go
@@ -114,7 +114,6 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
-				models.FeatureSupportLevelIDOPENSHIFTAI,
 				models.FeatureSupportLevelIDVIPAUTOALLOC,
 				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 			}
@@ -123,7 +122,6 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
-				models.FeatureSupportLevelIDOPENSHIFTAI,
 				models.FeatureSupportLevelIDVIPAUTOALLOC,
 				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 			}
@@ -132,13 +130,11 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
-				models.FeatureSupportLevelIDOPENSHIFTAI,
 			}
 			incompatibleFeatures["4.16.0-rc0"] = []models.FeatureSupportLevelID{
 				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 				models.FeatureSupportLevelIDODF,
-				models.FeatureSupportLevelIDOPENSHIFTAI,
 			}
 
 			testIncompatibleFeatures := []struct {

--- a/internal/operators/openshiftai/openshift_ai_manifests.go
+++ b/internal/operators/openshiftai/openshift_ai_manifests.go
@@ -58,11 +58,13 @@ func (o operator) executeTemplate(name string, cluster *common.Cluster) (result 
 		Operator *models.MonitoredOperator
 		Config   *Config
 		Cluster  *common.Cluster
+		IsSNO    bool
 	}
 	data := &Data{
 		Operator: &Operator,
 		Config:   o.config,
 		Cluster:  cluster,
+		IsSNO:    common.IsSingleNodeCluster(cluster),
 	}
 	buffer := &bytes.Buffer{}
 	err = template.Execute(buffer, data)

--- a/internal/operators/openshiftai/templates/files/setup.sh
+++ b/internal/operators/openshiftai/templates/files/setup.sh
@@ -1,5 +1,5 @@
 # Name of the storage class:
-storage_class="ocs-storagecluster-ceph-rbd"
+{{ if .IsSNO }}storage_class='lvms-vg1'{{ else }}storage_class='ocs-storagecluster-ceph-rbd'{{ end }}
 wait_interval="30s"
 
 log() {


### PR DESCRIPTION
Allow openshiftAI installation on SNO cluster

On SNO cluster, ODF can't be installed, so we have to rely another storage class. Here I'm using the storage class created by LVM, this is why it's added as dependency for SNO cluster

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
