### PR TITLE
AGENT-1303: Allow InfraEnv registration to use late binding

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -118,7 +118,10 @@ func registerCluster(ctx context.Context, log *log.Logger, bmInventory *client.A
 	}
 
 	existingCluster, err := agentbasedinstaller.GetCluster(ctx, log, bmInventory)
-	if err == nil {
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	if existingCluster != nil {
 		log.Infof("Skipping cluster registration. Found existing cluster with id: %s", existingCluster.ID.String())
 		return existingCluster.ID.String()
 	}
@@ -161,7 +164,7 @@ func registerInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 	}
 
 	modelsCluster, err := agentbasedinstaller.GetCluster(ctx, log, bmInventory)
-	if err != nil {
+	if err != nil || modelsCluster == nil {
 		log.Fatal("Failed to find cluster when registering infraenv: ", err)
 	} else {
 		log.Infof("Reference to cluster id: %s", modelsCluster.ID.String())

--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -164,10 +164,14 @@ func registerInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 	}
 
 	modelsCluster, err := agentbasedinstaller.GetCluster(ctx, log, bmInventory)
-	if err != nil || modelsCluster == nil {
+	if err != nil {
 		log.Fatal("Failed to find cluster when registering infraenv: ", err)
 	} else {
-		log.Infof("Reference to cluster id: %s", modelsCluster.ID.String())
+		if modelsCluster != nil {
+			log.Infof("Reference to cluster id: %s", modelsCluster.ID.String())
+		} else {
+			log.Info("No Cluster found, registering InfraEnv for late binding")
+		}
 	}
 
 	modelsInfraEnv, err := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,

--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 
+	"github.com/go-openapi/strfmt"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/client"
@@ -159,7 +160,11 @@ func RegisterInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 		return nil, infraenvErr
 	}
 
-	infraEnvParams := controllers.CreateInfraEnvParams(&infraEnv, models.ImageType(imageTypeISO), pullSecret, modelsCluster.ID, modelsCluster.OpenshiftVersion)
+	var clusterID *strfmt.UUID
+	if modelsCluster != nil {
+		clusterID = modelsCluster.ID
+	}
+	infraEnvParams := controllers.CreateInfraEnvParams(&infraEnv, models.ImageType(imageTypeISO), pullSecret, clusterID, "")
 
 	var nmStateConfig aiv1beta1.NMStateConfig
 

--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -237,7 +237,7 @@ func RegisterExtraManifests(fsys fs.FS, ctx context.Context, log *log.Logger, cl
 func GetCluster(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall) (cluster *models.Cluster, err error) {
 	list, err := bmInventory.Installer.V2ListClusters(ctx, &installer.V2ListClustersParams{})
 	if err != nil {
-		return nil, err
+		return nil, errorutil.GetAssistedError(err)
 	}
 	clusterList := list.Payload
 	numClusters := len(clusterList)
@@ -246,7 +246,7 @@ func GetCluster(ctx context.Context, log *log.Logger, bmInventory *client.Assist
 		return nil, errors.New(errorMessage)
 	}
 	if numClusters == 0 {
-		return nil, errors.New("No clusters registered in assisted-service")
+		return nil, nil
 	}
 	return clusterList[0], nil
 }


### PR DESCRIPTION
In ABI, if no Cluster is present when registering the InfraEnv, register it without a cluster reference and allow it to be used for late-binding agents.

In practice the Cluster is always registered before the InfraEnv in the regular ABI flow. This change allows the InfraEnv registration to be used without the Cluster registration when the latter is expected to be performed by the UI.