### PR TITLE
MGMT-22273: reduce log amount

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -120,10 +120,10 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 		})
 
 	defer func() {
-		log.Info("Agent Reconcile ended")
+		log.Debug("Agent Reconcile ended")
 	}()
 
-	log.Info("Agent Reconcile started")
+	log.Debug("Agent Reconcile started")
 
 	agent := &aiv1beta1.Agent{}
 

--- a/internal/controller/controllers/agentclassification_controller.go
+++ b/internal/controller/controllers/agentclassification_controller.go
@@ -60,10 +60,10 @@ func (r *AgentClassificationReconciler) Reconcile(origCtx context.Context, req c
 		})
 
 	defer func() {
-		log.Info("AgentClassification Reconcile ended")
+		log.Debug("AgentClassification Reconcile ended")
 	}()
 
-	log.Info("AgentClassification Reconcile started")
+	log.Debug("AgentClassification Reconcile started")
 
 	classification := &aiv1beta1.AgentClassification{}
 	if err := r.Get(ctx, req.NamespacedName, classification); err != nil {

--- a/internal/controller/controllers/agentclusterinstall_controller.go
+++ b/internal/controller/controllers/agentclusterinstall_controller.go
@@ -55,10 +55,10 @@ func (r *AgentClusterInstallReconciler) Reconcile(origCtx context.Context, req c
 		})
 
 	defer func() {
-		log.Info("AgentClusterInstall Reconcile ended")
+		log.Debug("AgentClusterInstall Reconcile ended")
 	}()
 
-	log.Info("AgentClusterInstall Reconcile started")
+	log.Debug("AgentClusterInstall Reconcile started")
 
 	// Retrieve AgentClusterInstall
 	clusterInstall := &hiveext.AgentClusterInstall{}
@@ -97,7 +97,7 @@ func (r *AgentClusterInstallReconciler) Reconcile(origCtx context.Context, req c
 		}
 	}
 
-	log.Info("AgentClusterInstall Reconcile successfully retrieved the associated ClusterDeployment")
+	log.Debug("AgentClusterInstall Reconcile successfully retrieved the associated ClusterDeployment")
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/controllers/agentlabel_controller.go
+++ b/internal/controller/controllers/agentlabel_controller.go
@@ -52,10 +52,10 @@ func (r *AgentLabelReconciler) Reconcile(origCtx context.Context, req ctrl.Reque
 		})
 
 	defer func() {
-		log.Info("AgentLabel Reconcile ended")
+		log.Debug("AgentLabel Reconcile ended")
 	}()
 
-	log.Info("AgentLabel Reconcile started")
+	log.Debug("AgentLabel Reconcile started")
 
 	agent := &aiv1beta1.Agent{}
 	if err := r.Get(ctx, req.NamespacedName, agent); err != nil {

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -235,10 +235,10 @@ func (r *AgentServiceConfigReconciler) Reconcile(origCtx context.Context, req ct
 		})
 
 	defer func() {
-		log.Info("AgentServiceConfig Reconcile ended")
+		log.Debug("AgentServiceConfig Reconcile ended")
 	}()
 
-	log.Info("AgentServiceConfig Reconcile started")
+	log.Debug("AgentServiceConfig Reconcile started")
 
 	instance := &aiv1beta1.AgentServiceConfig{}
 	asc = initASC(r, instance)

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -242,10 +242,10 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 		})
 
 	defer func() {
-		log.Info("BareMetalHost Reconcile ended")
+		log.Debug("BareMetalHost Reconcile ended")
 	}()
 
-	log.Info("BareMetalHost Reconcile started")
+	log.Debug("BareMetalHost Reconcile started")
 	bmh := &bmh_v1alpha1.BareMetalHost{}
 
 	if err := r.Get(ctx, req.NamespacedName, bmh); err != nil {
@@ -1093,10 +1093,10 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 
 	if !proceed {
 		if requeuePeriod != 0 {
-			log.Infof("Requeuing reconcileBMH: %s", reason)
+			log.Debugf("Requeuing reconcileBMH: %s", reason)
 			return reconcileRequeue{requeueAfter: requeuePeriod}
 		}
-		log.Infof("Stopping reconcileBMH: %s", reason)
+		log.Debugf("Stopping reconcileBMH: %s", reason)
 		return reconcileComplete{dirty: dirty, stop: stopReconcileLoop}
 	}
 
@@ -1143,7 +1143,7 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 		return reconcileError{err: err}
 	}
 	if !installed {
-		log.Infof("Skipping spoke BareMetalHost reconcile for agent %s/%s since it's not day2.", agent.Name, agent.Namespace)
+		log.Debugf("Skipping spoke BareMetalHost reconcile for agent %s/%s since it's not day2.", agent.Name, agent.Namespace)
 		return reconcileComplete{}
 	}
 
