### PR TITLE
ACM-25137: Remove the SERVICE_EL8_IMAGE env vars

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,6 @@ spec:
         env:
           - name: SERVICE_IMAGE
             value: quay.io/edge-infrastructure/assisted-service:latest
-          - name: SERVICE_EL8_IMAGE
-            value: quay.io/edge-infrastructure/assisted-service-el8:latest
           - name: IMAGE_SERVICE_IMAGE
             value: quay.io/edge-infrastructure/assisted-image-service:latest
           - name: DATABASE_IMAGE

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -1142,8 +1142,6 @@ spec:
                 env:
                 - name: SERVICE_IMAGE
                   value: quay.io/edge-infrastructure/assisted-service:latest
-                - name: SERVICE_EL8_IMAGE
-                  value: quay.io/edge-infrastructure/assisted-service-el8:latest
                 - name: IMAGE_SERVICE_IMAGE
                   value: quay.io/edge-infrastructure/assisted-image-service:latest
                 - name: DATABASE_IMAGE

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -2268,19 +2268,7 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 		Expect(found.Spec.Template.Spec.Containers[0].Image).To(Equal("quay.io/edge-infrastructure/assisted-service:latest"))
 	})
 
-	It("deploys the default image when the base image annotation is set to el8 (since 'el8' is removed)", func() {
-		asc = newASCDefault()
-		setAnnotation(&asc.ObjectMeta, serviceImageBaseAnnotation, serviceImageBaseEL8)
-		ascr = newTestReconciler(asc, route, assistedCM, assistedTrustedCM)
-		ascc = initASC(ascr, asc)
-		AssertReconcileSuccess(ctx, log, ascc, newAssistedServiceDeployment)
-
-		found := &appsv1.Deployment{}
-		Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
-		Expect(found.Spec.Template.Spec.Containers[0].Image).To(Equal("quay.io/edge-infrastructure/assisted-service:latest"))
-	})
-
-	It("deploys the default image when the base image annotation is set to any value other than el8", func() {
+	It("deploys the default image when the base image annotation is set to any value", func() {
 		asc = newASCDefault()
 		setAnnotation(&asc.ObjectMeta, serviceImageBaseAnnotation, "el10")
 		ascr = newTestReconciler(asc, route, assistedCM, assistedTrustedCM)

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -23,25 +23,17 @@ import (
 )
 
 const (
-	OsImagesEnvVar             string = "OS_IMAGES"
+	OsImagesEnvVar string = "OS_IMAGES"
+	// leaving this here to ensure it's consistent with the previous implementation if/when it is needed for el9/10
 	serviceImageBaseAnnotation string = "agent-install.openshift.io/service-image-base"
-	serviceImageBaseEL8        string = "el8"
 )
 
 func ServiceImage(asc client.Object) string {
-	val, ok := asc.GetAnnotations()[serviceImageBaseAnnotation]
-	if ok && val == serviceImageBaseEL8 {
-		return serviceImageEL8()
-	}
 	return serviceImageDefault()
 }
 
 func serviceImageDefault() string {
 	return getEnvVar("SERVICE_IMAGE", "quay.io/edge-infrastructure/assisted-service:latest")
-}
-
-func serviceImageEL8() string {
-	return getEnvVar("SERVICE_EL8_IMAGE", "quay.io/edge-infrastructure/assisted-service:latest")
 }
 
 func ImageServiceImage() string {


### PR DESCRIPTION
These were causing issues with the MCE installer build automation since the image has been removed

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/ACM-25137

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
