### PR TITLE
OCPBUGS-72403: Fix YAML marshaling for Kubernetes types in disconnected ignition

### DIFF
--- a/client/installer/v2_download_infra_env_files_parameters.go
+++ b/client/installer/v2_download_infra_env_files_parameters.go
@@ -63,7 +63,7 @@ type V2DownloadInfraEnvFilesParams struct {
 
 	/* DiscoveryIsoType.
 
-	   Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.
+	   Overrides the ISO type for the discovery ignition.
 	*/
 	DiscoveryIsoType *string
 

--- a/internal/ignition/disconnected.go
+++ b/internal/ignition/disconnected.go
@@ -24,9 +24,9 @@ import (
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type DisconnectedIgnitionGenerator struct {

--- a/internal/ignition/disconnected_test.go
+++ b/internal/ignition/disconnected_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("Disconnected Ignition", func() {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3926,10 +3926,11 @@ func init() {
           {
             "enum": [
               "full-iso",
-              "minimal-iso"
+              "minimal-iso",
+              "disconnected-iso"
             ],
             "type": "string",
-            "description": "Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.",
+            "description": "Overrides the ISO type for the discovery ignition.",
             "name": "discovery_iso_type",
             "in": "query"
           }
@@ -15372,10 +15373,11 @@ func init() {
           {
             "enum": [
               "full-iso",
-              "minimal-iso"
+              "minimal-iso",
+              "disconnected-iso"
             ],
             "type": "string",
-            "description": "Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.",
+            "description": "Overrides the ISO type for the discovery ignition.",
             "name": "discovery_iso_type",
             "in": "query"
           }

--- a/restapi/operations/installer/v2_download_infra_env_files_parameters.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_parameters.go
@@ -32,7 +32,7 @@ type V2DownloadInfraEnvFilesParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.
+	/*Overrides the ISO type for the discovery ignition.
 	  In: query
 	*/
 	DiscoveryIsoType *string
@@ -122,7 +122,7 @@ func (o *V2DownloadInfraEnvFilesParams) bindDiscoveryIsoType(rawData []string, h
 // validateDiscoveryIsoType carries on validations for parameter DiscoveryIsoType
 func (o *V2DownloadInfraEnvFilesParams) validateDiscoveryIsoType(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("discovery_iso_type", "query", *o.DiscoveryIsoType, []interface{}{"full-iso", "minimal-iso"}, true); err != nil {
+	if err := validate.EnumCase("discovery_iso_type", "query", *o.DiscoveryIsoType, []interface{}{"full-iso", "minimal-iso", "disconnected-iso"}, true); err != nil {
 		return err
 	}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1710,10 +1710,10 @@ paths:
           enum: ['discovery-image-always', 'boot-order-control']
         - in: query
           name: discovery_iso_type
-          description: Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.
+          description: Overrides the ISO type for the discovery ignition.
           required: false
           type: string
-          enum: ['full-iso', 'minimal-iso']
+          enum: ['full-iso', 'minimal-iso', 'disconnected-iso']
       responses:
         "200":
           description: Success.

--- a/vendor/github.com/openshift/assisted-service/client/installer/v2_download_infra_env_files_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/installer/v2_download_infra_env_files_parameters.go
@@ -63,7 +63,7 @@ type V2DownloadInfraEnvFilesParams struct {
 
 	/* DiscoveryIsoType.
 
-	   Overrides the ISO type for the disovery ignition, either 'full-iso' or 'minimal-iso'.
+	   Overrides the ISO type for the discovery ignition.
 	*/
 	DiscoveryIsoType *string
 


### PR DESCRIPTION
Replace `gopkg.in/yaml.v2` with `sigs.k8s.io/yaml` for marshaling Kubernetes manifests.

The yaml.v2 library uses struct field names when no `yaml:` tag is present, but K8s types use `json:` tags. This caused `openshift-install` to fail with "unknown field objectmeta" when parsing generated manifests.

Also adds `disconnected-iso` to the `discovery_iso_type` query parameter enum to allow requesting disconnected ignition via the download endpoint, and fixes a typo ("disovery" -> "discovery").