### PR TITLE
ACM-27859: Allow PreprovisioningImage finalizer to be removed once BMH finishes deprovisioning

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -769,11 +769,20 @@ func (r *PreprovisioningImageReconciler) handlePreprovisioningImageDeletion(ctx 
 		return ctrl.Result{RequeueAfter: longerRequeueAfterOnError}, err
 	}
 
-	// PreprovisioningImage should wait for a BMH with automated cleaning enabled to be deleted
+	// PreprovisioningImage should wait for a BMH with automated cleaning enabled to be deleted or finish deprovisioning
 	if bmh.Spec.AutomatedCleaningMode != metal3_v1alpha1.CleaningModeDisabled {
-		log.Infof("Cannot delete PreprovisioningImage yet: BMH %s/%s with automatedCleaningMode=%s exists and requires the image for deprovisioning",
-			bmh.Namespace, bmh.Name, bmh.Spec.AutomatedCleaningMode)
-		return ctrl.Result{Requeue: true}, nil
+		if bmh.DeletionTimestamp.IsZero() {
+			log.Infof("Cannot delete PreprovisioningImage yet: BMH %s/%s with automatedCleaningMode=%s is not being deleted",
+				bmh.Namespace, bmh.Name, bmh.Spec.AutomatedCleaningMode)
+			return ctrl.Result{Requeue: true}, nil
+		}
+		// already deprovisioned is true when the BMH is either in state powering off before delete or deleting
+		alreadyDeprovisioned := funk.Contains([]metal3_v1alpha1.ProvisioningState{metal3_v1alpha1.StatePoweringOffBeforeDelete, metal3_v1alpha1.StateDeleting}, bmh.Status.Provisioning.State)
+		if !alreadyDeprovisioned {
+			log.Infof("Cannot delete PreprovisioningImage yet: BMH %s/%s with automatedCleaningMode=%s has not finished deprovisioning yet. Current state: %s",
+				bmh.Namespace, bmh.Name, bmh.Spec.AutomatedCleaningMode, bmh.Status.Provisioning.State)
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// Safe to delete, remove finalizer

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -1366,6 +1366,7 @@ var _ = Describe("PreprovisioningImage deletion protection", func() {
 
 			// UpdateBMH to set metadata cleaning enabled
 			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeMetadata
+			bmh.Status.Provisioning.State = metal3_v1alpha1.StateDeprovisioning
 			bmh.Finalizers = []string{"arbitraryfinalizer"}
 			Expect(c.Update(ctx, bmh)).To(Succeed())
 			// Set BMH to be deleting
@@ -1388,6 +1389,46 @@ var _ = Describe("PreprovisioningImage deletion protection", func() {
 			Expect(c.Delete(ctx, ppi)).To(Succeed())
 			// Set BMH cleaning to disabled
 			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeDisabled
+			Expect(c.Update(ctx, bmh)).To(Succeed())
+			Expect(c.Delete(ctx, bmh)).To(Succeed())
+
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			// Verify ppi was deleted
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(k8serrors.IsNotFound(c.Get(ctx, key, ppi))).To(BeTrue())
+		})
+
+		It("allows deletion when BMH finished deprovisioning with state deleting", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+			// Set BMH to be deleting
+			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeMetadata
+			bmh.Status.Provisioning.State = metal3_v1alpha1.StateDeleting
+			Expect(c.Update(ctx, bmh)).To(Succeed())
+			Expect(c.Delete(ctx, bmh)).To(Succeed())
+
+			result, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			// Verify ppi was deleted
+			key := types.NamespacedName{Name: ppi.Name, Namespace: ppi.Namespace}
+			Expect(k8serrors.IsNotFound(c.Get(ctx, key, ppi))).To(BeTrue())
+		})
+
+		It("allows deletion when BMH finished deprovisioning with state powering off before delete", func() {
+			Expect(c.Create(ctx, ppi)).To(Succeed())
+			// Delete ppi
+			Expect(c.Delete(ctx, ppi)).To(Succeed())
+			// Set BMH to be deleting
+			bmh.Spec.AutomatedCleaningMode = metal3_v1alpha1.CleaningModeMetadata
+			bmh.Status.Provisioning.State = metal3_v1alpha1.StatePoweringOffBeforeDelete
 			Expect(c.Update(ctx, bmh)).To(Succeed())
 			Expect(c.Delete(ctx, bmh)).To(Succeed())
 


### PR DESCRIPTION
BMH owns the PreprovisioningImage (PPI), and foreground deletion waits for all children resources (PPI) to be deleted before it removes the owner (BMH)

With the PreprovisioningImage finalizer, there is a possibly for a deadlock to happen when foreground deletion is done.

The BMH (with foreground deletion) waits for the PPI to be deleted, however, previously, the PPI ends up waiting for the BMH to be deleted before its finalizer can be removed.

To prevent this, we'll rely on the state of the BMH to remove the finalizer.

If the BMH has finished deprovisioning (state powering off before deleting or deleting) then we assume we can safely remove the PPI finalizer as the image is no longer needed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): Delete BMH w/ metadata cleaning and foreground deletion. Observe it gets removed 
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 