### PR TITLE
MGMT-22078: Add readOnlyRootFilesystem to assisted-service template

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,6 +58,7 @@ spec:
                 fieldPath: metadata.name
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -28,6 +28,8 @@ items:
                 cpu: 100m
                 memory: 400Mi
             image: REPLACE_IMAGE_SERVICE_IMAGE
+            securityContext:
+              readOnlyRootFilesystem: true
             ports:
               - containerPort: 8080
             readinessProbe:
@@ -56,10 +58,16 @@ items:
                 value: REPLACE_IMAGE_SERVICE_BASE_URL
               - name: ALLOWED_DOMAINS
                 value: "*"
+              - name: DATA_TEMP_DIR
+                value: "/data_temp"
             volumeMounts:
               - mountPath: /data
                 name: image-service-data
+              - mountPath: /data_temp
+                name: data-temp-volume
         serviceAccountName: assisted-service
         volumes:
          - emptyDir: {}
            name: image-service-data
+         - emptyDir: {}
+           name: data-temp-volume

--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -24,6 +24,8 @@ spec:
               memory: 400Mi
           image: REPLACE_IMAGE
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 8090
           livenessProbe:
@@ -40,6 +42,8 @@ spec:
             - configMapRef:
                 name: assisted-service-config
           env:
+            - name: TMPDIR
+              value: /data
             - name: KAFKA_BOOTSTRAP_SERVER
               value: "ai-kafka-0.ai-kafka-headless.assisted-installer.svc.cluster.local:9092"
             - name: KAFKA_EVENT_STREAM_TOPIC
@@ -143,12 +147,16 @@ spec:
             - name: mirror-registry-conf
               mountPath: "/etc/containers"
               readOnly: true
+            - name: workdir-volume
+              mountPath: /data
       serviceAccountName: assisted-service
       volumes:
         - name: route53-creds
           secret:
             secretName: route53-creds
             optional: true
+        - name: workdir-volume
+          emptyDir: {}
         - name: mirror-registry-ca
           configMap:
             name: mirror-registry-ca

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -1186,6 +1186,7 @@ spec:
                     memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
               serviceAccountName: assisted-service
               terminationGracePeriodSeconds: 10
       permissions:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -254,6 +254,8 @@ objects:
           - name: envoy-sidecar
             image: ${ENVOY_IMAGE}:${ENVOY_TAG}
             imagePullPolicy: IfNotPresent
+            securityContext:
+              readOnlyRootFilesystem: true
             command:
             - envoy
             - --config-path
@@ -288,6 +290,8 @@ objects:
           - name: assisted-service
             image: ${ASSISTED_SERVICE_IMAGE}:${IMAGE_TAG}
             imagePullPolicy: Always
+            securityContext:
+              readOnlyRootFilesystem: true
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -512,6 +516,8 @@ objects:
                 value: ${AMD_SUPPORTED_GPUS}
               - name: TNA_CLUSTERS_SUPPORT
                 value: ${TNA_CLUSTERS_SUPPORT}
+              - name: TMPDIR
+                value: /data
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
Add `readOnlyRootFilesystem: true` to container specs in the assisted-service to comply with OpenShift security and hardening guidelines.

Applied across all relevant configurations (CI, SaaS, and ACM) to ensure consistent security behavior in every deployment environment.

Containers that cannot support a read-only root filesystem include a clear technical justification.
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