@@ -1174,7 +1174,7 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 		return reconcileComplete{}
 	}
 	if skipSpokeBMH {
-		log.Infof("Skipping spoke BareMetalHost creation for agent %s/%s since it's baremetal platform without MAPI capability", agent.Name, agent.Namespace)
+		log.Debugf("Skipping spoke BareMetalHost creation for agent %s/%s since it's baremetal platform without MAPI capability", agent.Name, agent.Namespace)
 		return reconcileComplete{}
 	}
 
@@ -1202,7 +1202,7 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 	if err != nil {
 		log.WithError(err).Errorf("failed to get checksum and url value from master spoke machine")
 		if stopReconcileLoop {
-			log.Info("Stopping reconcileDay2SpokeBMH")
+			log.Debug("Stopping reconcileDay2SpokeBMH")
 			return reconcileComplete{dirty: false, stop: stopReconcileLoop}
 		}
 		return reconcileError{err: err}
@@ -1472,7 +1472,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 		return reconcileError{err: err}
 	}
 	if !installed {
-		log.Infof("Skipping spoke MCS cert for agent %s/%s since it's not day2.", agent.Name, agent.Namespace)
+		log.Debugf("Skipping spoke MCS cert for agent %s/%s since it's not day2.", agent.Name, agent.Namespace)
 		return reconcileComplete{}
 	}
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -141,10 +141,10 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 	log := logutil.FromContext(ctx, r.Log).WithFields(logFields)
 
 	defer func() {
-		log.Info("ClusterDeployment Reconcile ended")
+		log.Debug("ClusterDeployment Reconcile ended")
 	}()
 
-	log.Info("ClusterDeployment Reconcile started")
+	log.Debug("ClusterDeployment Reconcile started")
 
 	clusterDeployment := &hivev1.ClusterDeployment{}
 	clusterInstallDeleted := false
