### PR TITLE
MGMT-21691: Reorder networks and VIPs after each DB fetch before install-config generation

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1469,6 +1469,8 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 		if cluster, err = common.GetClusterFromDBWithHosts(b.db, params.ClusterID); err != nil {
 			return nil, common.NewApiError(http.StatusNotFound, err)
 		}
+
+		b.orderClusterNetworks(cluster)
 	}
 	// Verify cluster is ready to install
 	if ok, reason := b.clusterApi.IsReadyForInstallation(cluster); !ok {
@@ -1494,6 +1496,8 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 	if cluster, err = common.GetClusterFromDB(b.db, params.ClusterID, common.UseEagerLoading); err != nil {
 		return nil, err
 	}
+
+	b.orderClusterNetworks(cluster)
 
 	if err = b.clusterApi.GenerateAdditionalManifests(ctx, cluster); err != nil {
 		b.log.WithError(err).Errorf("Failed to generate additional cluster manifest")
@@ -1830,6 +1834,7 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 			log.WithError(err).Errorf("failed to find cluster %s", params.ClusterID)
 			return err
 		}
+		b.orderClusterNetworks(cluster)
 
 		clusterInfraenvs, err = b.getClusterInfraenvs(cluster)
 		if err != nil {
@@ -4658,6 +4663,8 @@ func (b *bareMetalInventory) getCluster(ctx context.Context, clusterID string, f
 		return nil, err
 	}
 
+	b.orderClusterNetworks(cluster)
+
 	return cluster, nil
 }
 
@@ -7162,6 +7169,7 @@ func (b *bareMetalInventory) generateAgentInstallerKubeconfig(ctx context.Contex
 	if err != nil {
 		return err
 	}
+	b.orderClusterNetworks(cluster)
 
 	clusterInfraenvs, err := b.getClusterInfraenvs(cluster)
 	if err != nil {


### PR DESCRIPTION
Due to additional reports about incorrect ordering in the install-config, it was discovered that there are other several places in the code where we fetch the cluster from the DB, which puts us at risk of receiving machine_nets, service_nets, cluster_nets, and VIPs in the wrong order in install-config. In OpenShift, ordering matters for dual-stack scenarios, so we must reorder these fields after every DB fetch.
In general, all the fetching from DB thing and the order issue requires a more substantial refactor which should be solved as part of MGMT-22189, but for now this fix should address the install-config issue.

**Side note:** I wasn’t able to reproduce the problem as the behavior is inconsistent , so I hope this fix will be sufficient.

/cc @AlonaKaplan @danmanor 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
