### PR TITLE
MGMT-19836: Add ClusterID field on HostRoleUpdatedEvent

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -285,6 +285,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -2605,6 +2605,7 @@ func (e *HostStageTimedOutEvent) FormatMessage() string {
 //
 type HostRoleUpdatedEvent struct {
     eventName string
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2614,6 +2615,7 @@ type HostRoleUpdatedEvent struct {
 var HostRoleUpdatedEventName string = "host_role_updated"
 
 func NewHostRoleUpdatedEvent(
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2621,6 +2623,7 @@ func NewHostRoleUpdatedEvent(
 ) *HostRoleUpdatedEvent {
     return &HostRoleUpdatedEvent{
         eventName: HostRoleUpdatedEventName,
+        ClusterId: clusterId,
         HostId: hostId,
         InfraEnvId: infraEnvId,
         HostName: hostName,
@@ -2631,11 +2634,13 @@ func NewHostRoleUpdatedEvent(
 func SendHostRoleUpdatedEvent(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
     suggestedRole string,) {
     ev := NewHostRoleUpdatedEvent(
+        clusterId,
         hostId,
         infraEnvId,
         hostName,
@@ -2647,12 +2652,14 @@ func SendHostRoleUpdatedEvent(
 func SendHostRoleUpdatedEventAtTime(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
     suggestedRole string,
     eventTime time.Time) {
     ev := NewHostRoleUpdatedEvent(
+        clusterId,
         hostId,
         infraEnvId,
         hostName,
@@ -2669,7 +2676,7 @@ func (e *HostRoleUpdatedEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostRoleUpdatedEvent) GetClusterId() *strfmt.UUID {
-    return nil
+    return e.ClusterId
 }
 func (e *HostRoleUpdatedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2682,6 +2689,7 @@ func (e *HostRoleUpdatedEvent) GetInfraEnvId() strfmt.UUID {
 
 func (e *HostRoleUpdatedEvent) format(message *string) string {
     r := strings.NewReplacer(
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{host_id}", fmt.Sprint(e.HostId),
         "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
         "{host_name}", fmt.Sprint(e.HostName),

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -446,7 +446,7 @@ func (m *Manager) refreshRoleInternal(ctx context.Context, h *models.Host, db *g
 					if err = updateRole(m.log, h, h.Role, suggestedRole, db, string(h.Role)); err == nil {
 						h.SuggestedRole = suggestedRole
 						m.log.Infof("suggested role for host %s is %s", *h.ID, suggestedRole)
-						eventgen.SendHostRoleUpdatedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, hostutil.GetHostnameForMsg(h), string(suggestedRole))
+						eventgen.SendHostRoleUpdatedEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID, h.InfraEnvID, hostutil.GetHostnameForMsg(h), string(suggestedRole))
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Without ClusterID field, the events are discarded by assisted-events-streams and not indexed

According to cursor, here is the list of events that didn't include a ClusterID field as well

- HostRoleUpdatedEvent
- InfraEnvRegistrationFailedEvent
- InfraEnvRegisteredEvent
- InfraEnvDeregisterFailedEvent
- InfraEnvDeregisteredEvent
- GenerateImageFetchFailedEvent
- ExistingImageReusedEvent
- HostDiscoveryIgnitionConfigAppliedEvent
- HostResetFetchFailedEvent
- HostApprovedUpdatedEvent
- HostUnbindSucceededEvent
- GenerateImageFormatFailedEvent
- GenerateMinimalIsoFailedEvent
- UploadImageFailedEvent
- IgnitionConfigImageGeneratedEvent
- HostUnbindFailedEvent

I think it's ok/expected not to have the clusterID on the others. The value might exist sometime, but do we want to put it ? Let me know what you think

In term of volumetry, HostRoleUpdatedEvent are the most common, followed by InfraEnvDeregisteredEvent/InfraEnvRegisteredEvent 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
