### PR TITLE
[release-ocm-2.13] ACM-26035: Introduce PreprovisioningImage finalizer

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -48,13 +48,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type imageConditionReason string
 
-const archMismatchReason = "InfraEnvArchMismatch"
+const (
+	archMismatchReason                = "InfraEnvArchMismatch"
+	PreprovisioningImageFinalizerName = "preprovisioningimage." + aiv1beta1.Group + "/ai-deprovision"
+)
 
 type PreprovisioningImageControllerConfig struct {
 	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
@@ -105,6 +109,15 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	if !image.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.handlePreprovisioningImageDeletion(ctx, log, image)
+	}
+
+	if !funk.ContainsString(image.GetFinalizers(), PreprovisioningImageFinalizerName) {
+		return r.ensurePreprovisioningImageFinalizer(ctx, log, image)
+	}
+
 	if !funk.Some(image.Spec.AcceptFormats, metal3_v1alpha1.ImageFormatISO, metal3_v1alpha1.ImageFormatInitRD) {
 		// Currently, the PreprovisioningImageController only support ISO and InitRD image
 		log.Infof("Unsupported image format: %s", image.Spec.AcceptFormats)
@@ -115,7 +128,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		}
 		return ctrl.Result{}, err
 	}
-	// Consider adding finalizer in case we need to clean up resources
+
 	// Retrieve InfraEnv
 	infraEnv, err := r.findInfraEnvForPreprovisioningImage(ctx, log, image)
 	if err != nil {
@@ -612,6 +625,25 @@ func (r *PreprovisioningImageReconciler) fillIronicServiceURLs(ctx context.Conte
 	return nil
 }
 
+func (r *PreprovisioningImageReconciler) getBMH(ctx context.Context, image *metal3_v1alpha1.PreprovisioningImage) (*metal3_v1alpha1.BareMetalHost, error) {
+	bmhKey := types.NamespacedName{Namespace: image.Namespace}
+	for _, owner := range image.GetOwnerReferences() {
+		if owner.Kind == "BareMetalHost" {
+			bmhKey.Name = owner.Name
+		}
+	}
+
+	if bmhKey.Name == "" {
+		return nil, fmt.Errorf("failed to find BMH owner for preprovisioningimage")
+	}
+
+	bmh := &metal3_v1alpha1.BareMetalHost{}
+	if err := r.Get(ctx, bmhKey, bmh); err != nil {
+		return nil, errors.Wrapf(err, "failed to get owning bmh %s", bmhKey)
+	}
+	return bmh, nil
+}
+
 func (r *PreprovisioningImageReconciler) setBMHRebootAnnotation(ctx context.Context, image *metal3_v1alpha1.PreprovisioningImage) error {
 	bmhKey := types.NamespacedName{Namespace: image.Namespace}
 	for _, owner := range image.GetOwnerReferences() {
@@ -637,6 +669,58 @@ func (r *PreprovisioningImageReconciler) setBMHRebootAnnotation(ctx context.Cont
 	}
 
 	return nil
+}
+
+// ensurePreprovisioningImageFinalizer adds a finalizer to the PreprovisioningImage
+func (r *PreprovisioningImageReconciler) ensurePreprovisioningImageFinalizer(ctx context.Context, log logrus.FieldLogger, image *metal3_v1alpha1.PreprovisioningImage) (ctrl.Result, error) {
+	controllerutil.AddFinalizer(image, PreprovisioningImageFinalizerName)
+	if err := r.Update(ctx, image); err != nil {
+		log.WithError(err).Errorf("failed to add finalizer %s to PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// handlePreprovisioningImageDeletion handles the deletion of a PreprovisioningImage by checking if any BMHs
+// with automated cleaning enabled still reference it.
+func (r *PreprovisioningImageReconciler) handlePreprovisioningImageDeletion(ctx context.Context, log logrus.FieldLogger, image *metal3_v1alpha1.PreprovisioningImage) (ctrl.Result, error) {
+	if !funk.ContainsString(image.GetFinalizers(), PreprovisioningImageFinalizerName) {
+		// Allow deletion of the PreprovisioningImage if the finalizer is not present
+		return ctrl.Result{}, nil
+	}
+
+	// Get the BMH that owns this PreprovisioningImage
+	bmh, err := r.getBMH(ctx, image)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil || strings.Contains(err.Error(), "failed to find BMH owner") {
+			// BMH not found or this preprovisioningimage is not owned by a BMH, allow deletion of the PreprovisioningImage
+			log.Info("BMH not found, removing PreprovisioningImage finalizer")
+			controllerutil.RemoveFinalizer(image, PreprovisioningImageFinalizerName)
+			if err = r.Update(ctx, image); err != nil {
+				log.WithError(err).Errorf("failed to remove finalizer %s from PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+				return ctrl.Result{Requeue: true}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		log.WithError(err).Error("failed to get BMH for PreprovisioningImage")
+		return ctrl.Result{RequeueAfter: longerRequeueAfterOnError}, err
+	}
+
+	// PreprovisioningImage should wait for a BMH with automated cleaning enabled to be deleted
+	if bmh.Spec.AutomatedCleaningMode != metal3_v1alpha1.CleaningModeDisabled {
+		log.Infof("Cannot delete PreprovisioningImage yet: BMH %s/%s with automatedCleaningMode=%s exists and requires the image for deprovisioning",
+			bmh.Namespace, bmh.Name, bmh.Spec.AutomatedCleaningMode)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Safe to delete, remove finalizer
+	log.Info("Removing finalizer from PreprovisioningImage")
+	controllerutil.RemoveFinalizer(image, PreprovisioningImageFinalizerName)
+	if err := r.Update(ctx, image); err != nil {
+		log.WithError(err).Errorf("failed to remove finalizer %s from PreprovisioningImage %s/%s", PreprovisioningImageFinalizerName, image.Namespace, image.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // processMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -24,6 +24,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,6 +53,7 @@ func newPreprovisioningImage(name, namespace, labelKey, labelValue, bmhName stri
 				Kind:       "BareMetalHost",
 				Name:       bmhName,
 			}},
+			Finalizers: []string{PreprovisioningImageFinalizerName},
 		},
 		Spec: metal3_v1alpha1.PreprovisioningImageSpec{
 			AcceptFormats: []metal3_v1alpha1.ImageFormat{
@@ -1030,3 +1032,186 @@ func validateStatus(imageURL string, ExpectedImageReadyCondition *conditionsv1.C
 		meta.FindStatusCondition(ppi.Status.Conditions, string(metal3_v1alpha1.ConditionImageError)).Status)))
 
 }
+
+var _ = Describe("PreprovisioningImage deletion protection", func() {
+	var (
+		c                     client.Client
+		pr                    *PreprovisioningImageReconciler
+		mockCtrl              *gomock.Controller
+		mockInstallerInternal *bminventory.MockInstallerInternals
+		mockCRDEventsHandler  *MockCRDEventsHandler
+		mockVersionHandler    *versions.MockHandler
+		mockOcRelease         *oc.MockRelease
+		mockBMOUtils          *MockBMOUtils
+		ctx                   = context.Background()
+		ppi                   *metal3_v1alpha1.PreprovisioningImage
+		bmh                   *metal3_v1alpha1.BareMetalHost
+	)
+
+	BeforeEach(func() {
+		schemes := runtime.NewScheme()
+		Expect(configv1.AddToScheme(schemes)).To(Succeed())
+		Expect(metal3_v1alpha1.AddToScheme(schemes)).To(Succeed())
+		Expect(aiv1beta1.AddToScheme(schemes)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(schemes).
+			WithStatusSubresource(&metal3_v1alpha1.PreprovisioningImage{}, &metal3_v1alpha1.BareMetalHost{}).Build()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
+		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
+		mockVersionHandler = versions.NewMockHandler(mockCtrl)
+		mockOcRelease = oc.NewMockRelease(mockCtrl)
+		mockBMOUtils = NewMockBMOUtils(mockCtrl)
+
+		pr = &PreprovisioningImageReconciler{
+			Client:           c,
+			Log:              common.GetTestLog(),
+			Installer:        mockInstallerInternal,
+			CRDEventsHandler: mockCRDEventsHandler,
+			VersionsHandler:  mockVersionHandler,
+			OcRelease:        mockOcRelease,
+			BMOUtils:         mockBMOUtils,
+		}
+
+		bmh = &metal3_v1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testBMH",
+				Namespace: testNamespace,
+			},
+			Spec: metal3_v1alpha1.BareMetalHostSpec{
+				AutomatedCleaningMode: metal3_v1alpha1.CleaningModeMetadata,
+			},
+		}
+		Expect(c.Create(ctx, bmh)).To(Succeed())
+
+		ppi = newPreprovisioningImage("testPPI", testNamespace, InfraEnvLabel, "testInfraEnv", bmh.Name)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("ensurePreprovisioningImageFinalizer", func() {
+		It("adds finalizer when not present on PreprovisioningImage", func() {
+			ppi.Finalizers = []string{}
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+
+			// Reconcile and verify finalizer was added
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(c.Get(ctx, key, ppi)).To(Succeed())
+			Expect(ppi.GetFinalizers()).To(ContainElement(PreprovisioningImageFinalizerName))
+		})
+
+		It("does nothing when finalizer is already present on PreprovisioningImage", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+
+			// Reconcile and verify finalizer was not added again
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(c.Get(ctx, key, ppi)).To(Succeed())
+			Expect(ppi.GetFinalizers()).To(HaveLen(1))
+			Expect(ppi.GetFinalizers()).To(ContainElement(PreprovisioningImageFinalizerName))
+		})
+	})
+
+	Context("handlePreprovisioningImageDeletion", func() {
+		It("allows deletion when finalizer is not present", func() {
+			ppi.OwnerReferences = []metav1.OwnerReference{}
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			// Verify ppi was deleted
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(k8serrors.IsNotFound(c.Get(ctx, key, ppi))).To(BeTrue())
+		})
+
+		It("removes finalizer and allows deletion when BMH not found", func() {
+			// Set owner reference to a non-existent BMH
+			ppi.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "metal3.io/v1alpha1",
+				Kind:       "BareMetalHost",
+				Name:       "nonExistentBMH",
+			}}
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+			// Reconcile and verify ppi was deleted
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			// Verify ppi was deleted
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(k8serrors.IsNotFound(c.Get(ctx, key, ppi))).To(BeTrue())
+		})
+
+		It("blocks deletion when BMH has metadata cleaning enabled and is being deleted", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+
+			// UpdateBMH to set metadata cleaning enabled
+			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeMetadata
+			bmh.Finalizers = []string{"arbitraryfinalizer"}
+			Expect(c.Update(ctx, bmh)).To(Succeed())
+			// Set BMH to be deleting
+			Expect(c.Delete(ctx, bmh)).To(Succeed())
+
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+
+			Expect(err).To(BeNil())
+			Expect(result.Requeue).To(BeTrue())
+
+			// Verify finalizer was NOT removed
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(c.Get(ctx, key, ppi)).To(Succeed())
+			Expect(ppi.GetFinalizers()).To(ContainElement(PreprovisioningImageFinalizerName))
+		})
+
+		It("allows deletion when BMH has cleaning disabled", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+			// Set BMH cleaning to disabled
+			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeDisabled
+			Expect(c.Update(ctx, bmh)).To(Succeed())
+			Expect(c.Delete(ctx, bmh)).To(Succeed())
+
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			// Verify ppi was deleted
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(k8serrors.IsNotFound(c.Get(ctx, key, ppi))).To(BeTrue())
+		})
+
+		It("blocks deletion when BMH has metadata cleaning enabled but is NOT being deleted", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+			// BMH is not being deleted (no DeletionTimestamp)
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+
+			Expect(err).To(BeNil())
+			Expect(result.Requeue).To(BeTrue())
+
+			// Verify ppi finalizer was not removed
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(c.Get(ctx, key, ppi)).To(Succeed())
+			Expect(ppi.GetFinalizers()).To(ContainElement(PreprovisioningImageFinalizerName))
+		})
+	})
+})


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/assisted-service/pull/8221
Includes additional function: `getBMH` that was missing in original backport PR https://github.com/openshift/assisted-service/pull/8246

---
There is one case where a PreprovisioningImage should not be deleted before its associated BMH. This happens when the BMH has automatedCleaningMode set to metadata (enabled) and is being deleted. The PreprovisioningImage is required during deprovisioning since it contains the Ironic Python Agent (IPA) which is used to erase the disk of the host.

In this specific case, we should not allow a PreprovisioningImage to be removed before the BMH is removed. The finalizer is added to all PreprovisioningImage CRs we manage, and will be removed on deletion of the PreprovisioningImage unless the case above is occuring.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
