### PR TITLE
MGMT-22278: Skip deleting spoke resources for an uninstalled agent

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -958,10 +958,16 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		shouldAutoApproveCSRs bool
 		spokeClient           spoke_k8s_client.SpokeK8sClient
 		node                  *corev1.Node
+		ret                   ctrl.Result = ctrl.Result{}
 	)
 	patch := client.MergeFrom(origAgent.DeepCopy())
-
-	ret := ctrl.Result{}
+	defer func() {
+		if patchErr := r.Status().Patch(ctx, agent, patch); patchErr != nil {
+			log.WithError(patchErr).Error("failed to patch agent Status")
+			err = patchErr
+			return
+		}
+	}()
 	specSynced(agent, syncErr, internal)
 
 	if h != nil && h.Status != nil {
@@ -997,7 +1003,8 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 				}
 				if shouldAutoApproveCSRs, err = r.shouldApproveCSRsForAgent(ctx, agent, h); err != nil {
 					log.WithError(err).Errorf("Failed to determine if agent %s/%s is rebooting and belongs to none platform cluster or has an associated BMH", agent.Namespace, agent.Name)
-					return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
+					ret = ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}
+					return ret, nil
 				}
 
 				// TODO: Node name might be FQDN and not just host name if cluster is IPv6
@@ -1005,7 +1012,8 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 				if err != nil {
 					if !k8serrors.IsNotFound(err) {
 						r.Log.WithError(err).Errorf("agent %s/%s: failed to get node", agent.Namespace, agent.Name)
-						return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+						ret = ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}
+						return ret, err
 					}
 					node = nil
 				}
@@ -1014,10 +1022,12 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 				}
 				if err = r.applyDay2NodeLabels(ctx, log, agent, node, spokeClient); err != nil {
 					log.WithError(err).Errorf("Failed to apply labels for day2 node %s/%s", agent.Namespace, agent.Name)
-					return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+					ret = ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}
+					return ret, err
 				}
 				if err = r.UpdateDay2InstallPogress(ctx, h, agent, node, shouldAutoApproveCSRs); err != nil {
-					return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
+					ret = ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}
+					return ret, err
 				}
 				if agent.Status.Progress.CurrentStage != models.HostStageDone {
 					ret = ctrl.Result{RequeueAfter: r.ApproveCsrsRequeueDuration}
@@ -1040,7 +1050,9 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		if clusterId != nil {
 			err = r.populateEventsURL(log, agent, h.InfraEnvID.String())
 			if err != nil {
-				return ctrl.Result{Requeue: true}, nil
+				ret = ctrl.Result{Requeue: true}
+				err = nil
+				return ret, nil
 			}
 			if agent.Status.DebugInfo.LogsURL == "" && !time.Time(h.LogsCollectedAt).Equal(time.Time{}) { // logs collection time is updated means logs are available
 				var logsURL string
@@ -1061,18 +1073,10 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		setConditionsUnknown(agent)
 	}
 
-	if !reflect.DeepEqual(agent, origAgent) {
-		if patchErr := r.Status().Patch(ctx, agent, patch); patchErr != nil {
-			log.WithError(patchErr).Error("failed to patch agent Status")
-			return ctrl.Result{Requeue: true}, nil
-		}
-	} else {
-		log.Debugf("Agent %s/%s: update skipped", agent.Namespace, agent.Name)
-	}
 	if syncErr != nil && internal {
-		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
+		ret = ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}
 	}
-	return ret, nil
+	return ret, err
 }
 
 func (r *AgentReconciler) UpdateDay2InstallPogress(ctx context.Context, h *models.Host, agent *aiv1beta1.Agent, node *corev1.Node, shouldAutoApproveCSRs bool) error {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -3439,7 +3439,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			nodeError:           errors.New("Stam"),
 			expectedError:       errors.New("Stam"),
 			expectedResult:      ctrl.Result{RequeueAfter: defaultRequeueAfterOnError},
-			expectedStatus:      "",
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       "",
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,


### PR DESCRIPTION
Previously, when an Agent starts installation and hasn't completed installing, and a user comes in and tries to delete it, the Agent will be stuck deleting because spoke resource deletion will fail.

This gates the spoke cleanup process with the Agent's current status. The Agent must have spoke resources that need to be removed or is installed.

If the Agent does not have any spoke resources or is not installed, then the spoke cleanup process will be skipped.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual Testing

#### Recreate customer scenario

1. Infraenv w/ 1 BMH and 1 agent
2. Start installing agent
3. Delete BMH, Agent, and InfraEnv
4. Should delete all resources successfully

#### Additional functionality testing

- [x] Agent that is installing with a BMH created should have its BMH (and Node) deleted from the spoke cluster when it's deleted and should be deleted successfully afterwards
- [x] Agent that is installing with CSRs approved should have its Node deleted from the spoke cluster and should be deleted successfully afterwards

#### Regression testing

- [x] Agent that has not been bound to a cluster and has not started installation should be deleted successfully
- [x] Agent that has installed (with InfraEnv and Cluster not deleted) should have its spoke resources removed and be deleted successfully
- [x] Agent that has installed and needs spoke resource removal, but assisted does not have spoke client access (fails to delete spoke resources) should not be deleted
- [x] Agent that has installed (with InfraEnv deleted, but Cluster not deleted) should not have its spoke resources removed and be deleted successfully
- [x] Agent that has installed (with InfraEnv not deleted, but Cluster deleted) should not have its spoke resources removed and be deleted successfully 
- [x] Agent that has installed (with InfraEnv and Cluster not deleted) with skip spoke cleanup annotation should not have its spoke resources removed and be deleted successfully



## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
