### PR TITLE
ACM-27290: Explicitly set docker transport in policy.json

### DIFF
--- a/pkg/mirrorregistries/generator.go
+++ b/pkg/mirrorregistries/generator.go
@@ -119,6 +119,17 @@ func (m *mirrorRegistriesConfigBuilder) GenerateInsecurePolicyJSON() (string, er
 					{"type": "insecureAcceptAnything"},
 				},
 			},
+			"docker": map[string]interface{}{
+				"": []map[string]string{
+					{"type": "insecureAcceptAnything"},
+				},
+				"registry.redhat.io": []map[string]string{
+					{"type": "insecureAcceptAnything"},
+				},
+				"registry.access.redhat.com": []map[string]string{
+					{"type": "insecureAcceptAnything"},
+				},
+			},
 		},
 	}
 

--- a/pkg/mirrorregistries/mirror_registry_test.go
+++ b/pkg/mirrorregistries/mirror_registry_test.go
@@ -347,6 +347,16 @@ func TestGeneratePolicyJSON_ForceInsecure(t *testing.T) {
 	daemon := transports["docker-daemon"].(map[string]interface{})
 	daemonEntry := daemon[""].([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "insecureAcceptAnything", daemonEntry["type"])
+
+	docker := transports["docker"].(map[string]interface{})
+	dockerEntry := docker[""].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "insecureAcceptAnything", dockerEntry["type"])
+
+	rhIoEntry := docker["registry.redhat.io"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "insecureAcceptAnything", rhIoEntry["type"])
+
+	accessRhIoEntry := docker["registry.access.redhat.com"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "insecureAcceptAnything", accessRhIoEntry["type"])
 }
 
 func TestGeneratePolicyJSON_DefaultBehavior(t *testing.T) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-27290

## Summary
- Fix of [ACM-21309](https://issues.redhat.com/browse/ACM-21309)
- Updates `GenerateInsecurePolicyJSON` to include the `docker` transport.
- Explicitly adds `insecureAcceptAnything` for `registry.redhat.io` and `registry.access.redhat.com`.

## Reason
The previous fix (#7807) was insufficient because:
1. It targeted `docker-daemon` (local) instead of `docker` (remote) transport used by `podman pull`.
2. OCP 4.19+ systems appear to have specific signature policies (for more info see commit message) that override the global `default` setting. Explicitly defining the registry scopes is required to bypass these restrictions, as verified by the customer.