### PR TITLE
MGMT-22181: [4.18] ODF compact mode with 5 masters fails

### DIFF
--- a/internal/operators/odf/manifest.go
+++ b/internal/operators/odf/manifest.go
@@ -72,7 +72,16 @@ func Manifests(mode odfDeploymentMode, numberOfDisks int64, openshiftVersion str
 	}
 	openshiftManifests["50_openshift-odf_subscription.yaml"] = []byte(odfSubscription)
 	openshiftManifests["50_openshift-odf_operator_group.yaml"] = []byte(odfOperatorGroup)
-	odfSC = append([]byte(odfStorageSystem+"\n---\n"), odfSC...)
+
+	// StorageSystem manifest is only needed for OCP versions up to 4.18
+	constraintsPre419, subErr := version.NewConstraint("< 4.19.0")
+	if subErr != nil {
+		return nil, nil, subErr
+	}
+	if constraintsPre419.Check(v1) {
+		odfSC = append([]byte(odfStorageSystem+"\n---\n"), odfSC...)
+	}
+
 	return openshiftManifests, odfSC, nil
 }
 
@@ -143,6 +152,7 @@ metadata:
   name: openshift-storage
 spec: {}`
 
+// TODO: Remove this section when versions under 4.19 are no longer supported
 const odfStorageSystem = `apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem
 metadata:

--- a/internal/operators/odf/manifests_test.go
+++ b/internal/operators/odf/manifests_test.go
@@ -245,4 +245,50 @@ var _ = Describe("OCS manifest generation", func() {
 		})
 
 	})
+
+	Context("StorageSystem manifest version compatibility", func() {
+		createCluster := func(version string) *common.Cluster {
+			return &common.Cluster{Cluster: models.Cluster{
+				OpenshiftVersion: version,
+				Hosts: []*models.Host{
+					{Role: models.HostRoleMaster, InstallationDiskID: diskID1, Inventory: Inventory(&InventoryResources{Disks: []*models.Disk{
+						{ID: diskID1, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+						{ID: diskID2, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+					}})},
+					{Role: models.HostRoleMaster, InstallationDiskID: diskID1, Inventory: Inventory(&InventoryResources{Disks: []*models.Disk{
+						{ID: diskID1, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+						{ID: diskID2, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+					}})},
+					{Role: models.HostRoleMaster, InstallationDiskID: diskID1, Inventory: Inventory(&InventoryResources{Disks: []*models.Disk{
+						{ID: diskID1, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+						{ID: diskID2, SizeBytes: conversions.GbToBytes(30), DriveType: models.DriveTypeHDD},
+					}})},
+				},
+			}}
+		}
+
+		It("Should include StorageSystem for version 4.18.0", func() {
+			_, manifest, err := operator.GenerateManifests(createCluster("4.18.0"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(manifest)).To(ContainSubstring("kind: StorageSystem"))
+		})
+
+		It("Should include StorageSystem for version 4.18.1", func() {
+			_, manifest, err := operator.GenerateManifests(createCluster("4.18.1"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(manifest)).To(ContainSubstring("kind: StorageSystem"))
+		})
+
+		It("Should include StorageSystem for version 4.18.5", func() {
+			_, manifest, err := operator.GenerateManifests(createCluster("4.18.5"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(manifest)).To(ContainSubstring("kind: StorageSystem"))
+		})
+
+		It("Should NOT include StorageSystem for version 4.19.0", func() {
+			_, manifest, err := operator.GenerateManifests(createCluster("4.19.0"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(manifest)).NotTo(ContainSubstring("kind: StorageSystem"))
+		})
+	})
 })


### PR DESCRIPTION
  Limit StorageSystem manifest to OCP versions ≤ 4.18

  The ODF StorageSystem manifest is only required for OpenShift versions up to
  4.18.
  Starting with version 4.19, this manifest is no longer needed.

  Changes:
  - Add version check to only include StorageSystem manifest for OCP ≤ 4.18
  - Add unit tests verifying version-specific manifest inclusion

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
