### PR TITLE
MGMT-22042: add cve-automation github app to owners_aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,6 +24,7 @@ aliases:
     - pastequo
     - mlorenzofr
     - linoyaslan
+    - cve-automation
   emeritus_approvers:
     - empovit
     - yevgeny-shnaidman


### PR DESCRIPTION
This is required to allow auto merge on cve-automation pull requests