### PR TITLE
ACM-27290: Fix policy.json not generated for InfraEnv mirror registry config

### DIFF
--- a/internal/ignition/discovery_test.go
+++ b/internal/ignition/discovery_test.go
@@ -756,6 +756,7 @@ location = "%s"
 
 		It("produce ignition with secure cluster mirror registries config", func() {
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockMirrorRegistriesConfigBuilder.EXPECT().GenerateInsecurePolicyJSON().Return("", nil).Times(1)
 
 			mirrorRegistryConf, _ := getMirrorRegistryConfigurations(getSecureRegistryToml(), mirrorRegistryCertificate)
 			Expect(infraEnv.SetMirrorRegistryConfiguration(mirrorRegistryConf)).NotTo(HaveOccurred())
@@ -775,6 +776,7 @@ location = "%s"
 
 		It("service MirrorRegistriesConfig and cluster MirrorRegistryConfiguration are both set - only MirrorRegistryConfiguration applied", func() {
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockMirrorRegistriesConfigBuilder.EXPECT().GenerateInsecurePolicyJSON().Return("", nil).Times(1)
 
 			// These mocks are not needed here; they are only included to demonstrate that having service mirror configurations
 			// does not affect the mirror registry configuration in the ignition file.
@@ -809,6 +811,7 @@ location = "%s"
 
 		It("produce ignition with insecure cluster mirror registries config", func() {
 			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockMirrorRegistriesConfigBuilder.EXPECT().GenerateInsecurePolicyJSON().Return("", nil).Times(1)
 
 			mirrorRegistryConf, _ := getMirrorRegistryConfigurations(getInsecureRegistryToml(), mirrorRegistryCertificate)
 			Expect(infraEnv.SetMirrorRegistryConfiguration(mirrorRegistryConf)).NotTo(HaveOccurred())
@@ -844,6 +847,34 @@ location = "%s"
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(text).To(ContainSubstring("policy.json"))
+		})
+
+		It("adds insecureAcceptAnything policy when InfraEnv has mirror config and ForceInsecurePolicy is true", func() {
+			policyJSON := `{"default":[{"type":"insecureAcceptAnything"}],"transports":{"docker-daemon":{"":{"type":"insecureAcceptAnything"}}}}`
+			encodedPolicy := base64.StdEncoding.EncodeToString([]byte(policyJSON))
+			mockMirrorRegistriesConfigBuilder.EXPECT().GenerateInsecurePolicyJSON().Return(encodedPolicy, nil).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, errors.New("some error")).Times(1)
+
+			mirrorRegistryConf, _ := getMirrorRegistryConfigurations(getSecureRegistryToml(), mirrorRegistryCertificate)
+			Expect(infraEnv.SetMirrorRegistryConfiguration(mirrorRegistryConf)).NotTo(HaveOccurred())
+			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
+			Expect(err).ToNot(HaveOccurred())
+
+			config, report, err := config_31.Parse([]byte(text))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.IsFatal()).To(BeFalse())
+
+			var policyFile *types_31.File
+			for i := range config.Storage.Files {
+				if config.Storage.Files[i].Path == "/etc/containers/policy.json" {
+					policyFile = &config.Storage.Files[i]
+					break
+				}
+			}
+			Expect(policyFile).NotTo(BeNil(), "policy.json should be present in ignition files")
+			Expect(policyFile.Overwrite).NotTo(BeNil())
+			Expect(*policyFile.Overwrite).To(BeTrue(), "policy.json should have overwrite=true")
 		})
 
 		It("does not add policy file when ForceInsecurePolicy is false", func() {


### PR DESCRIPTION
When mirror registry is configured via `InfraEnv.spec.mirrorRegistryRef` (instead of `AgentServiceConfig.spec.mirrorRegistryRef`), the permissive policy.json was not being injected into the discovery ignition. This caused RHCOS 4.19 agents to fail with signature verification errors:

  Source image rejected: A signature was required, but no signature exists

  ## Root Cause

  `setIgnitionMirrorRegistry()` had two separate code paths:
  1. **InfraEnv path** - sets registries.conf/CA, returns early with **no policy.json**
  2. **Service path** - sets registries.conf/CA **and** calls `GenerateInsecurePolicyJSON()`

  PR #7807 only addressed the service-level path, leaving the InfraEnv path broken.

  ## Fix

  Refactored to call `GenerateInsecurePolicyJSON()` after either code path, ensuring policy.json is generated whenever any mirror config exists and `ForceInsecurePolicy` is enabled.

  ## Testing

  - Added unit test for InfraEnv mirror config + ForceInsecurePolicy=true
  - All existing ignition tests pass

  ## References

  - Completes fix started in PR #7807
  - Ticket: [ACM-27290](https://issues.redhat.com//browse/ACM-27290)