### PR TITLE
MGMT-22052: Allow single API and Ingress VIPs in dual-stack with IPv6 primary

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -301,33 +301,38 @@ func NewBareMetalInventory(
 	}
 }
 
-func (b *bareMetalInventory) setPrimaryIPStack(cluster *common.Cluster) error {
+func (b *bareMetalInventory) getPrimaryIPStack(machineNetworks []*models.MachineNetwork,
+	apiVips []*models.APIVip,
+	ingressVips []*models.IngressVip,
+	serviceNetworks []*models.ServiceNetwork,
+	clusterNetworks []*models.ClusterNetwork) (*common.PrimaryIPStack, error) {
 	// Only for dual-stack clusters
-	if !network.CheckIfClusterIsDualStack(cluster) {
-		cluster.PrimaryIPStack = nil
-		return nil
+	if !network.CheckIfNetworksAreDualStack(machineNetworks, serviceNetworks, clusterNetworks) {
+		return nil, nil
 	}
 
-	// get primary IP stack based on current network configuration
-	primaryStack, err := network.GetPrimaryIPStack(
-		cluster.MachineNetworks,
-		cluster.APIVips,
-		cluster.IngressVips,
-		cluster.ServiceNetworks,
-		cluster.ClusterNetworks,
+	// compute primary IP stack based on current network configuration
+	primaryStack, err := network.ComputePrimaryIPStack(
+		machineNetworks,
+		apiVips,
+		ingressVips,
+		serviceNetworks,
+		clusterNetworks,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	cluster.PrimaryIPStack = primaryStack
+	return primaryStack, nil
+}
 
-	return nil
+func (b *bareMetalInventory) setPrimaryIPStack(cluster *common.Cluster, primaryStack *common.PrimaryIPStack) {
+	cluster.PrimaryIPStack = primaryStack
 }
 
 // updatePrimaryIPStack handles primary IP stack validation and calculation for network changes
 // Returns true if PrimaryIPStack was updated, false otherwise
-func (b *bareMetalInventory) updatePrimaryIPStack(params installer.V2UpdateClusterParams, cluster *common.Cluster) (bool, error) {
+func (b *bareMetalInventory) updatePrimaryIPStack(params installer.V2UpdateClusterParams, cluster *common.Cluster) (bool, *common.PrimaryIPStack, error) {
 	// Only set primary IP stack if any networks or VIPs were actually updated
 	primaryIPStackNeedsUpdate := params.ClusterUpdateParams.ClusterNetworks != nil ||
 		params.ClusterUpdateParams.ServiceNetworks != nil ||
@@ -336,7 +341,7 @@ func (b *bareMetalInventory) updatePrimaryIPStack(params installer.V2UpdateClust
 		params.ClusterUpdateParams.IngressVips != nil
 
 	if !primaryIPStackNeedsUpdate {
-		return false, nil
+		return false, cluster.PrimaryIPStack, nil
 	}
 
 	if (params.ClusterUpdateParams.ClusterNetworks != nil &&
@@ -345,12 +350,14 @@ func (b *bareMetalInventory) updatePrimaryIPStack(params installer.V2UpdateClust
 		params.ClusterUpdateParams.APIVips != nil &&
 		params.ClusterUpdateParams.IngressVips != nil) || cluster.PrimaryIPStack == nil {
 		// Recalculate from scratch for full updates or new clusters
-		err := b.setPrimaryIPStack(cluster)
+
+		primaryIPStack, err := b.getPrimaryIPStack(params.ClusterUpdateParams.MachineNetworks, params.ClusterUpdateParams.APIVips, params.ClusterUpdateParams.IngressVips, params.ClusterUpdateParams.ServiceNetworks, params.ClusterUpdateParams.ClusterNetworks)
 		if err != nil {
 			b.log.WithError(err).Errorf("cluster update failed: unable to set primary IP stack")
-			return false, common.NewApiError(http.StatusBadRequest, err)
+			return false, cluster.PrimaryIPStack, common.NewApiError(http.StatusBadRequest, err)
 		}
-		return true, nil // PrimaryIPStack was updated
+
+		return true, primaryIPStack, nil // PrimaryIPStack was updated
 	}
 
 	// For partial updates, validate against existing PrimaryIPStack
@@ -364,10 +371,10 @@ func (b *bareMetalInventory) updatePrimaryIPStack(params installer.V2UpdateClust
 	)
 	if err != nil {
 		b.log.WithError(err).Errorf("cluster update failed: partial update inconsistent with existing primary IP stack")
-		return false, common.NewApiError(http.StatusBadRequest, err)
+		return false, cluster.PrimaryIPStack, common.NewApiError(http.StatusBadRequest, err)
 	}
 	// Keep existing PrimaryIPStack - no update needed
-	return false, nil
+	return false, cluster.PrimaryIPStack, nil
 }
 
 func (b *bareMetalInventory) ValidatePullSecret(additionalPublicRegistries []string, secret string, username string, releaseImageURL string) error {
@@ -599,14 +606,14 @@ func MarshalNewClusterParamsNoPullSecret(params installer.V2RegisterClusterParam
 	return jsonNewClusterParams
 }
 
-func (b *bareMetalInventory) validateRegisterClusterInternalPreDefaultValuesSet(params installer.V2RegisterClusterParams, id strfmt.UUID, ctx context.Context) error {
+func (b *bareMetalInventory) validateRegisterClusterInternalPreDefaultValuesSet(params installer.V2RegisterClusterParams, id strfmt.UUID, ctx context.Context, primaryIPStack *common.PrimaryIPStack) error {
 	params.NewClusterParams.HighAvailabilityMode, params.NewClusterParams.ControlPlaneCount = common.GetDefaultHighAvailabilityAndMasterCountParams(
 		params.NewClusterParams.HighAvailabilityMode, params.NewClusterParams.ControlPlaneCount,
 	)
 	if err := b.validateHighAvailabilityWithControlPlaneCount(*params.NewClusterParams.HighAvailabilityMode, *params.NewClusterParams.ControlPlaneCount, *params.NewClusterParams.OpenshiftVersion); err != nil {
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
-	if err := validations.ValidateClusterCreateIPAddresses(b.IPv6Support, id, params.NewClusterParams); err != nil {
+	if err := validations.ValidateClusterCreateIPAddresses(b.IPv6Support, id, params.NewClusterParams, primaryIPStack); err != nil {
 		b.log.WithError(err).Error("Cannot register cluster. Failed VIP validations")
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
@@ -650,7 +657,14 @@ func (b *bareMetalInventory) RegisterClusterInternal(ctx context.Context, kubeKe
 		}
 	}()
 
-	if err = b.validateRegisterClusterInternalPreDefaultValuesSet(params, id, ctx); err != nil {
+	// initial computation of PrimaryIPStack (needed for validations, will be recomputed later)
+	primaryIPStack, err := b.getPrimaryIPStack(params.NewClusterParams.MachineNetworks, params.NewClusterParams.APIVips, params.NewClusterParams.IngressVips, params.NewClusterParams.ServiceNetworks, params.NewClusterParams.ClusterNetworks)
+	if err != nil {
+		b.log.Debugf("cluster registration failed: unable to compute primary IP stack: %v", err)
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
+	if err = b.validateRegisterClusterInternalPreDefaultValuesSet(params, id, ctx, primaryIPStack); err != nil {
 		return nil, err
 	}
 
@@ -740,11 +754,14 @@ func (b *bareMetalInventory) RegisterClusterInternal(ctx context.Context, kubeKe
 		MachineNetworkCidrUpdatedAt: time.Now(),
 	}
 
-	err = b.setPrimaryIPStack(cluster)
+	// recompute PrimaryIPStack after cluster and service network defaults are applied
+	primaryIPStack, err = b.getPrimaryIPStack(params.NewClusterParams.MachineNetworks, params.NewClusterParams.APIVips, params.NewClusterParams.IngressVips, params.NewClusterParams.ServiceNetworks, params.NewClusterParams.ClusterNetworks)
 	if err != nil {
-		b.log.Debugf("cluster registration failed: unable to set primary IP stack: %v", err)
+		b.log.Debugf("cluster registration failed: unable to compute primary IP stack: %v", err)
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
+
+	b.setPrimaryIPStack(cluster, primaryIPStack)
 
 	if err = cluster.SetMirrorRegistryConfiguration(mirrorRegistryConfiguration); err != nil {
 		return nil, err
@@ -2018,7 +2035,7 @@ func (b *bareMetalInventory) v2NoneHaModeClusterUpdateValidations(cluster *commo
 	return nil
 }
 
-func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context, cluster *common.Cluster, params *installer.V2UpdateClusterParams) (installer.V2UpdateClusterParams, error) {
+func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context, cluster *common.Cluster, params *installer.V2UpdateClusterParams, primaryIPStack *common.PrimaryIPStack) (installer.V2UpdateClusterParams, error) {
 	log := logutil.FromContext(ctx, b.log)
 
 	// We don't want to update ControlPlaneCount in day2 clusters as we don't know the previous hosts
@@ -2062,7 +2079,7 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 		}
 	}
 
-	if err := validations.ValidateClusterUpdateVIPAddresses(b.IPv6Support, cluster, params.ClusterUpdateParams); err != nil {
+	if err := validations.ValidateClusterUpdateVIPAddresses(b.IPv6Support, cluster, params.ClusterUpdateParams, primaryIPStack); err != nil {
 		b.log.WithError(err).Errorf("Cluster %s failed VIP validations", params.ClusterID)
 		return installer.V2UpdateClusterParams{}, err
 
@@ -2168,9 +2185,10 @@ func (b *bareMetalInventory) validateUpdateCluster(
 	log logrus.FieldLogger,
 	cluster *common.Cluster,
 	params installer.V2UpdateClusterParams,
+	primaryIPStack *common.PrimaryIPStack,
 ) (installer.V2UpdateClusterParams, error) {
 	var err error
-	if params, err = b.validateAndUpdateClusterParams(ctx, cluster, &params); err != nil {
+	if params, err = b.validateAndUpdateClusterParams(ctx, cluster, &params, primaryIPStack); err != nil {
 		return params, common.NewApiError(http.StatusBadRequest, err)
 	}
 	alreadyDualStack := network.CheckIfClusterIsDualStack(cluster)
@@ -2247,6 +2265,8 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 	log := logutil.FromContext(ctx, b.log)
 	var cluster *common.Cluster
 	var err error
+	var primaryIPStackUpdated bool
+	var primaryIPStack *common.PrimaryIPStack
 	log.Infof("update cluster %s with params: %+v", params.ClusterID, params.ClusterUpdateParams)
 
 	err = b.db.Transaction(func(tx *gorm.DB) error {
@@ -2256,7 +2276,14 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 			return common.NewApiError(http.StatusNotFound, err)
 		}
 
-		params, err = b.validateUpdateCluster(ctx, log, cluster, params)
+		// compute PrimaryIPStack before validations (it’s needed by some validations)
+		// if the value changed, we set the updated PrimaryIPStack to the cluster object and to the DB later in updateClusterData.
+		primaryIPStackUpdated, primaryIPStack, err = b.updatePrimaryIPStack(params, cluster)
+		if err != nil {
+			return err
+		}
+
+		params, err = b.validateUpdateCluster(ctx, log, cluster, params, primaryIPStack)
 		if err != nil {
 			return err
 		}
@@ -2268,7 +2295,7 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 			return err
 		}
 
-		err = b.updateClusterData(ctx, cluster, params, usages, tx, log, interactivity, mirrorRegistryConfiguration)
+		err = b.updateClusterData(ctx, cluster, params, usages, tx, log, interactivity, mirrorRegistryConfiguration, primaryIPStackUpdated, primaryIPStack)
 		if err != nil {
 			log.WithError(err).Error("updateClusterData")
 			return err
@@ -2578,7 +2605,7 @@ func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncry
 	b.setUsage(swag.StringValue(c.DiskEncryption.EnableOn) != models.DiskEncryptionEnableOnNone, usage.DiskEncryption, &props, usages)
 }
 
-func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *common.Cluster, params installer.V2UpdateClusterParams, usages map[string]models.Usage, db *gorm.DB, log logrus.FieldLogger, interactivity Interactivity, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) error {
+func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *common.Cluster, params installer.V2UpdateClusterParams, usages map[string]models.Usage, db *gorm.DB, log logrus.FieldLogger, interactivity Interactivity, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration, primaryIPStackUpdated bool, primaryIPStack *common.PrimaryIPStack) error {
 	var err error
 	updates := map[string]interface{}{}
 	optionalParam(params.ClusterUpdateParams.Name, "name", updates)
@@ -2678,6 +2705,16 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 
 	if params.ClusterUpdateParams.ControlPlaneCount != nil && *params.ClusterUpdateParams.ControlPlaneCount != cluster.ControlPlaneCount {
 		updates["control_plane_count"] = *params.ClusterUpdateParams.ControlPlaneCount
+	}
+
+	// set and update the PrimaryIPStack only if it was actually updated
+	if primaryIPStackUpdated {
+		b.setPrimaryIPStack(cluster, primaryIPStack)
+		if primaryIPStack != nil {
+			updates["primary_ip_stack"] = *primaryIPStack
+		} else {
+			updates["primary_ip_stack"] = nil
+		}
 	}
 
 	if len(updates) > 0 {
@@ -3008,21 +3045,6 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.V2UpdateCluste
 	}
 	if err = b.updateVips(db, params, cluster); err != nil {
 		return err
-	}
-
-	// Handle primary IP stack updates
-	primaryIPStackUpdated, err := b.updatePrimaryIPStack(params, cluster)
-	if err != nil {
-		return err
-	}
-
-	// Update the primary_ip_stack field only if it was actually updated
-	if primaryIPStackUpdated {
-		if cluster.PrimaryIPStack != nil {
-			updates["primary_ip_stack"] = *cluster.PrimaryIPStack
-		} else {
-			updates["primary_ip_stack"] = nil
-		}
 	}
 
 	b.setUsage(vipDhcpAllocation, usage.VipDhcpAllocationUsage, nil, usages)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4461,7 +4461,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{Cidr: "fd2e:6f44:5dd8:c956::/120"}, {Cidr: "10.12.0.0/16"}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "IPv6-primary dual-stack requires OpenShift 4.12+")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Inconsistent IP family order: machine_networks first IP is fd2e:6f44:5dd8:c956::/120 but existing primary IP stack is ipv4. All networks must have the same IP family first")
 				})
 				It("API VIP in wrong subnet for dual-stack", func() {
 					apiVip := "10.11.12.15"
@@ -15838,7 +15838,7 @@ var _ = Describe("RegisterCluster", func() {
 						OpenshiftVersion:  swag.String(common.MinimumVersionForNonStandardHAOCPControlPlane),
 					},
 				})
-				verifyApiErrorString(reply, http.StatusBadRequest, "api-vip <1001:db8::64> does not belong to machine-network-cidr <1.2.3.0/24>")
+				verifyApiErrorString(reply, http.StatusBadRequest, "Inconsistent IP family order: machine_networks first IP is 1.2.3.0/24 but api_vips first IP is 1001:db8::64. All networks must have the same IP family first")
 			})
 
 			It("Ingress VIP from IPv6 Machine Network", func() {
@@ -15856,7 +15856,7 @@ var _ = Describe("RegisterCluster", func() {
 						OpenshiftVersion:  swag.String(common.MinimumVersionForNonStandardHAOCPControlPlane),
 					},
 				})
-				verifyApiErrorString(reply, http.StatusBadRequest, "ingress-vip <1001:db8::65> does not belong to machine-network-cidr <1.2.3.0/24>")
+				verifyApiErrorString(reply, http.StatusBadRequest, "Inconsistent IP family order: machine_networks first IP is 1.2.3.0/24 but ingress_vips first IP is 1001:db8::65. All networks must have the same IP family first")
 			})
 		})
 
@@ -19536,11 +19536,6 @@ var _ = Describe("Dual-stack cluster", func() {
 			})
 
 			It("RegisterClusterInternal should reject inconsistent IP family order", func() {
-				// Need minimal mocks for the validation path up to setPrimaryIPStack
-				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
-				mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
-
 				params.NewClusterParams.Name = swag.String("test-inconsistent")
 				params.NewClusterParams.PullSecret = swag.String(fakePullSecret)
 				params.NewClusterParams.BaseDNSDomain = "example.com"
@@ -19685,9 +19680,6 @@ var _ = Describe("Dual-stack cluster", func() {
 			})
 
 			It("v2UpdateClusterInternal should reject inconsistent IP family order", func() {
-				// Need VerifyClusterUpdatability mock since it's called before setPrimaryIPStack
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-
 				params.ClusterUpdateParams.ClusterNetworks = []*models.ClusterNetwork{
 					{Cidr: "2001:db8::/53", HostPrefix: 64}, // IPv6 first
 					{Cidr: "10.128.0.0/14", HostPrefix: 23},
@@ -19762,7 +19754,7 @@ var _ = Describe("Dual-stack cluster", func() {
 
 			It("v2UpdateClusterInternal should reject partial updates with inconsistent IP family order", func() {
 				// First, create a cluster with IPv4-first dual-stack
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Times(2)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Times(1)
 				mockClusterUpdateSuccess(1, 0)
 
 				// Full update to create IPv4-first cluster
@@ -21416,9 +21408,9 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 		common.DeleteTestDB(db, dbName)
 	})
 
-	Describe("setPrimaryIPStack", func() {
+	Describe("getPrimaryIPStack", func() {
 		Context("Single stack clusters", func() {
-			It("should set PrimaryIPStack to nil for IPv4-only cluster", func() {
+			It("should compute PrimaryIPStack as nil for IPv4-only cluster", func() {
 				cluster := &common.Cluster{
 					Cluster: models.Cluster{
 						ID:              &clusterID,
@@ -21430,12 +21422,12 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 					},
 				}
 
-				err := bm.setPrimaryIPStack(cluster)
+				primaryIPStack, err := bm.getPrimaryIPStack(cluster.MachineNetworks, cluster.APIVips, cluster.IngressVips, cluster.ServiceNetworks, cluster.ClusterNetworks)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.PrimaryIPStack).To(BeNil())
+				Expect(primaryIPStack).To(BeNil())
 			})
 
-			It("should set PrimaryIPStack to nil for IPv6-only cluster", func() {
+			It("should compute PrimaryIPStack as nil for IPv6-only cluster", func() {
 				cluster := &common.Cluster{
 					Cluster: models.Cluster{
 						ID:              &clusterID,
@@ -21447,14 +21439,14 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 					},
 				}
 
-				err := bm.setPrimaryIPStack(cluster)
+				primaryIPStack, err := bm.getPrimaryIPStack(cluster.MachineNetworks, cluster.APIVips, cluster.IngressVips, cluster.ServiceNetworks, cluster.ClusterNetworks)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.PrimaryIPStack).To(BeNil())
+				Expect(primaryIPStack).To(BeNil())
 			})
 		})
 
 		Context("Dual stack clusters", func() {
-			It("should set PrimaryIPStack to IPv4 for IPv4-first dual stack", func() {
+			It("should compute PrimaryIPStack as IPv4 for IPv4-first dual stack", func() {
 				cluster := &common.Cluster{
 					Cluster: models.Cluster{
 						ID:               &clusterID,
@@ -21481,14 +21473,13 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 						},
 					},
 				}
-
-				err := bm.setPrimaryIPStack(cluster)
+				primaryIPStack, err := bm.getPrimaryIPStack(cluster.MachineNetworks, cluster.APIVips, cluster.IngressVips, cluster.ServiceNetworks, cluster.ClusterNetworks)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.PrimaryIPStack).ToNot(BeNil())
-				Expect(*cluster.PrimaryIPStack).To(Equal(common.PrimaryIPStackV4))
+				Expect(primaryIPStack).ToNot(BeNil())
+				Expect(*primaryIPStack).To(Equal(common.PrimaryIPStackV4))
 			})
 
-			It("should set PrimaryIPStack to IPv6 for IPv6-first dual stack", func() {
+			It("should compute PrimaryIPStack as IPv6 for IPv6-first dual stack", func() {
 				cluster := &common.Cluster{
 					Cluster: models.Cluster{
 						ID:               &clusterID,
@@ -21516,10 +21507,10 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 					},
 				}
 
-				err := bm.setPrimaryIPStack(cluster)
+				primaryIPStack, err := bm.getPrimaryIPStack(cluster.MachineNetworks, cluster.APIVips, cluster.IngressVips, cluster.ServiceNetworks, cluster.ClusterNetworks)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.PrimaryIPStack).ToNot(BeNil())
-				Expect(*cluster.PrimaryIPStack).To(Equal(common.PrimaryIPStackV6))
+				Expect(primaryIPStack).ToNot(BeNil())
+				Expect(*primaryIPStack).To(Equal(common.PrimaryIPStackV6))
 			})
 
 			It("should return error for inconsistent IP family order", func() {
@@ -21546,7 +21537,7 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 					},
 				}
 
-				err := bm.setPrimaryIPStack(cluster)
+				_, err := bm.getPrimaryIPStack(cluster.MachineNetworks, cluster.APIVips, cluster.IngressVips, cluster.ServiceNetworks, cluster.ClusterNetworks)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Inconsistent IP family order"))
 			})
@@ -21737,9 +21728,10 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 
 		Context("No network updates", func() {
 			It("should return false when no networks are updated", func() {
-				updated, err := bm.updatePrimaryIPStack(params, cluster)
+				updated, primaryIPStack, err := bm.updatePrimaryIPStack(params, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeFalse())
+				Expect(primaryIPStack).To(Equal(cluster.PrimaryIPStack))
 			})
 		})
 
@@ -21775,11 +21767,11 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 			})
 
 			It("should recalculate PrimaryIPStack for full updates", func() {
-				updated, err := bm.updatePrimaryIPStack(params, cluster)
+				updated, primaryIPStack, err := bm.updatePrimaryIPStack(params, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
-				Expect(cluster.PrimaryIPStack).ToNot(BeNil())
-				Expect(*cluster.PrimaryIPStack).To(Equal(common.PrimaryIPStackV6))
+				Expect(primaryIPStack).ToNot(BeNil())
+				Expect(*primaryIPStack).To(Equal(common.PrimaryIPStackV6))
 			})
 		})
 
@@ -21793,11 +21785,11 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 				})
 
 				It("should validate and keep existing PrimaryIPStack", func() {
-					updated, err := bm.updatePrimaryIPStack(params, cluster)
+					updated, primaryIPStack, err := bm.updatePrimaryIPStack(params, cluster)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeFalse()) // No update needed
-					Expect(cluster.PrimaryIPStack).ToNot(BeNil())
-					Expect(*cluster.PrimaryIPStack).To(Equal(common.PrimaryIPStackV4)) // Unchanged
+					Expect(primaryIPStack).ToNot(BeNil())
+					Expect(primaryIPStack).To(Equal(cluster.PrimaryIPStack)) // Unchanged
 				})
 			})
 
@@ -21810,11 +21802,12 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 				})
 
 				It("should return error for inconsistent partial update", func() {
-					updated, err := bm.updatePrimaryIPStack(params, cluster)
+					updated, primaryIPStack, err := bm.updatePrimaryIPStack(params, cluster)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("Inconsistent IP family order"))
 					Expect(err.Error()).To(ContainSubstring("machine_networks first IP is 2001:db9::/64 but existing primary IP stack is ipv4"))
 					Expect(updated).To(BeFalse())
+					Expect(primaryIPStack).To(Equal(cluster.PrimaryIPStack))
 				})
 			})
 		})
@@ -21847,11 +21840,11 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 			})
 
 			It("should recalculate PrimaryIPStack for new cluster", func() {
-				updated, err := bm.updatePrimaryIPStack(params, cluster)
+				updated, primaryIPStack, err := bm.updatePrimaryIPStack(params, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
-				Expect(cluster.PrimaryIPStack).ToNot(BeNil())
-				Expect(*cluster.PrimaryIPStack).To(Equal(common.PrimaryIPStackV6))
+				Expect(primaryIPStack).ToNot(BeNil())
+				Expect(*primaryIPStack).To(Equal(common.PrimaryIPStackV6))
 			})
 		})
 	})

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -787,99 +787,185 @@ var _ = Describe("vip dhcp allocation", func() {
 })
 
 var _ = Describe("IPv6 support", func() {
+	v6 := common.PrimaryIPStackV6
+	v4 := common.PrimaryIPStackV4
+
 	tests := []struct {
-		ipV6Supported bool
-		element       []*string
-		valid         bool
+		ipV6Supported  bool
+		element        []*string
+		valid          bool
+		primaryIPStack *common.PrimaryIPStack
 	}{
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("1001:db8::/120")},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("1001:db8::/120")},
+			primaryIPStack: &v6,
+			valid:          true,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("1001:db8::/120")},
-			valid:         false,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("1001:db8::/120")},
+			primaryIPStack: nil,
+			valid:          true,
 		},
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("10.56.20.0/24")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("1001:db8::/120")},
+			valid:          false,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("10.56.20.0/24")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("1001:db8::/120")},
+			valid:          true,
+			primaryIPStack: &v6,
 		},
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("1001:db8::1")},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("1001:db8::1")},
-			valid:         false,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: &v4,
 		},
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("10.56.20.70")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("10.56.20.70")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: &v4,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("")},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("1001:db8::1")},
+			valid:          true,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{nil},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("1001:db8::1")},
+			valid:          true,
+			primaryIPStack: &v6,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{nil, swag.String("1001:db8::1")},
-			valid:         false,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("1001:db8::1")},
+			valid:          false,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("10.56.20.70"), swag.String("1001:db8::1")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("1001:db8::1")},
+			valid:          true,
+			primaryIPStack: &v6,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("1001:db8::/64"), swag.String("10.56.20.0/24")},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("10.56.20.70")},
+			valid:          true,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: false,
-			element:       []*string{swag.String("10.56.20.70"), swag.String("10.56.20.0/24")},
-			valid:         true,
+			ipV6Supported:  true,
+			element:        []*string{swag.String("10.56.20.70")},
+			valid:          true,
+			primaryIPStack: &v4,
 		},
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("10.56.20.70"), swag.String("1001:db8::1")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.70")},
+			valid:          true,
+			primaryIPStack: nil,
 		},
 		{
-			ipV6Supported: true,
-			element:       []*string{swag.String("1001:db8::1"), swag.String("10.56.20.70")},
-			valid:         true,
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.70")},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("")},
+			valid:          true,
+			primaryIPStack: nil,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("")},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("")},
+			valid:          true,
+			primaryIPStack: &v6,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{nil},
+			valid:          true,
+			primaryIPStack: nil,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{nil},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{nil},
+			valid:          true,
+			primaryIPStack: &v6,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.70"), swag.String("1001:db8::1")},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("1001:db8::/64"), swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: &v6,
+		},
+		{
+			ipV6Supported:  false,
+			element:        []*string{swag.String("10.56.20.70"), swag.String("10.56.20.0/24")},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  true,
+			element:        []*string{swag.String("10.56.20.70"), swag.String("1001:db8::1")},
+			valid:          true,
+			primaryIPStack: &v4,
+		},
+		{
+			ipV6Supported:  true,
+			element:        []*string{swag.String("1001:db8::1"), swag.String("10.56.20.70")},
+			valid:          true,
+			primaryIPStack: &v6,
 		},
 	}
 	for _, t := range tests {
 		t := t
 		It(fmt.Sprintf("IPv6 support validation. Supported: %t, IP addresses/CIDRs: %v", t.ipV6Supported, t.element), func() {
 			if t.valid {
-				Expect(ValidateIPAddressFamily(t.ipV6Supported, t.element...)).ToNot(HaveOccurred())
+				Expect(ValidateIPAddressFamily(t.ipV6Supported, "networks", t.primaryIPStack, t.element...)).ToNot(HaveOccurred())
 			} else {
-				Expect(ValidateIPAddressFamily(t.ipV6Supported, t.element...)).To(HaveOccurred())
+				Expect(ValidateIPAddressFamily(t.ipV6Supported, "networks", t.primaryIPStack, t.element...)).To(HaveOccurred())
 			}
 		})
 	}

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -559,7 +559,7 @@ func (feature *DualStackPrimaryIPv6Feature) getFeatureActiveLevel(cluster *commo
 	v6 := common.PrimaryIPStackV6
 
 	if clusterUpdateParams != nil {
-		primaryStack, _ := network.GetPrimaryIPStack(
+		primaryStack, _ := network.ComputePrimaryIPStack(
 			clusterUpdateParams.MachineNetworks,
 			clusterUpdateParams.APIVips,
 			clusterUpdateParams.IngressVips,

--- a/internal/network/dual_stack_validations.go
+++ b/internal/network/dual_stack_validations.go
@@ -33,9 +33,9 @@ func extractFirstIPAndType(networks interface{}) (string, string) {
 	return "", ""
 }
 
-// GetPrimaryIPStack analyzes the provided networks and VIPs to determine
+// ComputePrimaryIPStack analyzes the provided networks and VIPs to determine
 // the primary IP stack based on which IP family appears first in the lists
-func GetPrimaryIPStack(
+func ComputePrimaryIPStack(
 	machineNetworks []*models.MachineNetwork,
 	apiVips []*models.APIVip,
 	ingressVips []*models.IngressVip,

--- a/internal/network/dual_stack_validations_test.go
+++ b/internal/network/dual_stack_validations_test.go
@@ -9,9 +9,9 @@ import (
 
 var _ = Describe("DualStack Primary IP Stack Functionality", func() {
 
-	Describe("GetPrimaryIPStack", func() {
+	Describe("ComputePrimaryIPStack", func() {
 		It("should return nil for empty networks", func() {
-			primaryStack, err := GetPrimaryIPStack(nil, nil, nil, nil, nil)
+			primaryStack, err := ComputePrimaryIPStack(nil, nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(primaryStack).To(BeNil())
 		})
@@ -37,7 +37,7 @@ var _ = Describe("DualStack Primary IP Stack Functionality", func() {
 				{Cidr: "2001:db8:2::/64"},
 			}
 
-			primaryStack, err := GetPrimaryIPStack(machineNetworks, apiVips, ingressVips, serviceNetworks, clusterNetworks)
+			primaryStack, err := ComputePrimaryIPStack(machineNetworks, apiVips, ingressVips, serviceNetworks, clusterNetworks)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(primaryStack).ToNot(BeNil())
 			Expect(*primaryStack).To(Equal(common.PrimaryIPStackV4))
@@ -65,7 +65,7 @@ var _ = Describe("DualStack Primary IP Stack Functionality", func() {
 				{Cidr: "10.128.0.0/14"},
 			}
 
-			primaryStack, err := GetPrimaryIPStack(machineNetworks, apiVips, ingressVips, serviceNetworks, clusterNetworks)
+			primaryStack, err := ComputePrimaryIPStack(machineNetworks, apiVips, ingressVips, serviceNetworks, clusterNetworks)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(primaryStack).ToNot(BeNil())
 			Expect(*primaryStack).To(Equal(common.PrimaryIPStackV6))
@@ -81,7 +81,7 @@ var _ = Describe("DualStack Primary IP Stack Functionality", func() {
 				{IP: "10.0.1.1"},
 			}
 
-			primaryStack, err := GetPrimaryIPStack(machineNetworks, apiVips, nil, nil, nil)
+			primaryStack, err := ComputePrimaryIPStack(machineNetworks, apiVips, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Inconsistent IP family order"))
 			Expect(primaryStack).To(BeNil())
@@ -98,7 +98,7 @@ var _ = Describe("DualStack Primary IP Stack Functionality", func() {
 				{IP: "10.0.1.1"},
 			}
 
-			primaryStack, err := GetPrimaryIPStack(machineNetworks, apiVips, nil, nil, nil)
+			primaryStack, err := ComputePrimaryIPStack(machineNetworks, apiVips, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(primaryStack).ToNot(BeNil())
 			Expect(*primaryStack).To(Equal(common.PrimaryIPStackV6))


### PR DESCRIPTION
Until now, when IPV6_SUPPORT env var was false, we returned an error if the API and/or Ingress VIP list contained only one IPv6 entry. Now that we support dual-stack with IPv6 as primary, and a user may provide a single VIP, we’re updating the logic to allow one API VIP and one Ingress VIP in dual-stack configurations with IPv6 primary.

/cc @pastequo

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
