### PR TITLE
MGMT-21810: Support TNF cluster installation using kube-api

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -199,6 +199,8 @@ type AgentSpec struct {
 	IgnitionEndpointHTTPHeaders map[string]string `json:"ignitionEndpointHTTPHeaders,omitempty"`
 	// NodeLabels are the labels to be applied on the node associated with this agent
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+	// FencingCredentialsSecretRef is a name of a secret in the Agent's namespace that contains fencing credentials
+	FencingCredentialsSecretRef string `json:"fencingCredentialsSecretRef,omitempty"`
 }
 
 type IgnitionEndpointTokenReference struct {

--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -82,6 +82,10 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              fencingCredentialsSecretRef:
+                description: FencingCredentialsSecretRef is a name of a secret in
+                  the Agent's namespace that contains fencing credentials
+                type: string
               hostname:
                 type: string
               ignitionConfigOverrides:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -915,6 +915,10 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              fencingCredentialsSecretRef:
+                description: FencingCredentialsSecretRef is a name of a secret in
+                  the Agent's namespace that contains fencing credentials
+                type: string
               hostname:
                 type: string
               ignitionConfigOverrides:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -92,6 +92,10 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              fencingCredentialsSecretRef:
+                description: FencingCredentialsSecretRef is a name of a secret in
+                  the Agent's namespace that contains fencing credentials
+                type: string
               hostname:
                 type: string
               ignitionConfigOverrides:

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5960,6 +5960,15 @@ func (b *bareMetalInventory) BindHostInternal(ctx context.Context, params instal
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 
+	fencingClustersSupported, err := common.BaseVersionGreaterOrEqual(common.MinimumVersionForTwoNodesWithFencing, cluster.OpenshiftVersion)
+	if err != nil {
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
+	}
+	if host.FencingCredentials != "" && !fencingClustersSupported {
+		err = errors.Errorf("Host %s has fencing credentials, it must be bound to a cluster with openshift version %s or newer", host.ID, common.MinimumVersionForTwoNodesWithFencing)
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
 	if err = b.clusterApi.AcceptRegistration(cluster); err != nil {
 		log.WithError(err).Errorf("failed to bind host <%s> to cluster %s due to: %s",
 			params.HostID.String(), *params.BindHostParams.ClusterID, err.Error())

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -18165,7 +18165,7 @@ var _ = Describe("BindHost", func() {
 		hostID = strfmt.UUID(uuid.New().String())
 		infraEnvID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
-		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Kind: swag.String(models.ClusterKindCluster)}}).Error
+		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Kind: swag.String(models.ClusterKindCluster), OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
 		err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -18451,6 +18451,54 @@ var _ = Describe("BindHost", func() {
 		response = bm.V2DeregisterCluster(ctx, deregisterParams)
 		Expect(response).To(BeAssignableToTypeOf(&installer.V2DeregisterClusterNoContent{}))
 	})
+
+	It("successful bind with fencing credentials", func() {
+		var clusterObj models.Cluster
+		Expect(db.First(&clusterObj, "id = ?", clusterID).Error).ShouldNot(HaveOccurred())
+		Expect(db.Model(&clusterObj).Update("openshift_version", common.MinimumVersionForTwoNodesWithFencing).Error).ShouldNot(HaveOccurred())
+
+		var hostObj models.Host
+		Expect(db.First(&hostObj, "id = ?", hostID).Error).ShouldNot(HaveOccurred())
+		Expect(db.Model(&hostObj).Update("fencing_credentials", "credentials").Error).ShouldNot(HaveOccurred())
+
+		params := installer.BindHostParams{
+			HostID:         hostID,
+			InfraEnvID:     infraEnvID,
+			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
+		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
+		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
+
+		response := bm.BindHost(ctx, params)
+		Expect(response).To(BeAssignableToTypeOf(&installer.BindHostOK{}))
+	})
+
+	It("failed bind because openshift version doesn't support fencing credentials", func() {
+		var hostObj models.Host
+		Expect(db.First(&hostObj, "id = ?", hostID).Error).ShouldNot(HaveOccurred())
+		Expect(db.Model(&hostObj).Update("fencing_credentials", "credentials").Error).ShouldNot(HaveOccurred())
+
+		params := installer.BindHostParams{
+			HostID:         hostID,
+			InfraEnvID:     infraEnvID,
+			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
+		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
+		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any()).Times(0)
+
+		response := bm.BindHost(ctx, params)
+		verifyApiErrorString(response, http.StatusBadRequest, "has fencing credentials")
+	})
 })
 
 var _ = Describe("BindHost - with rhsso auth", func() {
@@ -18485,9 +18533,10 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 
 		err := db.Create(&common.Cluster{
 			Cluster: models.Cluster{
-				ID:       &clusterID,
-				Kind:     swag.String(models.ClusterKindCluster),
-				UserName: userName1}}).Error
+				ID:               &clusterID,
+				Kind:             swag.String(models.ClusterKindCluster),
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+				UserName:         userName1}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
 		err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID}}).Error
 		Expect(err).ShouldNot(HaveOccurred())

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -525,6 +525,7 @@ var _ = Describe("Day2 cluster with bind/unbind hosts", func() {
 				Name:               swag.String("test-cluster"),
 				APIVipDnsname:      swag.String("api.test-cluster.example.com"),
 				OpenshiftClusterID: &openshiftClusterID,
+				OpenshiftVersion:   openshiftVersion,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -199,6 +199,8 @@ type AgentSpec struct {
 	IgnitionEndpointHTTPHeaders map[string]string `json:"ignitionEndpointHTTPHeaders,omitempty"`
 	// NodeLabels are the labels to be applied on the node associated with this agent
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+	// FencingCredentialsSecretRef is a name of a secret in the Agent's namespace that contains fencing credentials
+	FencingCredentialsSecretRef string `json:"fencingCredentialsSecretRef,omitempty"`
 }
 
 type IgnitionEndpointTokenReference struct {


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Allow installing TNF clusters using the kube-api as described in our [enhancement](https://github.com/openshift/assisted-service/blob/master/docs/enhancements/tnf-clusters.md).

I deployed a cluster with MCE using my image and tested the following:
1. Setting an agent's spec.fencingCredentialsSecretName and checking that the correct credentials were set for the host's fencing_credentials. I tired with and without certificateVerification in the secret.
2. Setting an agent's spec.fencingCredentialsSecretName to a none existing secret and checking that the correct error was in the agent's status.
3. Setting a label on the BMH for the fencing credentials secret name in order to simulate ZTP and checking that it was set on the agent.
4. Without setting the agent's spec.fencingCredentialsSecretName and checking that the fencing credentials were set from the BMH and it's secret. I tried with and without disableCertificateVerification on the BMH.
5. Late binding a host with fencing credentials only works if the cluster's openshift version is at least 4.20.

## List all the issues related to this PR

Closes [MGMT-21810](https://issues.redhat.com//browse/MGMT-21810)

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
