### PR TITLE
MGMT-21982: Remove --interactive  flag from the unconfigured ignition

### DIFF
--- a/docs/enhancements/disconnected-iso-ignition-generation.md
+++ b/docs/enhancements/disconnected-iso-ignition-generation.md
@@ -79,7 +79,7 @@ When `discovery.ign` is requested for an InfraEnv with `disconnected-iso` image 
    - `cluster-manifests/pull-secret.yaml` - User's pull secret for registry access
    - `mirror/registries.conf` - OVE-specific registry mirror configuration
 4. Fetch the appropriate openshift-install binary matching the cluster version
-5. Execute `openshift-install agent create unconfigured-ignition --interactive`
+5. Execute `openshift-install agent create unconfigured-ignition`
 6. Return the ignition content
 
 **Key Constraints:**

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13017,11 +13017,12 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 		mockInstallerCache.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(installercache.NewMockRelease("/tmp/test", mockEvents), nil)
 		mockEvents.EXPECT().V2AddMetricsEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		mockExecuter.EXPECT().Execute(gomock.Any(), "agent", "create", "unconfigured-ignition", gomock.Any(), gomock.Any(), gomock.Any()).
+		mockExecuter.EXPECT().Execute(gomock.Any(), "agent", "create", "unconfigured-ignition", gomock.Any(), gomock.Any()).
 			DoAndReturn(func(command string, args ...string) (string, string, int) {
 				tempDir := args[len(args)-1]
+				mockIgnition := `{"ignition": {"version": "3.2.0"},"storage":{"files":[]}}`
 				err := os.WriteFile(filepath.Join(tempDir, "unconfigured-agent.ign"),
-					[]byte(`{"ignition": {"version": "3.2.0"}}`), 0600)
+					[]byte(mockIgnition), 0600)
 				Expect(err).NotTo(HaveOccurred())
 				return "", "", 0
 			})


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-21982


remove the `--interactive` flag from the `agent create unconfigured ignition` to comply with the migration to a sentinel file.