### PR TITLE
MGMT-22423: Fix race condition in ensureOwnerRef causing spec.installed to remain false

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -2415,6 +2415,11 @@ func FindStatusCondition(conditions []hivev1.ClusterInstallCondition, conditionT
 
 // ensureOwnerRef sets the owner reference of ClusterDeployment on AgentClusterInstall
 func (r *ClusterDeploymentsReconciler) ensureOwnerRef(ctx context.Context, log logrus.FieldLogger, cd *hivev1.ClusterDeployment, ci *hiveext.AgentClusterInstall) error {
+	for _, ref := range ci.GetOwnerReferences() {
+		if ref.UID == cd.UID {
+			return nil
+		}
+	}
 
 	if err := controllerutil.SetOwnerReference(cd, ci, r.Scheme); err != nil {
 		log.WithError(err).Error("error setting owner reference Agent Cluster Install")

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1447,6 +1447,28 @@ var _ = Describe("cluster reconcile", func() {
 		Expect(clusterInstall.ObjectMeta.OwnerReferences[0]).To(Equal(ownref))
 	})
 
+	It("skips owner reference update when already set", func() {
+		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+		aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cluster)
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		agentClusterInstallKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      agentClusterInstallName,
+		}
+		clusterInstallBefore := &hiveext.AgentClusterInstall{}
+		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstallBefore)).To(BeNil())
+		resourceVersionBefore := clusterInstallBefore.ResourceVersion
+
+		err := cr.ensureOwnerRef(ctx, common.GetTestLog(), cluster, clusterInstallBefore)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		clusterInstallAfter := &hiveext.AgentClusterInstall{}
+		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstallAfter)).To(BeNil())
+		Expect(clusterInstallAfter.ResourceVersion).To(Equal(resourceVersionBefore))
+	})
+
 	It("validate label on Pull Secret", func() {
 		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		sId := strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-22423

The `ClusterDeployment.spec.installed` field can get stuck at `false` even after successful cluster installation. This prevents downstream components (e.g., ManagedCluster import) from proceeding.

## Root Cause

The `ensureOwnerRef` function in `ClusterDeploymentsReconciler` always calls `r.Update()` on the AgentClusterInstall, even when the owner reference is already set.

During cluster state transitions, multiple controllers reconcile the same resources simultaneously. When `ensureOwnerRef` reads the AgentClusterInstall and later attempts to update it, another controller may have already modified the resource. This causes a conflict error:

```
Operation cannot be fulfilled on agentclusterinstalls: the object has been modified
```

When this happens, the reconciler returns early, never reaching `handleClusterInstalled()`. This blocks the Hive controller from setting `spec.installed=true`.

## Solution

Check if the owner reference already exists before calling `Update()`. If the ClusterDeployment is already set as an owner (matched by UID), return immediately without making an API call.

This eliminates unnecessary updates that cause conflicts during high-contention periods.