### PR TITLE
ACM-25980: Introduce PreprovisioningImage finalizer

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -48,13 +48,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type imageConditionReason string
 
-const archMismatchReason = "InfraEnvArchMismatch"
+const (
+	archMismatchReason                = "InfraEnvArchMismatch"
+	PreprovisioningImageFinalizerName = "preprovisioningimage." + aiv1beta1.Group + "/ai-deprovision"
+)
 
 type PreprovisioningImageControllerConfig struct {
 	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
@@ -105,6 +109,15 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	if !image.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.handlePreprovisioningImageDeletion(ctx, log, image)
+	}
+
+	if !funk.ContainsString(image.GetFinalizers(), PreprovisioningImageFinalizerName) {
+		return r.ensurePreprovisioningImageFinalizer(ctx, log, image)
+	}
+
 	if !funk.Some(image.Spec.AcceptFormats, metal3_v1alpha1.ImageFormatISO, metal3_v1alpha1.ImageFormatInitRD) {
 		// Currently, the PreprovisioningImageController only support ISO and InitRD image
 		log.Infof("Unsupported image format: %s", image.Spec.AcceptFormats)
@@ -115,7 +128,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		}
 		return ctrl.Result{}, err
 	}
-	// Consider adding finalizer in case we need to clean up resources
+
 	// Retrieve InfraEnv
 	infraEnv, err := r.findInfraEnvForPreprovisioningImage(ctx, log, image)
 	if err != nil {
@@ -710,6 +723,58 @@ func (r *PreprovisioningImageReconciler) setBMHRebootAnnotation(ctx context.Cont
 	}
 
 	return nil
+}
+
+// ensurePreprovisioningImageFinalizer adds a finalizer to the PreprovisioningImage
+func (r *PreprovisioningImageReconciler) ensurePreprovisioningImageFinalizer(ctx context.Context, log logrus.FieldLogger, image *metal3_v1alpha1.PreprovisioningImage) (ctrl.Result, error) {
+	controllerutil.AddFinalizer(image, PreprovisioningImageFinalizerName)
+	if err := r.Update(ctx, image); err != nil {
+		log.WithError(err).Errorf("failed to add finalizer %s to PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// handlePreprovisioningImageDeletion handles the deletion of a PreprovisioningImage by checking if any BMHs
+// with automated cleaning enabled still reference it.
+func (r *PreprovisioningImageReconciler) handlePreprovisioningImageDeletion(ctx context.Context, log logrus.FieldLogger, image *metal3_v1alpha1.PreprovisioningImage) (ctrl.Result, error) {
+	if !funk.ContainsString(image.GetFinalizers(), PreprovisioningImageFinalizerName) {
+		// Allow deletion of the PreprovisioningImage if the finalizer is not present
+		return ctrl.Result{}, nil
+	}
+
+	// Get the BMH that owns this PreprovisioningImage
+	bmh, err := r.getBMH(ctx, image)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil || strings.Contains(err.Error(), "failed to find BMH owner") {
+			// BMH not found or this preprovisioningimage is not owned by a BMH, allow deletion of the PreprovisioningImage
+			log.Info("BMH not found, removing PreprovisioningImage finalizer")
+			controllerutil.RemoveFinalizer(image, PreprovisioningImageFinalizerName)
+			if err = r.Update(ctx, image); err != nil {
+				log.WithError(err).Errorf("failed to remove finalizer %s from PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+				return ctrl.Result{Requeue: true}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		log.WithError(err).Error("failed to get BMH for PreprovisioningImage")
+		return ctrl.Result{RequeueAfter: longerRequeueAfterOnError}, err
+	}
+
+	// PreprovisioningImage should wait for a BMH with automated cleaning enabled to be deleted
+	if bmh.Spec.AutomatedCleaningMode != metal3_v1alpha1.CleaningModeDisabled {
+		log.Infof("Cannot delete PreprovisioningImage yet: BMH %s/%s with automatedCleaningMode=%s exists and requires the image for deprovisioning",
+			bmh.Namespace, bmh.Name, bmh.Spec.AutomatedCleaningMode)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Safe to delete, remove finalizer
+	log.Info("Removing finalizer from PreprovisioningImage")
+	controllerutil.RemoveFinalizer(image, PreprovisioningImageFinalizerName)
+	if err := r.Update(ctx, image); err != nil {
+		log.WithError(err).Errorf("failed to remove finalizer %s from PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // processMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap


### PR DESCRIPTION
There is one case where a PreprovisioningImage should not be deleted before its associated BMH. This happens when the BMH has automatedCleaningMode set to metadata (enabled) and is being deleted. The PreprovisioningImage is required during deprovisioning since it contains the Ironic Python Agent (IPA) which is used to erase the disk of the host.

In this specific case, we should not allow a PreprovisioningImage to be removed before the BMH is removed. The finalizer is added to all PreprovisioningImage CRs we manage, and will be removed on deletion of the PreprovisioningImage unless the case above is occuring.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): see below
- [ ] No tests needed

### Manual testing steps
1. Reproduced the issue: Create a SNO cluster with BMH in the same ns as the cluster resources, once the host is almost installed (ACI is finalizing), delete the full ns `oc delete ns test-sno-cluster` and observe that the BMH is stuck deprovisioning and the metal3-bmo pod shows an error creating the preprovisioningimage
2. Deploy image with these changes and reproduce the situation that caused the issue
3. During deletion, the BMH goes to deprovision and the preprovisioningimage is still there
4. Observe everything get deleted and removed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
