### PR TITLE
MGMT-22127: Stop non-existing InfraEnv reconcile

### DIFF
--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -124,15 +124,9 @@ var _ = Describe("infraEnv reconcile", func() {
 		mockCtrl.Finish()
 	})
 
-	It("none exiting infraEnv - delete", func() {
-		infraEnvImage := newInfraEnvImage("infraEnvImage", "namespace", aiv1beta1.InfraEnvSpec{})
-		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
-
-		noneExistingImage := newInfraEnvImage("image2", "namespace", aiv1beta1.InfraEnvSpec{})
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
-
-		result, err := ir.Reconcile(ctx, newInfraEnvRequest(noneExistingImage))
+	It("Happy flow - reconciling a non-existing infraEnv should be successful", func() {
+		nonexistingInfraEnv := newInfraEnvImage("nonexistingInfraEnv", "namespace", aiv1beta1.InfraEnvSpec{})
+		result, err := ir.Reconcile(ctx, newInfraEnvRequest(nonexistingInfraEnv))
 		Expect(err).To(BeNil())
 		Expect(result).To(Equal(ctrl.Result{}))
 	})
@@ -1019,152 +1013,154 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Status).To(Equal(corev1.ConditionFalse))
 	})
 
-	It("Delete infraEnv with no hosts verify finalizer removed", func() {
-		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
-		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
-		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
-			Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
-				Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
-				Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
-			}).Return(
-			&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
-			ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
-			PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+	Context("Deleting an InfraEnv", func() {
+		It("with no hosts should remove finalizers and return success", func() {
+			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
+					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
+					Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
+				ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+				PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+			})
+			Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
+
+			res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "infraEnvImage",
+			}
+			// Verify finalizer was added
+			Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+			Expect(infraEnvImage.Finalizers).ToNot(BeNil())
+			Expect(infraEnvImage.Finalizers[0]).To(Equal(InfraEnvFinalizerName))
+
+			//Delete InfraEnv, finalizer still exists
+			Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
+			Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+			Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(infraEnvImage.Finalizers).ToNot(BeNil())
+
+			// Reconcile and verify CR is deleted
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{}, nil)
+			mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
+			res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+
+			Expect(apierrors.IsNotFound(c.Get(ctx, key, infraEnvImage))).To(BeTrue())
 		})
-		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
-		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(ctrl.Result{}))
+		It("with unbound hosts should delete hosts and return success", func() {
+			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
+					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
+					Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
+				ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+				PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+			})
+			Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
-		key := types.NamespacedName{
-			Namespace: testNamespace,
-			Name:      "infraEnvImage",
-		}
-		// Verify finalizer was added
-		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		Expect(infraEnvImage.Finalizers).ToNot(BeNil())
-		Expect(infraEnvImage.Finalizers[0]).To(Equal(InfraEnvFinalizerName))
+			res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
 
-		//Delete InfraEnv, finalizer still exists
-		Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
-		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
-		Expect(infraEnvImage.Finalizers).ToNot(BeNil())
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "infraEnvImage",
+			}
+			//Delete InfraEnv, finalizer still exists
+			Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
+			Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+			Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(infraEnvImage.Finalizers).ToNot(BeNil())
 
-		// Reconcile and verify CR is deleted
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{}, nil)
-		mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
-		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(ctrl.Result{}))
+			// Reconcile and verify only Bound Host is deleted
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			hostId := strfmt.UUID(uuid.New().String())
+			host := &common.Host{Host: models.Host{ID: &hostId, Status: swag.String(models.HostStatusKnownUnbound)}}
+			mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{host}, nil)
+			mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
+			res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
 
-		Expect(apierrors.IsNotFound(c.Get(ctx, key, infraEnvImage))).To(BeTrue())
-	})
-
-	It("Delete infraEnv with Unbound hosts verify hosts are deleted", func() {
-		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
-		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
-		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
-			Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
-				Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
-				Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
-			}).Return(
-			&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
-			ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
-			PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+			// Verify that InfraEnv CR is deleted
+			Expect(apierrors.IsNotFound(c.Get(ctx, key, infraEnvImage))).To(BeTrue())
 		})
-		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
-		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(ctrl.Result{}))
+		It("with bound and unbound hosts should delete unbound hosts and return error", func() {
+			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
+				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
+					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
+					Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
+				}).Return(
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
+				ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+				PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+			})
+			Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
-		key := types.NamespacedName{
-			Namespace: testNamespace,
-			Name:      "infraEnvImage",
-		}
-		//Delete InfraEnv, finalizer still exists
-		Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
-		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
-		Expect(infraEnvImage.Finalizers).ToNot(BeNil())
+			res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
 
