### PR TITLE
OCPBUGS-66947: Fix OLM manifest configMap metadata names

### DIFF
--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -65,9 +65,9 @@ type OperatorFeatureSupportID struct {
 
 // operatorMetadata is a struct to marshal the metadata content into YAML for the OLM Operator ConfigMap.
 type operatorMetadata struct {
-	Namespace        string   `yaml:"namespace"`
-	SubscriptionName string   `yaml:"subscriptionName"`
-	Manifests        []string `yaml:"manifests"`
+	Namespace        string   `json:"namespace" yaml:"namespace"`
+	SubscriptionName string   `json:"subscriptionName" yaml:"subscriptionName"`
+	Manifests        []string `json:"manifests" yaml:"manifests"`
 }
 
 // API defines Operator management operation

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -288,6 +288,26 @@ var _ = Describe("Operators manager", func() {
 			Expect(cm.Data).Should(HaveKey("lso-01.yaml"), "Expected 'lso-01.yaml' entry for LSO")
 			Expect(cm.Data).Should(HaveKey("lso.metadata.yaml"), "Expected 'lso.metadata.yaml' entry for LSO")
 
+			// Validate metadata content has correct field names (lowercase/camelCase, not capitalized)
+			metadataContent, exists := cm.Data["cnv.metadata.yaml"]
+			Expect(exists).Should(BeTrue(), "Expected cnv.metadata.yaml in ConfigMap data")
+			Expect(metadataContent).ShouldNot(BeEmpty())
+
+			// Unmarshal into a map to check field names
+			var metadata map[string]interface{}
+			err = yaml.Unmarshal([]byte(metadataContent), &metadata)
+			Expect(err).ShouldNot(HaveOccurred(), "Expected metadata to be valid YAML")
+
+			// Verify fields are lowercase/camelCase (not capitalized)
+			Expect(metadata).Should(HaveKey("namespace"), "Expected 'namespace' field (lowercase)")
+			Expect(metadata).Should(HaveKey("subscriptionName"), "Expected 'subscriptionName' field (camelCase)")
+			Expect(metadata).Should(HaveKey("manifests"), "Expected 'manifests' field (lowercase)")
+
+			// Validate the actual values
+			Expect(metadata["namespace"]).Should(Equal("kubevirt-hyperconverged"), "Expected correct namespace value")
+			Expect(metadata["subscriptionName"]).Should(Equal("hco-operatorhub"), "Expected correct subscriptionName value")
+			Expect(metadata["manifests"]).Should(ContainElement("cnv-01.yaml"), "Expected manifests to contain cnv-01.yaml")
+
 		})
 	})
 


### PR DESCRIPTION
For the OLM manifest configMapi, the metadata field names were capitalized instead of using lowercase/camelCase format, preventing assisted-installer from parsing the metadata correctly.

Tested with agent-based installer in dev-scripts. Resolved error message:
```
time="2025-12-08T13:35:07Z" level=info msg="Checking if nmstate operator is initialized" func="github.com/openshift/assisted-installer/src/assisted_installer_controller.(*controller).getReadyOperators" file="/go/src/github.com/openshift/assisted-installer/src/assisted_installer_controller/assisted_installer_controller.go:695"
time="2025-12-08T13:35:07Z" level=warning msg="Failed to get subscription  in " func="github.com/openshift/assisted-installer/src/k8s_client.(*k8sClient).GetCSVFromSubscription" file="/go/src/github.com/openshift/assisted-installer/src/k8s_client/k8s_client.go:596" error="resource name may not be empty"
```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
