### PR TITLE
MGMT-22042: add cve-automation github app to owners_aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,6 +22,7 @@ aliases:
     - danmanor
     - eifrach
     - pastequo
+    - cve-automation
   emeritus_approvers:
     - empovit
     - yevgeny-shnaidman


### PR DESCRIPTION
This is required to allow auto merge on cve-automation pull requests