### PR TITLE
MGMT-22186: Add kata runtime class to Assisted installer

### DIFF
--- a/internal/operators/osc/manifest_test.go
+++ b/internal/operators/osc/manifest_test.go
@@ -24,20 +24,21 @@ var _ = Describe("OSC manifest generation", func() {
 	Context("OSC manifest", func() {
 		It("Check YAMLs of OSC", func() {
 			cluster = getCluster("4.17.0")
-			openshiftManifests, manifest, err := operator.GenerateManifests(cluster)
+			openshiftManifests, customManifest, err := operator.GenerateManifests(cluster)
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(openshiftManifests).To(HaveLen(3))
 			Expect(openshiftManifests["50_openshift-osc_ns.yaml"]).NotTo(HaveLen(0))
 			Expect(openshiftManifests["50_openshift-osc_subscription.yaml"]).NotTo(HaveLen(0))
 			Expect(openshiftManifests["50_openshift-osc_operator_group.yaml"]).NotTo(HaveLen(0))
+			Expect(string(customManifest)).To(ContainSubstring("KataConfig"))
 
 			for _, manifest := range openshiftManifests {
 				_, err = yaml.YAMLToJSON(manifest)
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 
-			_, err = yaml.YAMLToJSON(manifest)
+			_, err = yaml.YAMLToJSON(customManifest)
 			Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("yamltojson err: %v", err))
 		})
 
@@ -64,6 +65,13 @@ var _ = Describe("OSC manifest generation", func() {
 			Expect(err).To(BeNil())
 
 			Expect(extractData(opData, "metadata.namespace")).To(Equal(Namespace))
+		})
+
+		It("Check kata runtime customManifest", func() {
+			kataData, err := generateCustomManifests(Namespace)
+			Expect(err).To(BeNil())
+
+			Expect(extractData(kataData, "metadata.namespace")).To(Equal(Namespace))
 		})
 
 	})


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

**How to test:**

1. Selected osc operator in UI

2. check osc operator

#oc get operators
NAME                                                              AGE
sandboxed-containers-operator.openshift-sandboxed-containers-op   108m

3. check kata runtimeclass
#oc get runtimeclass
NAME   HANDLER   AGE
kata   kata      76m

4. start a kata container with kata runtimeclass
 #oc apply -f kata-pod.yaml

#cat kata-pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-pod
  namespace: default
spec:
  runtimeClassName: kata
  containers:
  - image: quay.io/prometheus/busybox
    name: busybox
    resources: {}
    command: ["sleep", "infinity"]
    dns_search: []
    securityContext:
      privileged: true

5. check pod status
 #oc get pods
NAME       READY   STATUS    RESTARTS   AGE
kata-pod   1/1     Running   0          101s