### PR TITLE
MGMT-22297: synch NTP in discovery

### DIFF
--- a/internal/ignition/discovery_test.go
+++ b/internal/ignition/discovery_test.go
@@ -1086,8 +1086,8 @@ location = "%s"
 		Expect(configText).To(MatchRegexp(`(?m)^server ntp1.example.com iburst$`))
 		Expect(configText).To(MatchRegexp(`(?m)^server ntp2.example.com iburst$`))
 
-		// Check that the original config has been preserved:
-		Expect(configText).To(MatchRegexp("(?m)^makestep 1.0 3$"))
+		// Check that makestep has been modified to allow unlimited stepping:
+		Expect(configText).To(MatchRegexp("(?m)^makestep 1.0 -1$"))
 	})
 })
 

--- a/internal/ignition/templates/add-ntp-sources.sh
+++ b/internal/ignition/templates/add-ntp-sources.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Allow chrony to step the clock at any time if the offset is larger than 1 second.
+# The default "makestep 1.0 3" only allows stepping during the first 3 clock updates,
+# which may have been exhausted before valid NTP sources were available.
+# Using -1 removes this limit, ensuring the clock can be corrected even with large offsets.
+sed -i 's/^makestep .*/makestep 1.0 -1/' /etc/chrony.conf
+
 cat >> /etc/chrony.conf <<.
 {{ range .AdditionalNtpSources }}
 server {{ . }} iburst


### PR DESCRIPTION
### [MGMT-22297](https://issues.redhat.com//browse/MGMT-22297): synch NTP in dicovery

**Problem**

When a discovery ISO boots with a broken clock and mixed NTP sources (one valid, one invalid), the node's system date remains incorrect even after valid NTP sources are added, which also breaks the discovery flow due to expired certs.

**Most probable root cause**
1. Discovery ISO boots with a broken clock (e.g., April 2023).
2. chronyd starts with makestep 1.0 3 (step allowed only for the first 3 clock updates).
3. If initial NTP sources are unreachable or invalid, chronyd exhausts its 3 makestep attempts without syncing.
4. When valid NTP sources are added later (via add-ntp-sources.sh), chronyd contacts them but refuses to step because the makestep limit was exhausted.
5. chronyd only slews (gradually adjusts), which is too slow for large offsets (years), so the clock never corrects.

The makestep 1.0 3 limit is intended to prevent disruptive time jumps during normal operation, but during discovery with a broken clock, unlimited stepping is needed.

**Solution**

The fix updates `add-ntp-sources.sh` to run remove the makestep limit from `/etc/chrony.conf` before appending NTP sources. This allows immediate clock correction when valid NTP sources become available, even if initial sources failed.

**Testing**

Reproduced the issue and tested the fix on integration env both manually and with custom assisted-service image.
Chrony was able to synch time after patching the config, and stalling discovery could progress immediately.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
