### PR TITLE
[release-ocm-2.12] - ACM-24335: CVE-2025-47907 Upgrade golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,57 +15,58 @@ run:
   # include test files or not, default is true
   tests: true
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - build
-    - client
-    - docs
-    - models
-    - restapi
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
 issues:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  exclude-dirs:
+    - build
+    - client
+    - docs
+    - models
+    - restapi
+
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - G107
-    - G402  # support object store DisableSSL
-    - G108
+    - G115  # Integer overflow conversion
+    - G402  # support scality DisableSSL
+    - G401  # Use of weak cryptographic primitive
+    - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
+    - '"ok" shadows declaration'
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
 
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - gosec
-    - megacheck
     - unconvert
-    - gci
     - goimports
-    - exportloopref
+    - copyloopvar
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
 
     settings:
       printf:

--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -1,6 +1,6 @@
 ARG RHEL_VERSION=9
 
-FROM registry.access.redhat.com/ubi$RHEL_VERSION/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi$RHEL_VERSION/go-toolset:1.24 AS golang
 
 ADD . /app
 WORKDIR /app

--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,6 +1,6 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 RUN go install gotest.tools/gotestsum@v1.12.2
 
 FROM quay.io/centos/centos:stream9

--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 RUN GOFLAGS=-mod=mod go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 

--- a/Dockerfile.assisted-service-rhel8-mce
+++ b/Dockerfile.assisted-service-rhel8-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-service-rhel9-mce
+++ b/Dockerfile.assisted-service-rhel9-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.assisted-service.ocp
+++ b/Dockerfile.assisted-service.ocp
@@ -1,5 +1,5 @@
 # Build binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 WORKDIR /src
 COPY . .
 

--- a/ci-images/Dockerfile.base
+++ b/ci-images/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 RUN go install gotest.tools/gotestsum@v1.12.2
 

--- a/ci-images/Dockerfile.lint
+++ b/ci-images/Dockerfile.lint
@@ -1,5 +1,5 @@
 FROM base
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.54.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.64.8
 
 RUN dnf install -y diffutils

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // #nosec G108 -- pprof is intentionally exposed for debugging
 	"os"
 	"os/signal"
 	"path/filepath"

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4423,7 +4423,7 @@ func (b *bareMetalInventory) DeregisterInfraEnvInternal(ctx context.Context, par
 	if len(hosts) > 0 {
 		msg := fmt.Sprintf("failed to deregister infraEnv %s, %d hosts are still associated", params.InfraEnvID, len(hosts))
 		log.Error(msg)
-		return common.NewApiError(http.StatusBadRequest, fmt.Errorf(msg))
+		return common.NewApiError(http.StatusBadRequest, fmt.Errorf("%s", msg))
 	}
 
 	if err = b.infraEnvApi.DeregisterInfraEnv(ctx, params.InfraEnvID); err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13185,7 +13185,8 @@ var _ = Describe("TestRegisterCluster", func() {
 			NewClusterParams := getDefaultClusterCreateParams()
 			NewClusterParams.OpenshiftVersion = t.OpenShiftVersion
 			NewClusterParams.HighAvailabilityMode = t.HighAvailabilityMode
-			NewClusterParams.Platform = &t.Platform
+			platform := t.Platform
+			NewClusterParams.Platform = &platform
 
 			reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
 				NewClusterParams: NewClusterParams,

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -219,9 +219,9 @@ func (feature *DualStackVipsFeature) getFeatureActiveLevel(cluster *common.Clust
 	if cluster == nil {
 		return activeLevelNotActive
 	}
-	if (cluster.APIVips != nil && len(cluster.APIVips) > 1 && clusterUpdateParams == nil) ||
-		(cluster.APIVips != nil && len(cluster.APIVips) > 1 && clusterUpdateParams != nil && (clusterUpdateParams.APIVips == nil || len(clusterUpdateParams.APIVips) > 1)) ||
-		(cluster.APIVips != nil && len(cluster.APIVips) <= 1 && clusterUpdateParams != nil && clusterUpdateParams.APIVips != nil && len(clusterUpdateParams.APIVips) > 1) {
+	if (len(cluster.APIVips) > 1 && clusterUpdateParams == nil) ||
+		(len(cluster.APIVips) > 1 && clusterUpdateParams != nil && (clusterUpdateParams.APIVips == nil || len(clusterUpdateParams.APIVips) > 1)) ||
+		(len(cluster.APIVips) <= 1 && clusterUpdateParams != nil && len(clusterUpdateParams.APIVips) > 1) {
 		return activeLevelActive
 	}
 	return activeLevelNotActive

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -184,7 +184,7 @@ func areISCSIHoldersValid(disk *models.Disk, inventory *models.Inventory) error 
 	holders := strings.Split(disk.Holders, ",")
 	for _, holder := range holders {
 		if _, exists := multipathDiskNamesMap[holder]; exists {
-			return fmt.Errorf(iSCSIWithMultipathHolder)
+			return fmt.Errorf("%s", iSCSIWithMultipathHolder)
 		}
 	}
 

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -323,7 +323,7 @@ func GetDiskEncryptionForDay2(log logrus.FieldLogger, host *models.Host) (*ignit
 	}
 
 	// Checks if LUKS (disk encryption) exists
-	if config.Storage.Luks == nil || len(config.Storage.Luks) == 0 {
+	if len(config.Storage.Luks) == 0 {
 		// Disk encryption is disabled
 		return nil, nil
 	}


### PR DESCRIPTION
## Jira Tickets
- https://issues.redhat.com/browse/ACM-24335
- https://issues.redhat.com/browse/ACM-24340

##
Update go version to 1.24 to address cve CVE-2025-47907