### PR TITLE
NO-ISSUE: Fix list bundle validation to check for feature incompatibilities

### DIFF
--- a/client/operators/v2_list_bundles_parameters.go
+++ b/client/operators/v2_list_bundles_parameters.go
@@ -84,7 +84,7 @@ type V2ListBundlesParams struct {
 
 	/* OpenshiftVersion.
 
-	   Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	   Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.
 	*/
 	OpenshiftVersion *string
 

--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -183,6 +183,26 @@ func IsFeatureAvailable(featureId models.FeatureSupportLevelID, openshiftVersion
 	return GetSupportLevel(featureId, filters) != models.SupportLevelUnavailable
 }
 
+func IsFeatureCompatibleWithOther(openshiftVersion string, featureID models.FeatureSupportLevelID, other []models.FeatureSupportLevelID) bool {
+	if other == nil {
+		return true
+	}
+
+	feature := GetFeatureByID(featureID)
+	if feature == nil {
+		return true // Unknown features are considered compatible with everything
+	}
+
+	incompatibilities := feature.getIncompatibleFeatures(openshiftVersion)
+	for _, incompatibility := range incompatibilities {
+		if slices.Contains(other, incompatibility) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func isFeatureCompatible(openshiftVersion string, feature SupportLevelFeature, features ...SupportLevelFeature) *SupportLevelFeature {
 	incompatibilities := feature.getIncompatibleFeatures(openshiftVersion)
 

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -700,7 +700,7 @@ func (mgr *Manager) ListBundles(filters *featuresupport.SupportLevelFilters, fea
 		}
 
 		// Check if all operators in the bundle are supported using featuresupport API
-		if mgr.isBundleSupported(completeBundleDetails, filters) {
+		if mgr.isBundleSupported(completeBundleDetails, filters, featureIDs) {
 			ret = append(ret, completeBundleDetails)
 		}
 	}
@@ -761,7 +761,7 @@ func (mgr *Manager) GetOperatorDependenciesFeatureID() []OperatorFeatureSupportI
 }
 
 // isBundleSupported checks if all operators in a bundle are supported using featuresupport API
-func (mgr *Manager) isBundleSupported(bundle *models.Bundle, filters *featuresupport.SupportLevelFilters) bool {
+func (mgr *Manager) isBundleSupported(bundle *models.Bundle, filters *featuresupport.SupportLevelFilters, featureIDs []models.FeatureSupportLevelID) bool {
 	// If bundle has no operators, it's not supported
 	if len(bundle.Operators) == 0 {
 		return false
@@ -781,7 +781,7 @@ func (mgr *Manager) isBundleSupported(bundle *models.Bundle, filters *featuresup
 			return false
 		}
 
-		if !mgr.isOperatorSupported(operatorFeatureSupportID, *filters) {
+		if !mgr.isOperatorSupported(operatorFeatureSupportID, *filters, featureIDs) {
 			return false
 		}
 	}
@@ -800,9 +800,13 @@ func (mgr *Manager) getOperatorFeatureSupportID(operatorName string) (models.Fea
 }
 
 // isOperatorSupported checks if an operator is supported using featuresupport API
-func (mgr *Manager) isOperatorSupported(featureID models.FeatureSupportLevelID, filters featuresupport.SupportLevelFilters) bool {
+func (mgr *Manager) isOperatorSupported(featureID models.FeatureSupportLevelID, filters featuresupport.SupportLevelFilters, featureIDs []models.FeatureSupportLevelID) bool {
 	supportLevel := featuresupport.GetSupportLevel(featureID, filters)
 
 	// Consider the operator supported if it's not unavailable or unsupported
-	return supportLevel != models.SupportLevelUnavailable && supportLevel != models.SupportLevelUnsupported
+	if supportLevel == models.SupportLevelUnavailable || supportLevel == models.SupportLevelUnsupported {
+		return false
+	}
+
+	return featuresupport.IsFeatureCompatibleWithOther(filters.OpenshiftVersion, featureID, featureIDs)
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5788,7 +5788,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.",
+            "description": "Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.",
             "name": "openshift_version",
             "in": "query"
           },
@@ -17234,7 +17234,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.",
+            "description": "Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.",
             "name": "openshift_version",
             "in": "query"
           },

--- a/restapi/operations/operators/v2_list_bundles_parameters.go
+++ b/restapi/operations/operators/v2_list_bundles_parameters.go
@@ -54,7 +54,7 @@ type V2ListBundlesParams struct {
 	  Collection Format: multi
 	*/
 	FeatureIds []string
-	/*Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	/*Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.
 	  In: query
 	*/
 	OpenshiftVersion *string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2756,7 +2756,7 @@ paths:
         - in: query
           name: openshift_version
           type: string
-          description: Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+          description: Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.
         - in: query
           name: cpu_architecture
           description: The CPU architecture of the image (x86_64/arm64/etc). openshift_version must be set.

--- a/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/operators/v2_list_bundles_parameters.go
@@ -84,7 +84,7 @@ type V2ListBundlesParams struct {
 
 	/* OpenshiftVersion.
 
-	   Version of the OpenShift cluster. If the parameter is not specified, only feature_ids parameter is taken into account.
+	   Version of the OpenShift cluster. If the parameter is not specified, no filtering is applied.
 	*/
 	OpenshiftVersion *string
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Current ilmplementation doesn't check for incompatibilities. As a result, with SNO feature as a constraint, the virtualization is returned while it contains operators that are incompatible with SNO

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

SNO Filtering
```
matt@redhat:assisted-service$ curl -X GET "http://127.0.0.1:8090/api/assisted-install/v2/operators/bundles?openshift_version=4.18.1&cpu_architecture=x86_64&platform_type=none&feature_ids=SNO" -s | jq                                                                                                                       
[                                                                                                                                                                                                                                                                                                                             
  {                                                                                                                                                                                                                                                                                                                           
    "description": "Train, serve, monitor and manage AI/ML models and applications using GPUs.",                                                                                                                                                                                                                              
    "id": "openshift-ai",                                                                                                                                                                                                                                                                                                     
    "operators": [                                                                                                                                                                                                                                                                                                            
      "nvidia-gpu",                                                                                                                                                                                                                                                                                                           
      "node-feature-discovery",                                                                                                                                                                                                                                                                                               
      "amd-gpu",                                                                                                                                                                                                                                                                                                              
      "lvm",                                                                                                                                                                                                                                                                                                                  
      "openshift-ai"                                                                                                                                                                                                                                                                                                          
    ],                                                                                                                                                                                                                                                                                                                        
    "title": "OpenShift AI"                                                                                                                                                                                                                                                                                                   
  }                                                                                                                                                                                                                                                                                                                           
]                                                                                                                                                                                                                                                                                                                             
 ```
 
 Backward compatibility
 ```
 matt@redhat:assisted-service$ curl -X GET "http://127.0.0.1:8090/api/assisted-install/v2/operators/bundles" -s | jq
[
  {
    "description": "Run virtual machines alongside containers on one platform.",
    "id": "virtualization",
    "operators": [
      "nmstate",
      "mtv",
      "node-maintenance",
      "kube-descheduler",
      "loki",
      "openshift-logging",
      "numaresources",
      "metallb",
      "cnv",
      "node-healthcheck",
      "fence-agents-remediation",
      "cluster-observability",
      "oadp"
    ],
    "title": "Virtualization"
  },
  {
    "description": "Train, serve, monitor and manage AI/ML models and applications using GPUs.",
    "id": "openshift-ai",
    "operators": [
      "node-feature-discovery",
      "pipelines",
      "serverless",
      "openshift-ai",
      "authorino",
      "amd-gpu",
      "nvidia-gpu",
      "servicemesh",
      "odf",
      "kmm"
    ],
    "title": "OpenShift AI"
  }
]
```

Without SNO
```
matt@redhat:assisted-service$ curl -X GET "http://127.0.0.1:8090/api/assisted-install/v2/operators/bundles?openshift_version=4.18.1&cpu_architecture=x86_64&platform_type=none" -s | jq                                                                                                                                       
[                                                                                                                                                                                                                                                                                                                             
  {                                                                                                                                                                                                                                                                                                                           
    "description": "Run virtual machines alongside containers on one platform.",                                                                                                                                                                                                                                              
    "id": "virtualization",                                                                                                                                                                                                                                                                                                   
    "operators": [                                                                                                                                                                                                                                                                                                            
      "node-maintenance",                                                                                                                                                                                                                                                                                                     
      "loki",                                                                                                                                                                                                                                                                                                                 
      "openshift-logging",                                                                                                                                                                                                                                                                                                    
      "cluster-observability",
      "nmstate",
      "oadp",
      "mtv",
      "node-healthcheck",
      "metallb",
      "cnv",
      "fence-agents-remediation",
      "kube-descheduler",
      "numaresources"
    ],
    "title": "Virtualization"
  },
  {
    "description": "Train, serve, monitor and manage AI/ML models and applications using GPUs.",
    "id": "openshift-ai",
    "operators": [
      "node-feature-discovery",
      "authorino",
      "amd-gpu",
      "openshift-ai",
      "nvidia-gpu",
      "pipelines",
      "servicemesh",
      "serverless",
      "kmm",
      "odf"
    ],
    "title": "OpenShift AI"
  }
]
```

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
