### PR TITLE
OCPBUGS-61237: Prevent race in agent-installer kubeconfig generation

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6504,6 +6504,7 @@ func (b *bareMetalInventory) V2DownloadInfraEnvFiles(ctx context.Context, params
 }
 
 func (b *bareMetalInventory) V2DownloadClusterCredentials(ctx context.Context, params installer.V2DownloadClusterCredentialsParams) middleware.Responder {
+	log := logutil.FromContext(ctx, b.log)
 	fileName := params.FileName
 	respBody, contentLength, err := b.V2DownloadClusterCredentialsInternal(ctx, params)
 
@@ -6524,6 +6525,15 @@ func (b *bareMetalInventory) V2DownloadClusterCredentials(ctx context.Context, p
 				b.log.WithError(agentErr).Errorf("failed to generate agent installer kubeconfig")
 				return common.GenerateErrorResponder(agentErr)
 			}
+
+			// Wait for S3 eventual consistency before attempting download
+			// After generation, the file might not be immediately visible due to S3 consistency delays
+			objectName := fmt.Sprintf("%s/%s", params.ClusterID, fileName)
+			if waitErr := b.objectHandler.WaitForObject(ctx, objectName); waitErr != nil {
+				log.WithError(waitErr).Errorf("file %s not available after generation for cluster %s", fileName, params.ClusterID)
+				return common.GenerateErrorResponder(common.NewApiError(http.StatusInternalServerError, waitErr))
+			}
+
 			respBody, contentLength, err = b.v2DownloadClusterFilesInternal(ctx, fileName, params.ClusterID.String())
 		}
 	}

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -281,3 +281,17 @@ func (mr *MockAPIMockRecorder) UploadWithMetadata(arg0, arg1, arg2, arg3 interfa
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadWithMetadata", reflect.TypeOf((*MockAPI)(nil).UploadWithMetadata), arg0, arg1, arg2, arg3)
 }
+
+// WaitForObject mocks base method.
+func (m *MockAPI) WaitForObject(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForObject", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForObject indicates an expected call of WaitForObject.
+func (mr *MockAPIMockRecorder) WaitForObject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForObject", reflect.TypeOf((*MockAPI)(nil).WaitForObject), arg0, arg1)
+}


### PR DESCRIPTION
This fix is specific to the agent-based installer workflow only.

Multiple concurrent requests to download kubeconfig could trigger simultaneous credential generation attempts, causing race conditions that resulted in 500 errors in disconnected environments. This fix adds database-level locking with a double-check pattern to ensure only one request generates credentials while others wait and reuse the result.

The fix only applies when installerInvoker is "agent-installer" and affects the early kubeconfig retrieval path used by the agent-based installer UI.

In addition, after generating credentials, files may not be immediately visible in S3 due to eventual consistency delays. This can cause download failures in disconnected environments where S3-compatible storage (MinIO, Ceph) may have slower consistency guarantees than AWS S3.

This fix adds retry logic with exponential backoff (100ms to 2s over 5 attempts) to wait for the file to become visible before attempting download. This handles the timing window between upload completion and object visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
