### PR TITLE
KONFLUX-6210: fix and set name and cpe label for assisted-service-rhel9-acm-ds-2-14

### DIFF
--- a/Dockerfile.assisted-service-rhel9-mce
+++ b/Dockerfile.assisted-service-rhel9-mce
@@ -74,4 +74,5 @@ LABEL com.redhat.component="multicluster-engine-assisted-service-9-container" \
       io.openshift.tags="OpenShift 4" \
       upstream_commit="${version}" \
       org.label-schema.vcs-ref="${version}" \
-      org.label-schema.vcs-url="https://github.com/openshift/assisted-service"
+      org.label-schema.vcs-url="https://github.com/openshift/assisted-service" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
