### PR TITLE
MGMT-22151: Fix multipart form file cleanup on V2UploadLogs validation errors

### DIFF
--- a/restapi/operations/installer/v2_upload_logs.go
+++ b/restapi/operations/installer/v2_upload_logs.go
@@ -59,6 +59,13 @@ func (o *V2UploadLogs) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
+		// Clean up multipart form files if validation fails
+		if r.MultipartForm != nil {
+			r.MultipartForm.RemoveAll()
+		}
+		if r.Body != nil {
+			r.Body.Close()
+		}
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}


### PR DESCRIPTION
## Problem

When uploading logs via `POST /v2/clusters/{cluster_id}/logs`, if file size validation fails (e.g., file exceeds the 250MB limit), the error response is returned before the handler function executes. This means the `defer` cleanup block in `v2uploadLogs` never runs, leaving multipart temporary files on disk and causing disk space issues over time.

## Solution

Added cleanup logic in the generated `ServeHTTP` method's error path to ensure multipart form files are removed when `BindValidRequest` fails.

## Why This Location?

The cleanup is placed in `restapi/operations/installer/v2_upload_logs.go` at the error path of `BindValidRequest` because Validation happens before handler execution: The `BindValidRequest` call (line 61) performs all parameter validation, including file size checks, before the handler is invoked. If validation fails, the handler's `defer` cleanup never executes.