-		// Reconcile and verify only Bound Host is deleted
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		hostId := strfmt.UUID(uuid.New().String())
-		host := &common.Host{Host: models.Host{ID: &hostId, Status: swag.String(models.HostStatusKnownUnbound)}}
-		mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{host}, nil)
-		mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
-		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(ctrl.Result{}))
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "infraEnvImage",
+			}
+			//Delete InfraEnv, finalizer still exists
+			Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
+			Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+			Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(infraEnvImage.Finalizers).ToNot(BeNil())
 
-		// Verify that InfraEnv CR is deleted
-		Expect(apierrors.IsNotFound(c.Get(ctx, key, infraEnvImage))).To(BeTrue())
-	})
+			// Reconcile and verify Host are deleted
+			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+			hostUnboundId := strfmt.UUID(uuid.New().String())
+			hostBoundId := strfmt.UUID(uuid.New().String())
+			hostUnbound := &common.Host{Host: models.Host{ID: &hostUnboundId, InfraEnvID: *backendInfraEnv.ID, Status: swag.String(models.HostStatusKnownUnbound)}}
+			hostBound := &common.Host{Host: models.Host{ID: &hostBoundId, InfraEnvID: *backendInfraEnv.ID, Status: swag.String(models.HostStatusKnown)}}
+			mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{hostUnbound, hostBound}, nil)
+			mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), installer.V2DeregisterHostParams{
+				InfraEnvID: *backendInfraEnv.ID,
+				HostID:     hostUnboundId,
+			}, bminventory.NonInteractive).Return(nil)
+			res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+			Expect(err).To(Not(BeNil()))
+			Expect(res).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
-	It("Delete infraEnv with Bound and Unbound hosts verify only Unbound hosts are deleted", func() {
-		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
-		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
-		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
-			Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
-				Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
-				Expect(string(params.InfraEnvUpdateParams.ImageType)).To(Equal(""))
-			}).Return(
-			&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
-			ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
-			PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
+			//Verify that InfraEnv CR still exists with finalizer
+			Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+			Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(infraEnvImage.Finalizers).ToNot(BeNil())
 		})
-		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
-
-		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(ctrl.Result{}))
-
-		key := types.NamespacedName{
-			Namespace: testNamespace,
-			Name:      "infraEnvImage",
-		}
-		//Delete InfraEnv, finalizer still exists
-		Expect(c.Delete(ctx, infraEnvImage)).To(BeNil())
-		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
-		Expect(infraEnvImage.Finalizers).ToNot(BeNil())
-
-		// Reconcile and verify Host are deleted
-		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-		hostUnboundId := strfmt.UUID(uuid.New().String())
-		hostBoundId := strfmt.UUID(uuid.New().String())
-		hostUnbound := &common.Host{Host: models.Host{ID: &hostUnboundId, InfraEnvID: *backendInfraEnv.ID, Status: swag.String(models.HostStatusKnownUnbound)}}
-		hostBound := &common.Host{Host: models.Host{ID: &hostBoundId, InfraEnvID: *backendInfraEnv.ID, Status: swag.String(models.HostStatusKnown)}}
-		mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{hostUnbound, hostBound}, nil)
-		mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), installer.V2DeregisterHostParams{
-			InfraEnvID: *backendInfraEnv.ID,
-			HostID:     hostUnboundId,
-		}, bminventory.NonInteractive).Return(nil)
-		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).To(Not(BeNil()))
-		Expect(res).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
-
-		//Verify that InfraEnv CR still exists with finalizer
-		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		Expect(infraEnvImage.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
-		Expect(infraEnvImage.Finalizers).ToNot(BeNil())
 	})
 
 	It("InfraEnv is created when doesn't exist in DB - custom OSImageVersion, no cluster ref", func() {


### PR DESCRIPTION
Previously, if an InfraEnv CR is removed from the cluster and the controller reconciles it one more time, the controller will try to deregister the infra env from the DB.

If the deregistration fails, the controller re-reconciles this same non-existing InfraEnv, causing an endless loop.

The controller now will stop reconciling after it attempts to deregister the infraenv regardless of failure to prevent an endless loop from occurring.

The deregistration for this flow also previously did not try to remove existing hosts too, so this change also modifies the deregistration to also deregister hosts if they exist.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): See below
- [ ] No tests needed

### Manual testing

#### Error scenario
From originating issue [MGMT-22098](https://issues.redhat.com/browse/MGMT-22098): 
Create a SNO cluster. During installation, delete the Agent and InfraEnv and remove their finalizers.
Observe endless looping with current assisted-service.

Use new image with these changes and observe the infraenv getting reconciled once, showing it tried to deregister and failing, then ending and never reconciling again.

#### Regression scenarios

- [x] Create an infraenv with no hosts. Deleting it should be successful
- [x] Create an infraenv with hosts that are unbound. Deleting it should be successful
- [x] Create an infraenv with bound hosts. Deleting it should be stopped by the controller


## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
