### PR TITLE
[release-ocm-2.14] - ACM-24331: CVE-2025-47907 Upgrade golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -1,6 +1,6 @@
 ARG RHEL_VERSION=9
 
-FROM registry.access.redhat.com/ubi$RHEL_VERSION/go-toolset:1.23 AS golang
+FROM registry.access.redhat.com/ubi$RHEL_VERSION/go-toolset:1.24 AS golang
 
 ADD . /app
 WORKDIR /app

--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 RUN go install gotest.tools/gotestsum@v1.12.2

--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 RUN GOFLAGS=-mod=mod go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 

--- a/Dockerfile.assisted-service-rhel8-mce
+++ b/Dockerfile.assisted-service-rhel8-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-service-rhel9-mce
+++ b/Dockerfile.assisted-service-rhel9-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-service.ocp
+++ b/Dockerfile.assisted-service.ocp
@@ -1,5 +1,5 @@
 # Build binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 WORKDIR /src
 COPY . .
 

--- a/ci-images/Dockerfile.base
+++ b/ci-images/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 RUN go install gotest.tools/gotestsum@v1.12.2
 

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -225,7 +225,7 @@ func (feature *DualStackVipsFeature) getFeatureActiveLevel(cluster *common.Clust
 	}
 	if (len(cluster.APIVips) > 1 && clusterUpdateParams == nil) ||
 		(len(cluster.APIVips) > 1 && clusterUpdateParams != nil && (clusterUpdateParams.APIVips == nil || len(clusterUpdateParams.APIVips) > 1)) ||
-		(cluster.APIVips != nil && len(cluster.APIVips) <= 1 && clusterUpdateParams != nil && clusterUpdateParams.APIVips != nil && len(clusterUpdateParams.APIVips) > 1) {
+		(len(cluster.APIVips) <= 1 && clusterUpdateParams != nil && len(clusterUpdateParams.APIVips) > 1) {
 		return activeLevelActive
 	}
 	return activeLevelNotActive


### PR DESCRIPTION
## Jira Tickets
- https://issues.redhat.com/browse/ACM-24331
- https://issues.redhat.com/browse/ACM-24336

##
Update go version to 1.24 to address cve CVE-2025-47907