### PR TITLE
CVE-2025-47907 - Upgrade golang to 1.24

### DIFF
--- a/Dockerfile.assisted-service-rhel8-mce
+++ b/Dockerfile.assisted-service-rhel8-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-service-rhel9-mce
+++ b/Dockerfile.assisted-service-rhel9-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Security fix for CVE-2025-47907:
Upgrading golang from 1.2x to 1.24