### PR TITLE
[release-ocm-2.13] MGMT-20651: Assisted Service panics if both installation_disk_id and installation-disk_path are empty 

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -141,7 +141,11 @@ func GetHostInstallationDisk(host *models.Host) (*models.Disk, error) {
 		return nil, err
 	}
 
-	return GetDiskByInstallationPath(inventory.Disks, GetHostInstallationPath(host)), nil
+	installationDisk := GetDiskByInstallationPath(inventory.Disks, GetHostInstallationPath(host))
+	if installationDisk == nil {
+		return nil, fmt.Errorf("installation disk not found for host %s", host.ID)
+	}
+	return installationDisk, nil
 }
 
 func GetDiskByInstallationPath(disks []*models.Disk, installationPath string) *models.Disk {

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -1,6 +1,8 @@
 package hostutil
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -217,6 +219,153 @@ var _ = Describe("Get Disks of Holder", func() {
 		filteredDisks := GetDisksOfHolderByType(disks, &holder2, models.DriveTypeFC)
 		Expect(len(filteredDisks)).To(Equal(1))
 		Expect(filteredDisks).Should(ContainElement(&disksOfHolder2[0]))
+	})
+})
+
+var _ = Describe("GetHostInstallationDisk", func() {
+	var (
+		hostId    strfmt.UUID
+		diskId    = "/dev/disk/by-id/test-disk"
+		diskName  = "test-disk"
+		validHost *models.Host
+	)
+
+	BeforeEach(func() {
+		hostId = strfmt.UUID(uuid.New().String())
+	})
+
+	It("should return installation disk when found by disk ID", func() {
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{
+				{ID: diskId, Name: diskName},
+			},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   diskId,
+			InstallationDiskPath: "",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(disk).NotTo(BeNil())
+		Expect(disk.ID).To(Equal(diskId))
+		Expect(disk.Name).To(Equal(diskName))
+	})
+
+	It("should return installation disk when found by disk path", func() {
+		expectedFullName := fmt.Sprintf("/dev/%s", diskName)
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{
+				{ID: diskId, Name: diskName, Path: "/dev/sda"},
+			},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   "",
+			InstallationDiskPath: expectedFullName,
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(disk).NotTo(BeNil())
+		Expect(disk.ID).To(Equal(diskId))
+		Expect(disk.Name).To(Equal(diskName))
+	})
+
+	It("should return error when installation disk is not found - empty installation path", func() {
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{
+				{ID: diskId, Name: diskName},
+			},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   "",
+			InstallationDiskPath: "",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("installation disk not found for host %s", hostId))))
+		Expect(disk).To(BeNil())
+	})
+
+	It("should return error when installation disk is not found - non-matching disk ID", func() {
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{
+				{ID: diskId, Name: diskName},
+			},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   "/dev/disk/by-id/non-existent-disk",
+			InstallationDiskPath: "",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("installation disk not found for host %s", hostId))))
+		Expect(disk).To(BeNil())
+	})
+
+	It("should return error when installation disk is not found - non-matching disk path", func() {
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{
+				{ID: diskId, Name: diskName, Path: "/dev/sda"},
+			},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   "",
+			InstallationDiskPath: "/dev/non-existent-disk",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("installation disk not found for host %s", hostId))))
+		Expect(disk).To(BeNil())
+	})
+
+	It("should return error when inventory has no disks", func() {
+		inventory := &models.Inventory{
+			Disks: []*models.Disk{},
+		}
+		inventoryBytes, _ := json.Marshal(inventory)
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            string(inventoryBytes),
+			InstallationDiskID:   diskId,
+			InstallationDiskPath: "",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("installation disk not found for host %s", hostId))))
+		Expect(disk).To(BeNil())
+	})
+
+	It("should return error when inventory is invalid JSON", func() {
+		validHost = &models.Host{
+			ID:                   &hostId,
+			Inventory:            "invalid json",
+			InstallationDiskID:   diskId,
+			InstallationDiskPath: "",
+		}
+
+		disk, err := GetHostInstallationDisk(validHost)
+		Expect(err).To(HaveOccurred())
+		Expect(disk).To(BeNil())
 	})
 })
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -713,14 +713,17 @@ func IsInStages(stages ...models.HostStage) func(stateswitch.StateSwitch, states
 }
 
 func (th *transitionHandler) replaceMacros(template string, sHost *stateHost, params *TransitionArgsRefreshHost) string {
+	log := logutil.FromContext(params.ctx, th.log)
+
 	template = strings.Replace(template, "$STAGE", string(sHost.host.Progress.CurrentStage), 1)
 	maxTime := th.config.HostStageTimeout(sHost.host.Progress.CurrentStage)
 	template = strings.Replace(template, "$MAX_TIME", maxTime.String(), 1)
 	if strings.Contains(template, "$INSTALLATION_DISK") {
 		var installationDisk *models.Disk
 		installationDisk, err := hostutil.GetHostInstallationDisk(sHost.host)
-		if err != nil {
+		if err != nil || installationDisk == nil {
 			// in case we fail to parse the inventory replace $INSTALLATION_DISK with nothing
+			log.Warnf("Failed to get installation disk for host %s: %v", sHost.host.ID, err)
 			template = strings.Replace(template, "$INSTALLATION_DISK", "", 1)
 		} else {
 			template = strings.Replace(template, "$INSTALLATION_DISK", fmt.Sprintf("(%s, %s)", installationDisk.Name, common.GetDeviceIdentifier(installationDisk)), 1)


### PR DESCRIPTION
Manual cherry-pick of #7764

https://issues.redhat.com/browse/ACM-24232

---
Original PR message

Previously, if the host's installation disk wasn't found, the code would panic when trying to use a nil value. This PR adds a check in GetHostInstallationDisk to return an error if the disk is missing.
Also, in replaceMacros, we now handle this error properly by logging a warning and replacing $INSTALLATION_DISK with an empty string instead of crashing.

/cc @gamli75 