### PR TITLE
MGMT-21870: Add new parameters for bundle routes

### DIFF
--- a/client/operators/operators_client.go
+++ b/client/operators/operators_client.go
@@ -20,12 +20,12 @@ type API interface {
 	/*
 	   V2GetBundle gets operator properties for a bundle
 
-	   Retrieves an array of operator properties for the specified bundle.*/
+	   Retrieves an array of operator properties for the specified bundle when some features are activated.*/
 	V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V2GetBundleOK, error)
 	/*
-	   V2ListBundles gets list of avaliable bundles
+	   V2ListBundles gets list of available bundles
 
-	   Retrieves a list of avaliable bundles.*/
+	   Retrieves a list of available bundles filtered by support level.*/
 	V2ListBundles(ctx context.Context, params *V2ListBundlesParams) (*V2ListBundlesOK, error)
 	/*
 	   V2ListOfClusterOperators Lists operators to be monitored for a cluster.*/
@@ -62,7 +62,7 @@ type Client struct {
 /*
 V2GetBundle gets operator properties for a bundle
 
-Retrieves an array of operator properties for the specified bundle.
+Retrieves an array of operator properties for the specified bundle when some features are activated.
 */
 func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V2GetBundleOK, error) {
 
@@ -87,9 +87,9 @@ func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V
 }
 
 /*
-V2ListBundles gets list of avaliable bundles
+V2ListBundles gets list of available bundles
 
-Retrieves a list of avaliable bundles.
+Retrieves a list of available bundles filtered by support level.
 */
 func (a *Client) V2ListBundles(ctx context.Context, params *V2ListBundlesParams) (*V2ListBundlesOK, error) {
 

--- a/client/operators/v2_get_bundle_parameters.go
+++ b/client/operators/v2_get_bundle_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2GetBundleParams creates a new V2GetBundleParams object,
@@ -61,9 +62,15 @@ V2GetBundleParams contains all the parameters to send to the API endpoint
 */
 type V2GetBundleParams struct {
 
+	/* FeatureIds.
+
+	   Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+	*/
+	FeatureIds []string
+
 	/* ID.
 
-	   Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
+	   Identifier of the bundle, for example, `virtualization` or `openshift-ai`.
 	*/
 	ID string
 
@@ -120,6 +127,17 @@ func (o *V2GetBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithFeatureIds adds the featureIds to the v2 get bundle params
+func (o *V2GetBundleParams) WithFeatureIds(featureIds []string) *V2GetBundleParams {
+	o.SetFeatureIds(featureIds)
+	return o
+}
+
+// SetFeatureIds adds the featureIds to the v2 get bundle params
+func (o *V2GetBundleParams) SetFeatureIds(featureIds []string) {
+	o.FeatureIds = featureIds
+}
+
 // WithID adds the id to the v2 get bundle params
 func (o *V2GetBundleParams) WithID(id string) *V2GetBundleParams {
 	o.SetID(id)
@@ -139,6 +157,17 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 	}
 	var res []error
 
+	if o.FeatureIds != nil {
+
+		// binding items for feature_ids
+		joinedFeatureIds := o.bindParamFeatureIds(reg)
+
+		// query array param feature_ids
+		if err := r.SetQueryParam("feature_ids", joinedFeatureIds...); err != nil {
+			return err
+		}
+	}
+
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
@@ -148,4 +177,21 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// bindParamV2GetBundle binds the parameter feature_ids
+func (o *V2GetBundleParams) bindParamFeatureIds(formats strfmt.Registry) []string {
+	featureIdsIR := o.FeatureIds
+
+	var featureIdsIC []string
+	for _, featureIdsIIR := range featureIdsIR { // explode []string
+
+		featureIdsIIV := featureIdsIIR // string as string
+		featureIdsIC = append(featureIdsIC, featureIdsIIV)
+	}
+
+	// items.CollectionFormat: "multi"
+	featureIdsIS := swag.JoinByFormat(featureIdsIC, "multi")
+
+	return featureIdsIS
 }

--- a/client/operators/v2_get_bundle_responses.go
+++ b/client/operators/v2_get_bundle_responses.go
@@ -29,6 +29,12 @@ func (o *V2GetBundleReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewV2GetBundleBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 404:
 		result := NewV2GetBundleNotFound()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -100,6 +106,69 @@ func (o *V2GetBundleOK) GetPayload() *models.Bundle {
 func (o *V2GetBundleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Bundle)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewV2GetBundleBadRequest creates a V2GetBundleBadRequest with default headers values
+func NewV2GetBundleBadRequest() *V2GetBundleBadRequest {
+	return &V2GetBundleBadRequest{}
+}
+
+/*
+V2GetBundleBadRequest describes a response with status code 400, with default header values.
+
+Error.
+*/
+type V2GetBundleBadRequest struct {
+	Payload *models.Error
+}
+
+// IsSuccess returns true when this v2 get bundle bad request response has a 2xx status code
+func (o *V2GetBundleBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this v2 get bundle bad request response has a 3xx status code
+func (o *V2GetBundleBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this v2 get bundle bad request response has a 4xx status code
+func (o *V2GetBundleBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this v2 get bundle bad request response has a 5xx status code
+func (o *V2GetBundleBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this v2 get bundle bad request response a status code equal to that given
+func (o *V2GetBundleBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
+func (o *V2GetBundleBadRequest) Error() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2GetBundleBadRequest) String() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2GetBundleBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *V2GetBundleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/operators/v2_list_bundles_parameters.go
+++ b/client/operators/v2_list_bundles_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2ListBundlesParams creates a new V2ListBundlesParams object,
@@ -60,6 +61,39 @@ V2ListBundlesParams contains all the parameters to send to the API endpoint
 	Typically these are written to a http.Request.
 */
 type V2ListBundlesParams struct {
+
+	/* CPUArchitecture.
+
+	   The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.
+
+	   Default: "x86_64"
+	*/
+	CPUArchitecture *string
+
+	/* ExternalPlatformName.
+
+	   External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.
+	*/
+	ExternalPlatformName *string
+
+	/* FeatureIds.
+
+	   Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+	*/
+	FeatureIds []string
+
+	/* OpenshiftVersion.
+
+	   Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	*/
+	OpenshiftVersion *string
+
+	/* PlatformType.
+
+	   The provider platform type. openshift_version must be set.
+	*/
+	PlatformType *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -77,7 +111,18 @@ func (o *V2ListBundlesParams) WithDefaults() *V2ListBundlesParams {
 //
 // All values with no default are reset to their zero value.
 func (o *V2ListBundlesParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		cPUArchitectureDefault = string("x86_64")
+	)
+
+	val := V2ListBundlesParams{
+		CPUArchitecture: &cPUArchitectureDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the v2 list bundles params
@@ -113,6 +158,61 @@ func (o *V2ListBundlesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCPUArchitecture adds the cPUArchitecture to the v2 list bundles params
+func (o *V2ListBundlesParams) WithCPUArchitecture(cPUArchitecture *string) *V2ListBundlesParams {
+	o.SetCPUArchitecture(cPUArchitecture)
+	return o
+}
+
+// SetCPUArchitecture adds the cpuArchitecture to the v2 list bundles params
+func (o *V2ListBundlesParams) SetCPUArchitecture(cPUArchitecture *string) {
+	o.CPUArchitecture = cPUArchitecture
+}
+
+// WithExternalPlatformName adds the externalPlatformName to the v2 list bundles params
+func (o *V2ListBundlesParams) WithExternalPlatformName(externalPlatformName *string) *V2ListBundlesParams {
+	o.SetExternalPlatformName(externalPlatformName)
+	return o
+}
+
+// SetExternalPlatformName adds the externalPlatformName to the v2 list bundles params
+func (o *V2ListBundlesParams) SetExternalPlatformName(externalPlatformName *string) {
+	o.ExternalPlatformName = externalPlatformName
+}
+
+// WithFeatureIds adds the featureIds to the v2 list bundles params
+func (o *V2ListBundlesParams) WithFeatureIds(featureIds []string) *V2ListBundlesParams {
+	o.SetFeatureIds(featureIds)
+	return o
+}
+
+// SetFeatureIds adds the featureIds to the v2 list bundles params
+func (o *V2ListBundlesParams) SetFeatureIds(featureIds []string) {
+	o.FeatureIds = featureIds
+}
+
+// WithOpenshiftVersion adds the openshiftVersion to the v2 list bundles params
+func (o *V2ListBundlesParams) WithOpenshiftVersion(openshiftVersion *string) *V2ListBundlesParams {
+	o.SetOpenshiftVersion(openshiftVersion)
+	return o
+}
+
+// SetOpenshiftVersion adds the openshiftVersion to the v2 list bundles params
+func (o *V2ListBundlesParams) SetOpenshiftVersion(openshiftVersion *string) {
+	o.OpenshiftVersion = openshiftVersion
+}
+
+// WithPlatformType adds the platformType to the v2 list bundles params
+func (o *V2ListBundlesParams) WithPlatformType(platformType *string) *V2ListBundlesParams {
+	o.SetPlatformType(platformType)
+	return o
+}
+
+// SetPlatformType adds the platformType to the v2 list bundles params
+func (o *V2ListBundlesParams) SetPlatformType(platformType *string) {
+	o.PlatformType = platformType
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2ListBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -121,8 +221,104 @@ func (o *V2ListBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
+	if o.CPUArchitecture != nil {
+
+		// query param cpu_architecture
+		var qrCPUArchitecture string
+
+		if o.CPUArchitecture != nil {
+			qrCPUArchitecture = *o.CPUArchitecture
+		}
+		qCPUArchitecture := qrCPUArchitecture
+		if qCPUArchitecture != "" {
+
+			if err := r.SetQueryParam("cpu_architecture", qCPUArchitecture); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.ExternalPlatformName != nil {
+
+		// query param external_platform_name
+		var qrExternalPlatformName string
+
+		if o.ExternalPlatformName != nil {
+			qrExternalPlatformName = *o.ExternalPlatformName
+		}
+		qExternalPlatformName := qrExternalPlatformName
+		if qExternalPlatformName != "" {
+
+			if err := r.SetQueryParam("external_platform_name", qExternalPlatformName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FeatureIds != nil {
+
+		// binding items for feature_ids
+		joinedFeatureIds := o.bindParamFeatureIds(reg)
+
+		// query array param feature_ids
+		if err := r.SetQueryParam("feature_ids", joinedFeatureIds...); err != nil {
+			return err
+		}
+	}
+
+	if o.OpenshiftVersion != nil {
+
+		// query param openshift_version
+		var qrOpenshiftVersion string
+
+		if o.OpenshiftVersion != nil {
+			qrOpenshiftVersion = *o.OpenshiftVersion
+		}
+		qOpenshiftVersion := qrOpenshiftVersion
+		if qOpenshiftVersion != "" {
+
+			if err := r.SetQueryParam("openshift_version", qOpenshiftVersion); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.PlatformType != nil {
+
+		// query param platform_type
+		var qrPlatformType string
+
+		if o.PlatformType != nil {
+			qrPlatformType = *o.PlatformType
+		}
+		qPlatformType := qrPlatformType
+		if qPlatformType != "" {
+
+			if err := r.SetQueryParam("platform_type", qPlatformType); err != nil {
+				return err
+			}
+		}
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// bindParamV2ListBundles binds the parameter feature_ids
+func (o *V2ListBundlesParams) bindParamFeatureIds(formats strfmt.Registry) []string {
+	featureIdsIR := o.FeatureIds
+
+	var featureIdsIC []string
+	for _, featureIdsIIR := range featureIdsIR { // explode []string
+
+		featureIdsIIV := featureIdsIIR // string as string
+		featureIdsIC = append(featureIdsIC, featureIdsIIV)
+	}
+
+	// items.CollectionFormat: "multi"
+	featureIdsIS := swag.JoinByFormat(featureIdsIC, "multi")
+
+	return featureIdsIS
 }

--- a/client/operators/v2_list_bundles_responses.go
+++ b/client/operators/v2_list_bundles_responses.go
@@ -29,6 +29,12 @@ func (o *V2ListBundlesReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewV2ListBundlesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewV2ListBundlesInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -95,6 +101,69 @@ func (o *V2ListBundlesOK) readResponse(response runtime.ClientResponse, consumer
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewV2ListBundlesBadRequest creates a V2ListBundlesBadRequest with default headers values
+func NewV2ListBundlesBadRequest() *V2ListBundlesBadRequest {
+	return &V2ListBundlesBadRequest{}
+}
+
+/*
+V2ListBundlesBadRequest describes a response with status code 400, with default header values.
+
+Error.
+*/
+type V2ListBundlesBadRequest struct {
+	Payload *models.Error
+}
+
+// IsSuccess returns true when this v2 list bundles bad request response has a 2xx status code
+func (o *V2ListBundlesBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this v2 list bundles bad request response has a 3xx status code
+func (o *V2ListBundlesBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this v2 list bundles bad request response has a 4xx status code
+func (o *V2ListBundlesBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this v2 list bundles bad request response has a 5xx status code
+func (o *V2ListBundlesBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this v2 list bundles bad request response a status code equal to that given
+func (o *V2ListBundlesBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
+func (o *V2ListBundlesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles][%d] v2ListBundlesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2ListBundlesBadRequest) String() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles][%d] v2ListBundlesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2ListBundlesBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *V2ListBundlesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/internal/operators/amdgpu/amd_gpu_operator.go
+++ b/internal/operators/amdgpu/amd_gpu_operator.go
@@ -273,6 +273,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDAMDGPU
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -57,8 +57,8 @@ type Operator interface {
 	GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error)
 	// GetFeatureSupportID returns the operator unique feature-support ID
 	GetFeatureSupportID() models.FeatureSupportLevelID
-	// GetBundleLabels returns the list of bundles names associated with the operator
-	GetBundleLabels() []string
+	// GetBundleLabels returns the list of bundles names associated with the operator based on the given feature IDs
+	GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string
 }
 
 // Storage Operator provide a generic API for storage operators

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -53,17 +53,17 @@ func (mr *MockOperatorMockRecorder) GenerateManifests(arg0 interface{}) *gomock.
 }
 
 // GetBundleLabels mocks base method.
-func (m *MockOperator) GetBundleLabels() []string {
+func (m *MockOperator) GetBundleLabels(arg0 []models.FeatureSupportLevelID) []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundleLabels")
+	ret := m.ctrl.Call(m, "GetBundleLabels", arg0)
 	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
 // GetBundleLabels indicates an expected call of GetBundleLabels.
-func (mr *MockOperatorMockRecorder) GetBundleLabels() *gomock.Call {
+func (mr *MockOperatorMockRecorder) GetBundleLabels(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleLabels", reflect.TypeOf((*MockOperator)(nil).GetBundleLabels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleLabels", reflect.TypeOf((*MockOperator)(nil).GetBundleLabels), arg0)
 }
 
 // GetClusterValidationIDs mocks base method.

--- a/internal/operators/authorino/authorino_operator.go
+++ b/internal/operators/authorino/authorino_operator.go
@@ -2,6 +2,7 @@ package authorino
 
 import (
 	"context"
+	"slices"
 	"text/template"
 
 	"github.com/lib/pq"
@@ -140,6 +141,12 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the Authorino operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/clusterobservability/cluster_observability_operator.go
+++ b/internal/operators/clusterobservability/cluster_observability_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -358,6 +358,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the Authorino operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/handler/handler_v2.go
+++ b/internal/operators/handler/handler_v2.go
@@ -2,12 +2,65 @@ package handler
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/hashicorp/go-version"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/featuresupport"
+	"github.com/openshift/assisted-service/models"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	restoperators "github.com/openshift/assisted-service/restapi/operations/operators"
+	"github.com/pkg/errors"
 )
+
+// validateBundleParameters validates the parameters for bundle operations
+func (h *Handler) validateBundleParameters(openshiftVersion *string, cpuArchitecture *string, platformType *models.PlatformType, externalPlatformName *string) middleware.Responder {
+	if openshiftVersion == nil || *openshiftVersion == "" {
+		// No filtering
+		return nil
+	}
+
+	if cpuArchitecture == nil || *cpuArchitecture == "" {
+		// This should never happen
+		return common.NewApiError(http.StatusBadRequest, fmt.Errorf("cpu architecture is required"))
+	}
+
+	// Validate OpenShift version format
+	_, err := version.NewVersion(*openshiftVersion)
+	if err != nil {
+		return common.NewApiError(http.StatusBadRequest, fmt.Errorf("invalid openshift version: %w", err))
+	}
+
+	// Validate CPU architecture support
+	archSupported, err := featuresupport.IsArchitectureSupported(*cpuArchitecture, *openshiftVersion)
+	if err != nil {
+		h.log.Errorf("Failed to validate CPU architecture support: %v", err)
+
+		return common.NewApiError(http.StatusInternalServerError, errors.New("failed to validate CPU architecture support"))
+	}
+
+	if !archSupported {
+		return common.NewApiError(http.StatusBadRequest, fmt.Errorf("cpu architecture %s is not supported for openshift version %s", *cpuArchitecture, *openshiftVersion))
+	}
+
+	// Validate platform support if platform type is provided
+	if platformType != nil {
+		platformSupported, err := featuresupport.IsPlatformSupported(*platformType, externalPlatformName, *openshiftVersion, *cpuArchitecture)
+		if err != nil {
+			h.log.Errorf("Failed to validate platform support: %v", err)
+
+			return common.NewApiError(http.StatusBadRequest, errors.New("failed to validate platform support"))
+		}
+
+		if !platformSupported {
+			return common.NewApiError(http.StatusBadRequest, fmt.Errorf("platform %s is not supported for openshift version %s and cpu architecture %s", *platformType, *openshiftVersion, *cpuArchitecture))
+		}
+	}
+
+	return nil
+}
 
 // V2ListOfClusterOperators Lists operators to be monitored for a cluster.
 func (h *Handler) V2ListOfClusterOperators(ctx context.Context, params restoperators.V2ListOfClusterOperatorsParams) middleware.Responder {
@@ -21,34 +74,76 @@ func (h *Handler) V2ListOfClusterOperators(ctx context.Context, params restopera
 // V2ListOperatorProperties Lists properties for an operator name.
 func (h *Handler) V2ListOperatorProperties(ctx context.Context, params restoperators.V2ListOperatorPropertiesParams) middleware.Responder {
 	log := logutil.FromContext(ctx, h.log)
+
 	properties, err := h.operatorsAPI.GetOperatorProperties(params.OperatorName)
 	if err != nil {
 		log.Errorf("%s operator has not been found", params.OperatorName)
+
 		return restoperators.NewV2ListOperatorPropertiesNotFound()
 	}
 
-	return restoperators.NewV2ListOperatorPropertiesOK().
-		WithPayload(properties)
+	return restoperators.NewV2ListOperatorPropertiesOK().WithPayload(properties)
 }
 
 // V2ListSupportedOperators Retrieves the list of supported operators.
 func (h *Handler) V2ListSupportedOperators(_ context.Context, _ restoperators.V2ListSupportedOperatorsParams) middleware.Responder {
-	return restoperators.NewV2ListSupportedOperatorsOK().
-		WithPayload(h.operatorsAPI.GetSupportedOperators())
+	return restoperators.NewV2ListSupportedOperatorsOK().WithPayload(h.operatorsAPI.GetSupportedOperators())
 }
 
-// V2GetBundles Retrieves the list of supported bundles.
-func (h *Handler) V2ListBundles(_ context.Context, _ restoperators.V2ListBundlesParams) middleware.Responder {
-	return restoperators.NewV2ListBundlesOK().WithPayload(h.operatorsAPI.ListBundles())
+// V2ListBundles Retrieves the list of supported bundles filtered by feature support.
+func (h *Handler) V2ListBundles(_ context.Context, params restoperators.V2ListBundlesParams) middleware.Responder {
+	// Convert platform type to models.PlatformType if provided
+	var platformType *models.PlatformType
+	if params.PlatformType != nil {
+		pt := models.PlatformType(*params.PlatformType)
+		platformType = &pt
+	}
+
+	// Validate parameters
+	err := h.validateBundleParameters(params.OpenshiftVersion, params.CPUArchitecture, platformType, params.ExternalPlatformName)
+	if err != nil {
+		return err
+	}
+
+	// Create SupportLevelFilters struct
+	var filters *featuresupport.SupportLevelFilters
+
+	if params.OpenshiftVersion != nil && *params.OpenshiftVersion != "" {
+		filters = &featuresupport.SupportLevelFilters{
+			OpenshiftVersion:     *params.OpenshiftVersion,
+			CPUArchitecture:      params.CPUArchitecture,
+			PlatformType:         platformType,
+			ExternalPlatformName: params.ExternalPlatformName,
+		}
+	}
+
+	// Convert string slice to FeatureSupportLevelID slice
+	var featureIDs []models.FeatureSupportLevelID
+	for _, featureID := range params.FeatureIds {
+		featureIDs = append(featureIDs, models.FeatureSupportLevelID(featureID))
+	}
+
+	// Get filtered bundles using featuresupport API
+	filteredBundles := h.operatorsAPI.ListBundles(filters, featureIDs)
+
+	return restoperators.NewV2ListBundlesOK().WithPayload(filteredBundles)
 }
 
 // V2GetBundle Retrieves the Bundle object for a specific bundleName.
 func (h *Handler) V2GetBundle(ctx context.Context, params restoperators.V2GetBundleParams) middleware.Responder {
 	log := logutil.FromContext(ctx, h.log)
-	bundle, err := h.operatorsAPI.GetBundle(params.ID)
+
+	// Convert string slice to FeatureSupportLevelID slice
+	var featureIDs []models.FeatureSupportLevelID
+	for _, featureID := range params.FeatureIds {
+		featureIDs = append(featureIDs, models.FeatureSupportLevelID(featureID))
+	}
+
+	bundle, err := h.operatorsAPI.GetBundle(params.ID, featureIDs)
 	if err != nil {
 		log.Errorf("Failed to get operators for bundle %s: %v", params.ID, err)
 		return common.GenerateErrorResponder(err)
 	}
+
 	return restoperators.NewV2GetBundleOK().WithPayload(bundle)
 }

--- a/internal/operators/kmm/kmm_operator.go
+++ b/internal/operators/kmm/kmm_operator.go
@@ -2,6 +2,7 @@ package kmm
 
 import (
 	"context"
+	"slices"
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
@@ -182,6 +183,12 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDKMM
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/kubedescheduler/kube_descheduler_operator.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -117,6 +117,6 @@ func (l *lsOperator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the LSO operator
-func (l *lsOperator) GetBundleLabels() []string {
+func (l *lsOperator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -3,6 +3,7 @@ package lvm
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift/assisted-service/internal/common"
@@ -238,7 +239,13 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDLVM
 }
 
-// GetBundleLabels returns the bundle labels for the LSO operator
-func (o *operator) GetBundleLabels() []string {
-	return []string(Operator.Bundles)
+// GetBundleLabels returns the bundle labels for the LVM operator
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, include in openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{"openshift-ai"}
+	}
+
+	// For non-SNO deployments, LVM is not in any bundle by default
+	return []string{}
 }

--- a/internal/operators/mce/mce_operator.go
+++ b/internal/operators/mce/mce_operator.go
@@ -221,7 +221,6 @@ func (o *operator) GetSupportedArchitectures() []string {
 	return []string{common.X86CPUArchitecture, common.PowerCPUArchitecture,
 		common.S390xCPUArchitecture, common.ARM64CPUArchitecture, common.AMD64CPUArchitecture,
 	}
-
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
@@ -236,6 +235,6 @@ func GetMinDiskSizeGB(cluster *models.Cluster) int64 {
 }
 
 // GetBundleLabels returns the bundle labels for the LSO operator
-func (l *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/metallb/metallb_operator.go
+++ b/internal/operators/metallb/metallb_operator.go
@@ -143,6 +143,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns bundle labels for MetalLB
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	featuresupport "github.com/openshift/assisted-service/internal/featuresupport"
 	api "github.com/openshift/assisted-service/internal/operators/api"
 	models "github.com/openshift/assisted-service/models"
 )
@@ -80,18 +81,18 @@ func (mr *MockAPIMockRecorder) GenerateManifests(arg0, arg1 interface{}) *gomock
 }
 
 // GetBundle mocks base method.
-func (m *MockAPI) GetBundle(arg0 string) (*models.Bundle, error) {
+func (m *MockAPI) GetBundle(arg0 string, arg1 []models.FeatureSupportLevelID) (*models.Bundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundle", arg0)
+	ret := m.ctrl.Call(m, "GetBundle", arg0, arg1)
 	ret0, _ := ret[0].(*models.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBundle indicates an expected call of GetBundle.
-func (mr *MockAPIMockRecorder) GetBundle(arg0 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetBundle(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockAPI)(nil).GetBundle), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockAPI)(nil).GetBundle), arg0, arg1)
 }
 
 // GetMonitoredOperatorsList mocks base method.
@@ -211,17 +212,17 @@ func (mr *MockAPIMockRecorder) GetSupportedOperatorsByType(arg0 interface{}) *go
 }
 
 // ListBundles mocks base method.
-func (m *MockAPI) ListBundles() []*models.Bundle {
+func (m *MockAPI) ListBundles(arg0 *featuresupport.SupportLevelFilters, arg1 []models.FeatureSupportLevelID) []*models.Bundle {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBundles")
+	ret := m.ctrl.Call(m, "ListBundles", arg0, arg1)
 	ret0, _ := ret[0].([]*models.Bundle)
 	return ret0
 }
 
 // ListBundles indicates an expected call of ListBundles.
-func (mr *MockAPIMockRecorder) ListBundles() *gomock.Call {
+func (mr *MockAPIMockRecorder) ListBundles(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockAPI)(nil).ListBundles))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockAPI)(nil).ListBundles), arg0, arg1)
 }
 
 // ResolveDependencies mocks base method.

--- a/internal/operators/mtv/operator.go
+++ b/internal/operators/mtv/operator.go
@@ -210,6 +210,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the MTV operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/nmstate/operator.go
+++ b/internal/operators/nmstate/operator.go
@@ -155,6 +155,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/nmstate/operator_test.go
+++ b/internal/operators/nmstate/operator_test.go
@@ -34,7 +34,7 @@ var _ = Describe("NMState Operator", func() {
 		})
 
 		It("should return the right feature support id", func() {
-			Expect(operator.GetBundleLabels()).To(Equal(bundle))
+			Expect(operator.GetBundleLabels(nil)).To(Equal(bundle))
 		})
 	})
 })

--- a/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
+++ b/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
@@ -149,6 +149,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDNODEFEATUREDISCOVERY
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/nodehealthcheck/node_healthcheck_operator.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_operator.go
@@ -92,6 +92,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/nodemaintenance/node_maintenance_operator.go
+++ b/internal/operators/nodemaintenance/node_maintenance_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/numaresources/numaresources_operator.go
+++ b/internal/operators/numaresources/numaresources_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/nvidiagpu/nvidia_gpu_operator.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator.go
@@ -278,6 +278,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDNVIDIAGPU
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/oadp/oadp_operator.go
+++ b/internal/operators/oadp/oadp_operator.go
@@ -84,6 +84,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/odf/odf_operator.go
+++ b/internal/operators/odf/odf_operator.go
@@ -3,6 +3,7 @@ package odf
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -283,7 +284,6 @@ func (o *operator) GetHostRequirements(_ context.Context, cluster *common.Cluste
 		CPUCores: o.config.ODFPerHostCPUStandardMode + (diskCount * o.config.ODFPerDiskCPUCount),
 		RAMMib:   conversions.GibToMib(o.config.ODFPerHostMemoryGiBStandardMode + (diskCount * o.config.ODFPerDiskRAMGiB)),
 	}, nil
-
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
@@ -328,8 +328,14 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDODF
 }
 
-// GetBundleLabels returns the bundle labels for the LSO operator
-func (l *operator) GetBundleLabels() []string {
+// GetBundleLabels returns the bundle labels for the ODF operator
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }
 

--- a/internal/operators/openshiftai/openshift_ai_operator.go
+++ b/internal/operators/openshiftai/openshift_ai_operator.go
@@ -332,7 +332,7 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDOPENSHIFTAI
 }
 
-// GetBundleLabels returns the bundle labels for the LSO operator
-func (l *operator) GetBundleLabels() []string {
+// GetBundleLabels returns the bundle labels for the OpenShift AI operator
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/osc/operator.go
+++ b/internal/operators/osc/operator.go
@@ -213,6 +213,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the bundle labels for the OSC operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/pipelines/pipelines_operator.go
+++ b/internal/operators/pipelines/pipelines_operator.go
@@ -2,6 +2,7 @@ package pipelines
 
 import (
 	"context"
+	"slices"
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
@@ -150,6 +151,12 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDPIPELINES
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/selfnoderemediation/self_node_remediation_operator.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_operator.go
@@ -82,6 +82,6 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 }
 
 // GetBundleLabels returns the list of bundles names associated with the operator
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/serverless/serverless_operator.go
+++ b/internal/operators/serverless/serverless_operator.go
@@ -2,6 +2,7 @@ package serverless
 
 import (
 	"context"
+	"slices"
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
@@ -150,6 +151,12 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDSERVERLESS
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }

--- a/internal/operators/servicemesh/servicemesh_operator.go
+++ b/internal/operators/servicemesh/servicemesh_operator.go
@@ -2,6 +2,7 @@ package servicemesh
 
 import (
 	"context"
+	"slices"
 	"text/template"
 
 	"github.com/kelseyhightower/envconfig"
@@ -149,6 +150,12 @@ func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {
 	return models.FeatureSupportLevelIDSERVICEMESH
 }
 
-func (o *operator) GetBundleLabels() []string {
+func (o *operator) GetBundleLabels(featureIDs []models.FeatureSupportLevelID) []string {
+	// For SNO feature, exclude from openshift-ai bundle
+	if slices.Contains(featureIDs, models.FeatureSupportLevelIDSNO) {
+		return []string{}
+	}
+
+	// For non-SNO deployments, use the default bundle behavior
 	return []string(Operator.Bundles)
 }

--- a/restapi/configure_assisted_install.go
+++ b/restapi/configure_assisted_install.go
@@ -271,7 +271,7 @@ type OperatorsAPI interface {
 	/* V2GetBundle Get operator properties for a bundle */
 	V2GetBundle(ctx context.Context, params operators.V2GetBundleParams) middleware.Responder
 
-	/* V2ListBundles Get list of avaliable bundles */
+	/* V2ListBundles Get list of available bundles */
 	V2ListBundles(ctx context.Context, params operators.V2ListBundlesParams) middleware.Responder
 
 	/* V2ListOfClusterOperators Lists operators to be monitored for a cluster. */

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5773,12 +5773,67 @@ func init() {
     },
     "/v2/operators/bundles": {
       "get": {
-        "description": "Retrieves a list of avaliable bundles.",
+        "description": "Retrieves a list of available bundles filtered by support level.",
         "tags": [
           "operators"
         ],
-        "summary": "Get list of avaliable bundles",
+        "summary": "Get list of available bundles",
         "operationId": "V2ListBundles",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.",
+            "name": "openshift_version",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "x86_64",
+              "aarch64",
+              "arm64",
+              "ppc64le",
+              "s390x",
+              "multi"
+            ],
+            "type": "string",
+            "default": "x86_64",
+            "description": "The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.",
+            "name": "cpu_architecture",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "baremetal",
+              "none",
+              "nutanix",
+              "vsphere",
+              "external"
+            ],
+            "type": "string",
+            "description": "The provider platform type. openshift_version must be set.",
+            "name": "platform_type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.",
+            "name": "external_platform_name",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "enum": [
+                "SNO"
+              ],
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Array of feature IDs that affect bundle composition (e.g., [\"SNO\"] for Single Node OpenShift).",
+            "name": "feature_ids",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",
@@ -5787,6 +5842,12 @@ func init() {
               "items": {
                 "$ref": "#/definitions/bundle"
               }
+            }
+          },
+          "400": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "500": {
@@ -5800,7 +5861,7 @@ func init() {
     },
     "/v2/operators/bundles/{id}": {
       "get": {
-        "description": "Retrieves an array of operator properties for the specified bundle.",
+        "description": "Retrieves an array of operator properties for the specified bundle when some features are activated.",
         "tags": [
           "operators"
         ],
@@ -5809,10 +5870,23 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
+            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai` + "`" + `.",
             "name": "id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "array",
+            "items": {
+              "enum": [
+                "SNO"
+              ],
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Array of feature IDs that affect bundle composition (e.g., [\"SNO\"] for Single Node OpenShift).",
+            "name": "feature_ids",
+            "in": "query"
           }
         ],
         "responses": {
@@ -5820,6 +5894,12 @@ func init() {
             "description": "Success",
             "schema": {
               "$ref": "#/definitions/bundle"
+            }
+          },
+          "400": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "404": {
@@ -17104,12 +17184,67 @@ func init() {
     },
     "/v2/operators/bundles": {
       "get": {
-        "description": "Retrieves a list of avaliable bundles.",
+        "description": "Retrieves a list of available bundles filtered by support level.",
         "tags": [
           "operators"
         ],
-        "summary": "Get list of avaliable bundles",
+        "summary": "Get list of available bundles",
         "operationId": "V2ListBundles",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.",
+            "name": "openshift_version",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "x86_64",
+              "aarch64",
+              "arm64",
+              "ppc64le",
+              "s390x",
+              "multi"
+            ],
+            "type": "string",
+            "default": "x86_64",
+            "description": "The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.",
+            "name": "cpu_architecture",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "baremetal",
+              "none",
+              "nutanix",
+              "vsphere",
+              "external"
+            ],
+            "type": "string",
+            "description": "The provider platform type. openshift_version must be set.",
+            "name": "platform_type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.",
+            "name": "external_platform_name",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "enum": [
+                "SNO"
+              ],
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Array of feature IDs that affect bundle composition (e.g., [\"SNO\"] for Single Node OpenShift).",
+            "name": "feature_ids",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",
@@ -17118,6 +17253,12 @@ func init() {
               "items": {
                 "$ref": "#/definitions/bundle"
               }
+            }
+          },
+          "400": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "500": {
@@ -17131,7 +17272,7 @@ func init() {
     },
     "/v2/operators/bundles/{id}": {
       "get": {
-        "description": "Retrieves an array of operator properties for the specified bundle.",
+        "description": "Retrieves an array of operator properties for the specified bundle when some features are activated.",
         "tags": [
           "operators"
         ],
@@ -17140,10 +17281,23 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai-nvidia` + "`" + `.",
+            "description": "Identifier of the bundle, for example, ` + "`" + `virtualization` + "`" + ` or ` + "`" + `openshift-ai` + "`" + `.",
             "name": "id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "array",
+            "items": {
+              "enum": [
+                "SNO"
+              ],
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Array of feature IDs that affect bundle composition (e.g., [\"SNO\"] for Single Node OpenShift).",
+            "name": "feature_ids",
+            "in": "query"
           }
         ],
         "responses": {
@@ -17151,6 +17305,12 @@ func init() {
             "description": "Success",
             "schema": {
               "$ref": "#/definitions/bundle"
+            }
+          },
+          "400": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "404": {

--- a/restapi/operations/operators/v2_get_bundle.go
+++ b/restapi/operations/operators/v2_get_bundle.go
@@ -34,7 +34,7 @@ func NewV2GetBundle(ctx *middleware.Context, handler V2GetBundleHandler) *V2GetB
 
 # Get operator properties for a bundle
 
-Retrieves an array of operator properties for the specified bundle.
+Retrieves an array of operator properties for the specified bundle when some features are activated.
 */
 type V2GetBundle struct {
 	Context *middleware.Context

--- a/restapi/operations/operators/v2_get_bundle_responses.go
+++ b/restapi/operations/operators/v2_get_bundle_responses.go
@@ -58,6 +58,51 @@ func (o *V2GetBundleOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
+// V2GetBundleBadRequestCode is the HTTP code returned for type V2GetBundleBadRequest
+const V2GetBundleBadRequestCode int = 400
+
+/*
+V2GetBundleBadRequest Error.
+
+swagger:response v2GetBundleBadRequest
+*/
+type V2GetBundleBadRequest struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewV2GetBundleBadRequest creates V2GetBundleBadRequest with default headers values
+func NewV2GetBundleBadRequest() *V2GetBundleBadRequest {
+
+	return &V2GetBundleBadRequest{}
+}
+
+// WithPayload adds the payload to the v2 get bundle bad request response
+func (o *V2GetBundleBadRequest) WithPayload(payload *models.Error) *V2GetBundleBadRequest {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the v2 get bundle bad request response
+func (o *V2GetBundleBadRequest) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *V2GetBundleBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(400)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // V2GetBundleNotFoundCode is the HTTP code returned for type V2GetBundleNotFound
 const V2GetBundleNotFoundCode int = 404
 

--- a/restapi/operations/operators/v2_get_bundle_urlbuilder.go
+++ b/restapi/operations/operators/v2_get_bundle_urlbuilder.go
@@ -10,11 +10,15 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/swag"
 )
 
 // V2GetBundleURL generates an URL for the v2 get bundle operation
 type V2GetBundleURL struct {
 	ID string
+
+	FeatureIds []string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -54,6 +58,24 @@ func (o *V2GetBundleURL) Build() (*url.URL, error) {
 		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var featureIdsIR []string
+	for _, featureIdsI := range o.FeatureIds {
+		featureIdsIS := featureIdsI
+		if featureIdsIS != "" {
+			featureIdsIR = append(featureIdsIR, featureIdsIS)
+		}
+	}
+
+	featureIds := swag.JoinByFormat(featureIdsIR, "multi")
+
+	for _, qsv := range featureIds {
+		qs.Add("feature_ids", qsv)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/restapi/operations/operators/v2_list_bundles.go
+++ b/restapi/operations/operators/v2_list_bundles.go
@@ -32,9 +32,9 @@ func NewV2ListBundles(ctx *middleware.Context, handler V2ListBundlesHandler) *V2
 /*
 	V2ListBundles swagger:route GET /v2/operators/bundles operators v2ListBundles
 
-# Get list of avaliable bundles
+# Get list of available bundles
 
-Retrieves a list of avaliable bundles.
+Retrieves a list of available bundles filtered by support level.
 */
 type V2ListBundles struct {
 	Context *middleware.Context

--- a/restapi/operations/operators/v2_list_bundles_parameters.go
+++ b/restapi/operations/operators/v2_list_bundles_parameters.go
@@ -6,18 +6,29 @@ package operators
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewV2ListBundlesParams creates a new V2ListBundlesParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewV2ListBundlesParams() V2ListBundlesParams {
 
-	return V2ListBundlesParams{}
+	var (
+		// initialize parameters with default values
+
+		cPUArchitectureDefault = string("x86_64")
+	)
+
+	return V2ListBundlesParams{
+		CPUArchitecture: &cPUArchitectureDefault,
+	}
 }
 
 // V2ListBundlesParams contains all the bound params for the v2 list bundles operation
@@ -28,6 +39,29 @@ type V2ListBundlesParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.
+	  In: query
+	  Default: "x86_64"
+	*/
+	CPUArchitecture *string
+	/*External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.
+	  In: query
+	*/
+	ExternalPlatformName *string
+	/*Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+	  In: query
+	  Collection Format: multi
+	*/
+	FeatureIds []string
+	/*Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	  In: query
+	*/
+	OpenshiftVersion *string
+	/*The provider platform type. openshift_version must be set.
+	  In: query
+	*/
+	PlatformType *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -39,8 +73,161 @@ func (o *V2ListBundlesParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qCPUArchitecture, qhkCPUArchitecture, _ := qs.GetOK("cpu_architecture")
+	if err := o.bindCPUArchitecture(qCPUArchitecture, qhkCPUArchitecture, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qExternalPlatformName, qhkExternalPlatformName, _ := qs.GetOK("external_platform_name")
+	if err := o.bindExternalPlatformName(qExternalPlatformName, qhkExternalPlatformName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qFeatureIds, qhkFeatureIds, _ := qs.GetOK("feature_ids")
+	if err := o.bindFeatureIds(qFeatureIds, qhkFeatureIds, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOpenshiftVersion, qhkOpenshiftVersion, _ := qs.GetOK("openshift_version")
+	if err := o.bindOpenshiftVersion(qOpenshiftVersion, qhkOpenshiftVersion, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPlatformType, qhkPlatformType, _ := qs.GetOK("platform_type")
+	if err := o.bindPlatformType(qPlatformType, qhkPlatformType, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindCPUArchitecture binds and validates parameter CPUArchitecture from query.
+func (o *V2ListBundlesParams) bindCPUArchitecture(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewV2ListBundlesParams()
+		return nil
+	}
+	o.CPUArchitecture = &raw
+
+	if err := o.validateCPUArchitecture(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateCPUArchitecture carries on validations for parameter CPUArchitecture
+func (o *V2ListBundlesParams) validateCPUArchitecture(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("cpu_architecture", "query", *o.CPUArchitecture, []interface{}{"x86_64", "aarch64", "arm64", "ppc64le", "s390x", "multi"}, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// bindExternalPlatformName binds and validates parameter ExternalPlatformName from query.
+func (o *V2ListBundlesParams) bindExternalPlatformName(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.ExternalPlatformName = &raw
+
+	return nil
+}
+
+// bindFeatureIds binds and validates array parameter FeatureIds from query.
+//
+// Arrays are parsed according to CollectionFormat: "multi" (defaults to "csv" when empty).
+func (o *V2ListBundlesParams) bindFeatureIds(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	// CollectionFormat: multi
+	featureIdsIC := rawData
+	if len(featureIdsIC) == 0 {
+		return nil
+	}
+
+	var featureIdsIR []string
+	for i, featureIdsIV := range featureIdsIC {
+		featureIdsI := featureIdsIV
+
+		if err := validate.EnumCase(fmt.Sprintf("%s.%v", "feature_ids", i), "query", featureIdsI, []interface{}{"SNO"}, true); err != nil {
+			return err
+		}
+
+		featureIdsIR = append(featureIdsIR, featureIdsI)
+	}
+
+	o.FeatureIds = featureIdsIR
+
+	return nil
+}
+
+// bindOpenshiftVersion binds and validates parameter OpenshiftVersion from query.
+func (o *V2ListBundlesParams) bindOpenshiftVersion(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.OpenshiftVersion = &raw
+
+	return nil
+}
+
+// bindPlatformType binds and validates parameter PlatformType from query.
+func (o *V2ListBundlesParams) bindPlatformType(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.PlatformType = &raw
+
+	if err := o.validatePlatformType(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validatePlatformType carries on validations for parameter PlatformType
+func (o *V2ListBundlesParams) validatePlatformType(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("platform_type", "query", *o.PlatformType, []interface{}{"baremetal", "none", "nutanix", "vsphere", "external"}, true); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/restapi/operations/operators/v2_list_bundles_responses.go
+++ b/restapi/operations/operators/v2_list_bundles_responses.go
@@ -61,6 +61,51 @@ func (o *V2ListBundlesOK) WriteResponse(rw http.ResponseWriter, producer runtime
 	}
 }
 
+// V2ListBundlesBadRequestCode is the HTTP code returned for type V2ListBundlesBadRequest
+const V2ListBundlesBadRequestCode int = 400
+
+/*
+V2ListBundlesBadRequest Error.
+
+swagger:response v2ListBundlesBadRequest
+*/
+type V2ListBundlesBadRequest struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewV2ListBundlesBadRequest creates V2ListBundlesBadRequest with default headers values
+func NewV2ListBundlesBadRequest() *V2ListBundlesBadRequest {
+
+	return &V2ListBundlesBadRequest{}
+}
+
+// WithPayload adds the payload to the v2 list bundles bad request response
+func (o *V2ListBundlesBadRequest) WithPayload(payload *models.Error) *V2ListBundlesBadRequest {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the v2 list bundles bad request response
+func (o *V2ListBundlesBadRequest) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *V2ListBundlesBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(400)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // V2ListBundlesInternalServerErrorCode is the HTTP code returned for type V2ListBundlesInternalServerError
 const V2ListBundlesInternalServerErrorCode int = 500
 

--- a/restapi/operations/operators/v2_list_bundles_urlbuilder.go
+++ b/restapi/operations/operators/v2_list_bundles_urlbuilder.go
@@ -9,11 +9,21 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/swag"
 )
 
 // V2ListBundlesURL generates an URL for the v2 list bundles operation
 type V2ListBundlesURL struct {
+	CPUArchitecture      *string
+	ExternalPlatformName *string
+	FeatureIds           []string
+	OpenshiftVersion     *string
+	PlatformType         *string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -42,6 +52,56 @@ func (o *V2ListBundlesURL) Build() (*url.URL, error) {
 		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var cPUArchitectureQ string
+	if o.CPUArchitecture != nil {
+		cPUArchitectureQ = *o.CPUArchitecture
+	}
+	if cPUArchitectureQ != "" {
+		qs.Set("cpu_architecture", cPUArchitectureQ)
+	}
+
+	var externalPlatformNameQ string
+	if o.ExternalPlatformName != nil {
+		externalPlatformNameQ = *o.ExternalPlatformName
+	}
+	if externalPlatformNameQ != "" {
+		qs.Set("external_platform_name", externalPlatformNameQ)
+	}
+
+	var featureIdsIR []string
+	for _, featureIdsI := range o.FeatureIds {
+		featureIdsIS := featureIdsI
+		if featureIdsIS != "" {
+			featureIdsIR = append(featureIdsIR, featureIdsIS)
+		}
+	}
+
+	featureIds := swag.JoinByFormat(featureIdsIR, "multi")
+
+	for _, qsv := range featureIds {
+		qs.Add("feature_ids", qsv)
+	}
+
+	var openshiftVersionQ string
+	if o.OpenshiftVersion != nil {
+		openshiftVersionQ = *o.OpenshiftVersion
+	}
+	if openshiftVersionQ != "" {
+		qs.Set("openshift_version", openshiftVersionQ)
+	}
+
+	var platformTypeQ string
+	if o.PlatformType != nil {
+		platformTypeQ = *o.PlatformType
+	}
+	if platformTypeQ != "" {
+		qs.Set("platform_type", platformTypeQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2747,9 +2747,39 @@ paths:
     get:
       tags:
         - operators
-      summary: Get list of avaliable bundles 
-      description: Retrieves a list of avaliable bundles.
+      summary: Get list of available bundles 
+      description: Retrieves a list of available bundles filtered by support level.
       operationId: V2ListBundles
+      parameters:
+        - in: query
+          name: openshift_version
+          type: string
+          description: Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+        - in: query
+          name: cpu_architecture
+          description: The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.
+          type: string
+          # TODO: remove arm64 when AI moves to using aarch64
+          enum: [ 'x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi' ]
+          default: x86_64
+        - in: query
+          name: platform_type
+          description: The provider platform type. openshift_version must be set.
+          type: string
+          enum: [ 'baremetal', 'none', 'nutanix', 'vsphere', 'external' ]
+        - in: query
+          name: external_platform_name
+          description: External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.
+          type: string
+        - in: query
+          name: feature_ids
+          description: Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+          type: array
+          items:
+            type: string
+            enum:
+              - 'SNO'
+          collectionFormat: multi
       responses:
         "200":
           description: Success
@@ -2757,6 +2787,10 @@ paths:
             type: array
             items:
               $ref: '#/definitions/bundle'
+        "400":
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         "500":
           description: Internal server error
           schema:
@@ -2767,19 +2801,32 @@ paths:
       tags:
         - operators
       summary: Get operator properties for a bundle
-      description: Retrieves an array of operator properties for the specified bundle.
+      description: Retrieves an array of operator properties for the specified bundle when some features are activated.
       operationId: V2GetBundle
       parameters:
         - in: path
           name: id
-          description: Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
+          description: Identifier of the bundle, for example, `virtualization` or `openshift-ai`.
           required: true
           type: string
+        - in: query
+          name: feature_ids
+          description: Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+          type: array
+          items:
+            type: string
+            enum:
+              - 'SNO'
+          collectionFormat: multi
       responses:
         "200":
           description: Success
           schema:
             $ref: '#/definitions/bundle'
+        "400":
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         "404":
           description: Bundle not found
           schema:

--- a/vendor/github.com/openshift/assisted-service/client/operators/operators_client.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/operators_client.go
@@ -20,12 +20,12 @@ type API interface {
 	/*
 	   V2GetBundle gets operator properties for a bundle
 
-	   Retrieves an array of operator properties for the specified bundle.*/
+	   Retrieves an array of operator properties for the specified bundle when some features are activated.*/
 	V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V2GetBundleOK, error)
 	/*
-	   V2ListBundles gets list of avaliable bundles
+	   V2ListBundles gets list of available bundles
 
-	   Retrieves a list of avaliable bundles.*/
+	   Retrieves a list of available bundles filtered by support level.*/
 	V2ListBundles(ctx context.Context, params *V2ListBundlesParams) (*V2ListBundlesOK, error)
 	/*
 	   V2ListOfClusterOperators Lists operators to be monitored for a cluster.*/
@@ -62,7 +62,7 @@ type Client struct {
 /*
 V2GetBundle gets operator properties for a bundle
 
-Retrieves an array of operator properties for the specified bundle.
+Retrieves an array of operator properties for the specified bundle when some features are activated.
 */
 func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V2GetBundleOK, error) {
 
@@ -87,9 +87,9 @@ func (a *Client) V2GetBundle(ctx context.Context, params *V2GetBundleParams) (*V
 }
 
 /*
-V2ListBundles gets list of avaliable bundles
+V2ListBundles gets list of available bundles
 
-Retrieves a list of avaliable bundles.
+Retrieves a list of available bundles filtered by support level.
 */
 func (a *Client) V2ListBundles(ctx context.Context, params *V2ListBundlesParams) (*V2ListBundlesOK, error) {
 

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2GetBundleParams creates a new V2GetBundleParams object,
@@ -61,9 +62,15 @@ V2GetBundleParams contains all the parameters to send to the API endpoint
 */
 type V2GetBundleParams struct {
 
+	/* FeatureIds.
+
+	   Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+	*/
+	FeatureIds []string
+
 	/* ID.
 
-	   Identifier of the bundle, for example, `virtualization` or `openshift-ai-nvidia`.
+	   Identifier of the bundle, for example, `virtualization` or `openshift-ai`.
 	*/
 	ID string
 
@@ -120,6 +127,17 @@ func (o *V2GetBundleParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithFeatureIds adds the featureIds to the v2 get bundle params
+func (o *V2GetBundleParams) WithFeatureIds(featureIds []string) *V2GetBundleParams {
+	o.SetFeatureIds(featureIds)
+	return o
+}
+
+// SetFeatureIds adds the featureIds to the v2 get bundle params
+func (o *V2GetBundleParams) SetFeatureIds(featureIds []string) {
+	o.FeatureIds = featureIds
+}
+
 // WithID adds the id to the v2 get bundle params
 func (o *V2GetBundleParams) WithID(id string) *V2GetBundleParams {
 	o.SetID(id)
@@ -139,6 +157,17 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 	}
 	var res []error
 
+	if o.FeatureIds != nil {
+
+		// binding items for feature_ids
+		joinedFeatureIds := o.bindParamFeatureIds(reg)
+
+		// query array param feature_ids
+		if err := r.SetQueryParam("feature_ids", joinedFeatureIds...); err != nil {
+			return err
+		}
+	}
+
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
@@ -148,4 +177,21 @@ func (o *V2GetBundleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// bindParamV2GetBundle binds the parameter feature_ids
+func (o *V2GetBundleParams) bindParamFeatureIds(formats strfmt.Registry) []string {
+	featureIdsIR := o.FeatureIds
+
+	var featureIdsIC []string
+	for _, featureIdsIIR := range featureIdsIR { // explode []string
+
+		featureIdsIIV := featureIdsIIR // string as string
+		featureIdsIC = append(featureIdsIC, featureIdsIIV)
+	}
+
+	// items.CollectionFormat: "multi"
+	featureIdsIS := swag.JoinByFormat(featureIdsIC, "multi")
+
+	return featureIdsIS
 }

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_responses.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_get_bundle_responses.go
@@ -29,6 +29,12 @@ func (o *V2GetBundleReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewV2GetBundleBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 404:
 		result := NewV2GetBundleNotFound()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -100,6 +106,69 @@ func (o *V2GetBundleOK) GetPayload() *models.Bundle {
 func (o *V2GetBundleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Bundle)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewV2GetBundleBadRequest creates a V2GetBundleBadRequest with default headers values
+func NewV2GetBundleBadRequest() *V2GetBundleBadRequest {
+	return &V2GetBundleBadRequest{}
+}
+
+/*
+V2GetBundleBadRequest describes a response with status code 400, with default header values.
+
+Error.
+*/
+type V2GetBundleBadRequest struct {
+	Payload *models.Error
+}
+
+// IsSuccess returns true when this v2 get bundle bad request response has a 2xx status code
+func (o *V2GetBundleBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this v2 get bundle bad request response has a 3xx status code
+func (o *V2GetBundleBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this v2 get bundle bad request response has a 4xx status code
+func (o *V2GetBundleBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this v2 get bundle bad request response has a 5xx status code
+func (o *V2GetBundleBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this v2 get bundle bad request response a status code equal to that given
+func (o *V2GetBundleBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
+func (o *V2GetBundleBadRequest) Error() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2GetBundleBadRequest) String() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles/{id}][%d] v2GetBundleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2GetBundleBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *V2GetBundleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2ListBundlesParams creates a new V2ListBundlesParams object,
@@ -60,6 +61,39 @@ V2ListBundlesParams contains all the parameters to send to the API endpoint
 	Typically these are written to a http.Request.
 */
 type V2ListBundlesParams struct {
+
+	/* CPUArchitecture.
+
+	   The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.
+
+	   Default: "x86_64"
+	*/
+	CPUArchitecture *string
+
+	/* ExternalPlatformName.
+
+	   External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external or if openshift_version is not set.
+	*/
+	ExternalPlatformName *string
+
+	/* FeatureIds.
+
+	   Array of feature IDs that affect bundle composition (e.g., ["SNO"] for Single Node OpenShift).
+	*/
+	FeatureIds []string
+
+	/* OpenshiftVersion.
+
+	   Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	*/
+	OpenshiftVersion *string
+
+	/* PlatformType.
+
+	   The provider platform type. openshift_version must be set.
+	*/
+	PlatformType *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -77,7 +111,18 @@ func (o *V2ListBundlesParams) WithDefaults() *V2ListBundlesParams {
 //
 // All values with no default are reset to their zero value.
 func (o *V2ListBundlesParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		cPUArchitectureDefault = string("x86_64")
+	)
+
+	val := V2ListBundlesParams{
+		CPUArchitecture: &cPUArchitectureDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the v2 list bundles params
@@ -113,6 +158,61 @@ func (o *V2ListBundlesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCPUArchitecture adds the cPUArchitecture to the v2 list bundles params
+func (o *V2ListBundlesParams) WithCPUArchitecture(cPUArchitecture *string) *V2ListBundlesParams {
+	o.SetCPUArchitecture(cPUArchitecture)
+	return o
+}
+
+// SetCPUArchitecture adds the cpuArchitecture to the v2 list bundles params
+func (o *V2ListBundlesParams) SetCPUArchitecture(cPUArchitecture *string) {
+	o.CPUArchitecture = cPUArchitecture
+}
+
+// WithExternalPlatformName adds the externalPlatformName to the v2 list bundles params
+func (o *V2ListBundlesParams) WithExternalPlatformName(externalPlatformName *string) *V2ListBundlesParams {
+	o.SetExternalPlatformName(externalPlatformName)
+	return o
+}
+
+// SetExternalPlatformName adds the externalPlatformName to the v2 list bundles params
+func (o *V2ListBundlesParams) SetExternalPlatformName(externalPlatformName *string) {
+	o.ExternalPlatformName = externalPlatformName
+}
+
+// WithFeatureIds adds the featureIds to the v2 list bundles params
+func (o *V2ListBundlesParams) WithFeatureIds(featureIds []string) *V2ListBundlesParams {
+	o.SetFeatureIds(featureIds)
+	return o
+}
+
+// SetFeatureIds adds the featureIds to the v2 list bundles params
+func (o *V2ListBundlesParams) SetFeatureIds(featureIds []string) {
+	o.FeatureIds = featureIds
+}
+
+// WithOpenshiftVersion adds the openshiftVersion to the v2 list bundles params
+func (o *V2ListBundlesParams) WithOpenshiftVersion(openshiftVersion *string) *V2ListBundlesParams {
+	o.SetOpenshiftVersion(openshiftVersion)
+	return o
+}
+
+// SetOpenshiftVersion adds the openshiftVersion to the v2 list bundles params
+func (o *V2ListBundlesParams) SetOpenshiftVersion(openshiftVersion *string) {
+	o.OpenshiftVersion = openshiftVersion
+}
+
+// WithPlatformType adds the platformType to the v2 list bundles params
+func (o *V2ListBundlesParams) WithPlatformType(platformType *string) *V2ListBundlesParams {
+	o.SetPlatformType(platformType)
+	return o
+}
+
+// SetPlatformType adds the platformType to the v2 list bundles params
+func (o *V2ListBundlesParams) SetPlatformType(platformType *string) {
+	o.PlatformType = platformType
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2ListBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -121,8 +221,104 @@ func (o *V2ListBundlesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 	var res []error
 
+	if o.CPUArchitecture != nil {
+
+		// query param cpu_architecture
+		var qrCPUArchitecture string
+
+		if o.CPUArchitecture != nil {
+			qrCPUArchitecture = *o.CPUArchitecture
+		}
+		qCPUArchitecture := qrCPUArchitecture
+		if qCPUArchitecture != "" {
+
+			if err := r.SetQueryParam("cpu_architecture", qCPUArchitecture); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.ExternalPlatformName != nil {
+
+		// query param external_platform_name
+		var qrExternalPlatformName string
+
+		if o.ExternalPlatformName != nil {
+			qrExternalPlatformName = *o.ExternalPlatformName
+		}
+		qExternalPlatformName := qrExternalPlatformName
+		if qExternalPlatformName != "" {
+
+			if err := r.SetQueryParam("external_platform_name", qExternalPlatformName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FeatureIds != nil {
+
+		// binding items for feature_ids
+		joinedFeatureIds := o.bindParamFeatureIds(reg)
+
+		// query array param feature_ids
+		if err := r.SetQueryParam("feature_ids", joinedFeatureIds...); err != nil {
+			return err
+		}
+	}
+
+	if o.OpenshiftVersion != nil {
+
+		// query param openshift_version
+		var qrOpenshiftVersion string
+
+		if o.OpenshiftVersion != nil {
+			qrOpenshiftVersion = *o.OpenshiftVersion
+		}
+		qOpenshiftVersion := qrOpenshiftVersion
+		if qOpenshiftVersion != "" {
+
+			if err := r.SetQueryParam("openshift_version", qOpenshiftVersion); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.PlatformType != nil {
+
+		// query param platform_type
+		var qrPlatformType string
+
+		if o.PlatformType != nil {
+			qrPlatformType = *o.PlatformType
+		}
+		qPlatformType := qrPlatformType
+		if qPlatformType != "" {
+
+			if err := r.SetQueryParam("platform_type", qPlatformType); err != nil {
+				return err
+			}
+		}
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// bindParamV2ListBundles binds the parameter feature_ids
+func (o *V2ListBundlesParams) bindParamFeatureIds(formats strfmt.Registry) []string {
+	featureIdsIR := o.FeatureIds
+
+	var featureIdsIC []string
+	for _, featureIdsIIR := range featureIdsIR { // explode []string
+
+		featureIdsIIV := featureIdsIIR // string as string
+		featureIdsIC = append(featureIdsIC, featureIdsIIV)
+	}
+
+	// items.CollectionFormat: "multi"
+	featureIdsIS := swag.JoinByFormat(featureIdsIC, "multi")
+
+	return featureIdsIS
 }

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_responses.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_responses.go
@@ -29,6 +29,12 @@ func (o *V2ListBundlesReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewV2ListBundlesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewV2ListBundlesInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -95,6 +101,69 @@ func (o *V2ListBundlesOK) readResponse(response runtime.ClientResponse, consumer
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewV2ListBundlesBadRequest creates a V2ListBundlesBadRequest with default headers values
+func NewV2ListBundlesBadRequest() *V2ListBundlesBadRequest {
+	return &V2ListBundlesBadRequest{}
+}
+
+/*
+V2ListBundlesBadRequest describes a response with status code 400, with default header values.
+
+Error.
+*/
+type V2ListBundlesBadRequest struct {
+	Payload *models.Error
+}
+
+// IsSuccess returns true when this v2 list bundles bad request response has a 2xx status code
+func (o *V2ListBundlesBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this v2 list bundles bad request response has a 3xx status code
+func (o *V2ListBundlesBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this v2 list bundles bad request response has a 4xx status code
+func (o *V2ListBundlesBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this v2 list bundles bad request response has a 5xx status code
+func (o *V2ListBundlesBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this v2 list bundles bad request response a status code equal to that given
+func (o *V2ListBundlesBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
+func (o *V2ListBundlesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles][%d] v2ListBundlesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2ListBundlesBadRequest) String() string {
+	return fmt.Sprintf("[GET /v2/operators/bundles][%d] v2ListBundlesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *V2ListBundlesBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *V2ListBundlesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 


### PR DESCRIPTION
As of today openshift-ai bundle operator composition is static but it should depend on if the cluster is SNO or MNO. This PR introduces changes in the bundle routes to be able to return the right bundle list based on the cluster spec.

It might happen that because of some spec (cpu architecture, version, ...) , an operator in a bundle is not supported. In this case, the whole bundle is not returned by ListBundle

This introduces a API breaking change (a new parameter, openshift_version, is now mandatory) so front and back must be synced while being deployed.

cc @ammont82 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