@@ -161,7 +161,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 
 	clusterInstall := &hiveext.AgentClusterInstall{}
 	if clusterDeployment.Spec.ClusterInstallRef == nil {
-		log.Infof("AgentClusterInstall not set for ClusterDeployment %s", clusterDeployment.Name)
+		log.Debugf("AgentClusterInstall not set for ClusterDeployment %s", clusterDeployment.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -176,7 +176,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 		if k8serrors.IsNotFound(err) {
 			// mark that clusterInstall was already deleted so we skip it if needed.
 			clusterInstallDeleted = true
-			log.WithField("AgentClusterInstall", aciName).Infof("AgentClusterInstall does not exist for ClusterDeployment %s", clusterDeployment.Name)
+			log.WithField("AgentClusterInstall", aciName).Debugf("AgentClusterInstall does not exist for ClusterDeployment %s", clusterDeployment.Name)
 			if clusterDeployment.ObjectMeta.DeletionTimestamp.IsZero() {
 				// we have no agentClusterInstall and clusterDeployment is not being deleted. stop reconciliation.
 				return ctrl.Result{}, nil

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -99,7 +99,7 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 	}
 
 	if err == nil {
-		log.Infof("Agent CR %s already exists", hostId)
+		log.Debugf("Agent CR %s already exists", hostId)
 		key := types.NamespacedName{Name: hostId, Namespace: infraEnvCR.Namespace}
 		// fetch previous by KubeKey
 		h, err2 := u.hostApi.GetHostByKubeKey(key)
@@ -109,11 +109,11 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 
 		if err2 == nil {
 			if cluster != nil && h.ClusterID != nil && *h.ClusterID == *cluster.ID {
-				log.Infof("Agent CR %s already exists, same cluster %s", hostId, h.ClusterID)
+				log.Debugf("Agent CR %s already exists, same cluster %s", hostId, h.ClusterID)
 				return nil
 			}
 			if h.InfraEnvID == *infraenv.ID {
-				log.Infof("Agent CR %s already exists, same infraEnv %s", hostId, h.InfraEnvID)
+				log.Debugf("Agent CR %s already exists, same infraEnv %s", hostId, h.InfraEnvID)
 				return nil
 			}
 			//delete previous host

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -149,8 +149,8 @@ func (hr *HypershiftAgentServiceConfigReconciler) Reconcile(origCtx context.Cont
 			"hypershift_service_namespace": req.Namespace,
 		})
 
-	log.Info("HypershiftAgentServiceConfig Reconcile started")
-	defer log.Info("HypershiftAgentServiceConfig Reconcile ended")
+	log.Debug("HypershiftAgentServiceConfig Reconcile started")
+	defer log.Debug("HypershiftAgentServiceConfig Reconcile ended")
 
 	// read the resource from k8s
 	instance := &aiv1beta1.HypershiftAgentServiceConfig{}

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -104,10 +104,10 @@ func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request
 		})
 
 	defer func() {
-		log.Info("InfraEnv Reconcile ended")
+		log.Debug("InfraEnv Reconcile ended")
 	}()
 
-	log.Info("InfraEnv Reconcile started")
+	log.Debug("InfraEnv Reconcile started")
 
 	infraEnv := &aiv1beta1.InfraEnv{}
 	if err := r.Get(ctx, req.NamespacedName, infraEnv); err != nil {

--- a/internal/controller/controllers/local_cluster_import_controller.go
+++ b/internal/controller/controllers/local_cluster_import_controller.go
@@ -85,10 +85,10 @@ func (r *LocalClusterImportReconciler) setReconciliationStatus(ctx context.Conte
 
 func (r *LocalClusterImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	defer func() {
-		r.log.Info("AgentServiceConfig (LocalClusterImport) Reconcile ended")
+		r.log.Debug("AgentServiceConfig (LocalClusterImport) Reconcile ended")
 	}()
 
-	r.log.Info("AgentServiceConfig (LocalClusterImport) Reconcile started")
+	r.log.Debug("AgentServiceConfig (LocalClusterImport) Reconcile started")
 
 	instance := &aiv1beta1.AgentServiceConfig{}
 

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -98,10 +98,10 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		})
 
 	defer func() {
-		log.Info("PreprovisioningImage Reconcile ended")
+		log.Debug("PreprovisioningImage Reconcile ended")
 	}()
 
-	log.Info("PreprovisioningImage Reconcile started")
+	log.Debug("PreprovisioningImage Reconcile started")
 
 	// Retrieve PreprovisioningImage
 	image := &metal3_v1alpha1.PreprovisioningImage{}
@@ -172,7 +172,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 	// The image has been created sooner than the specified cooldown period
 	imageTimePlusCooldown := infraEnv.Status.CreatedTime.Time.Add(InfraEnvImageCooldownPeriod)
 	if imageTimePlusCooldown.After(time.Now()) {
-		log.Info("InfraEnv image is too recent. Requeuing and retrying again soon")
+		log.Debug("InfraEnv image is too recent. Requeuing and retrying again soon")
 		err = r.patchImageStatus(ctx, log, image, setCoolDownCondition)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -554,7 +554,7 @@ func (r *PreprovisioningImageReconciler) getIronicAgentImageByPriority(
 	}
 
 	if iccIronicAgentImage != "" && r.imageMatchesInfraenvArch(log, infraEnvInternal, iccIronicAgentImage) {
-		log.Infof("Setting ironic agent image (%s) from ICC config", iccIronicAgentImage)
+		log.Debugf("Setting ironic agent image (%s) from ICC config", iccIronicAgentImage)
 		return iccIronicAgentImage
 	}
 
@@ -576,7 +576,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, lo
 	}
 
 	if iccConfig != nil {
-		log.Infof("Using ironic URLs from ICC config (Base: %s, Inspector: %s)", iccConfig.IronicBaseURL, iccConfig.IronicInspectorBaseUrl)
+		log.Debugf("Using ironic URLs from ICC config (Base: %s, Inspector: %s)", iccConfig.IronicBaseURL, iccConfig.IronicInspectorBaseUrl)
 	} else {
 		iccConfig = &ICCConfig{}
 		if err := r.fillIronicServiceURLs(ctx, infraEnv, infraEnvInternal, iccConfig); err != nil {
@@ -590,7 +590,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, lo
 		return nil, fmt.Errorf("Failed to determine ironic config")
 	}
 
-	log.Infof("Ironic Agent Image is (%s) Ironic URL is (%s) Inspector URL is (%s)",
+	log.Debugf("Ironic Agent Image is (%s) Ironic URL is (%s) Inspector URL is (%s)",
 		iccConfig.IronicAgentImage,
 		iccConfig.IronicBaseURL,
 		iccConfig.IronicInspectorBaseUrl)
@@ -625,6 +625,11 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 
 	updated := false
 	if string(conf) != infraEnvInternal.InternalIgnitionConfigOverride {
+		log.Infof("Updating Ironic config: Agent Image (%s) Ironic URL (%s) Inspector URL (%s)",
+			iccConfig.IronicAgentImage,
+			iccConfig.IronicBaseURL,
+			iccConfig.IronicInspectorBaseUrl)
+
 		var mirrorRegistryConfiguration *common.MirrorRegistryConfiguration
 		if infraEnvInternal.MirrorRegistryConfiguration != "" {
 			mirrorRegistryConfiguration, err = r.processMirrorRegistryConfig(ctx, log, infraEnv)

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -156,7 +156,7 @@ func (i *InstructionManager) GetNextSteps(ctx context.Context, host *models.Host
 	InfraEnvID := host.InfraEnvID
 	hostID := host.ID
 	hostStatus := swag.StringValue(host.Status)
-	log.Infof("GetNextSteps infra_env: <%s>, host: <%s>, host status: <%s>", InfraEnvID, hostID, hostStatus)
+	log.Debugf("GetNextSteps infra_env: <%s>, host: <%s>, host status: <%s>", InfraEnvID, hostID, hostStatus)
 
 	returnSteps := models.Steps{}
 	stateToSteps := i.installingClusterStateToSteps
@@ -280,7 +280,7 @@ func createStepID(stepType models.StepType) string {
 
 func logSteps(steps models.Steps, infraEnvId strfmt.UUID, hostId *strfmt.UUID, log logrus.FieldLogger) {
 	if len(steps.Instructions) == 0 {
-		log.Infof("No steps required for infraEnv <%s> host <%s>", infraEnvId, hostId)
+		log.Debugf("No steps required for infraEnv <%s> host <%s>", infraEnvId, hostId)
 	}
 	for _, step := range steps.Instructions {
 		log.Infof("Submitting step <%s> id <%s> to infra_env <%s> host <%s>  Arguments: <%+v>", step.StepType, step.StepID, infraEnvId, hostId, step.Args)


### PR DESCRIPTION
## [MGMT-22273](https://issues.redhat.com//browse/MGMT-22273): Reduce excessive controller logging to improve must-gather usefulness

In large environments, the assisted-service generates such a high volume of logs that must-gathers become effectively useless for debugging. In one reported environment, the collected logs only spanned **20 minutes** of activity, making it nearly impossible to debug customer issues unless the gather is created immediately after the problem occurs.

The root cause is that controllers log many routine operational messages at `Info` level that provide no diagnostic value when nothing is actually changing.

The fix moves high-frequency, low-value log messages from `Info` to `Debug` level while preserving actionable messages that indicate actual state changes or operations:
- Reconcile start/end messages fire for every reconciliation cycle, which can be hundreds of times per minute in large environments. They provide no diagnostic value at `Info` level since the actual work done (or not done) within the reconcile is logged separately.
- "Skipping" and "Stopping" messages (BMH controller and others) indicate expected no-op conditions during normal operation. For example, "Skipping spoke BareMetalHost reconcile... since it's not day2" fires on every reconcile for day1 installations, which is expected behavior, not something requiring attention.
- Configuration confirmation messages log the same Ironic configuration values on every reconcile cycle. The configuration rarely changes, so repeatedly logging it provides no value.
- "Already exists" messages: when an Agent CR already exists, this is normal operation during re-registration or reconciliation. It's not an action being taken.
- Host polling messages: `GetNextSteps` is called every ~60 seconds per host. In environments with many hosts, this generates significant log volume with no diagnostic value during normal operation. The "No steps required" message similarly fires constantly when hosts are idle. `Submitting step...` remains at `Info` level because it indicates an actual instruction being sent to a host.

Based on simple test results this change can reduce the assisted-service log by more than 50% even for an SNO deployment, but potentionally can have much higher impact on large installations.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ x Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
