### PR TITLE
MGMT-22154: return bad request when cluster or host are missing in v2uploadLogs

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -592,7 +592,7 @@ func (b *bareMetalInventory) v2uploadLogs(ctx context.Context, params installer.
 
 	if params.LogsType == string(models.LogsTypeHost) {
 		if common.StrFmtUUIDPtr(params.ClusterID) == nil || params.HostID == nil {
-			return common.NewApiError(http.StatusInternalServerError,
+			return common.NewApiError(http.StatusBadRequest,
 				errors.Errorf("cluster_id and host_id are required for upload %s logs", params.LogsType))
 		}
 


### PR DESCRIPTION
spinoff from #8355.

In internal/bminventory/inventory_v2_handlers.go around line 587, the handler
incorrectly returns http.StatusInternalServerError when required parameters are
missing for logs_type "host"; change the returned error to use
http.StatusBadRequest (i.e., return common.NewApiError(http.StatusBadRequest,
errors.Errorf("cluster_id and host_id are required for upload %s logs",
params.LogsType))) so validation failures produce 400; ensure the http package
is referenced and the error construction matches surrounding code patterns.