### PR TITLE
MGMT-22042: add cve-automation github app to owners_aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,7 @@
 
 aliases:
   approvers:
+    - cve-automation
     - openshift-edge-bot
     - romfreiman
     - oourfali


### PR DESCRIPTION
This is required to allow auto merge on cve-automation pull requests