### PR TITLE
MGMT-22553: Partial cluster updates fail with false validation errors on dual-stack clusters

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3167,7 +3167,7 @@ var _ = Describe("cluster", func() {
 						Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 						UserManagedNetworking: swag.Bool(false),
 						CPUArchitecture:       common.X86CPUArchitecture,
-						MachineNetworks:       []*models.MachineNetwork{{Cidr: "1.3.4.0/24"}},
+						MachineNetworks:       []*models.MachineNetwork{{Cidr: "1.2.3.0/24"}},
 					}}
 					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
@@ -3254,14 +3254,15 @@ var _ = Describe("cluster", func() {
 					ingressVip := "1.2.3.101"
 					apiVips := []*models.APIVip{{IP: models.IP(apiVip)}, {IP: models.IP("2001:db8::1")}}
 					ingressVips := []*models.IngressVip{{IP: models.IP(ingressVip)}, {IP: models.IP("2001:db8::2")}}
-
+					machineNetworks := []*models.MachineNetwork{{Cidr: "1.2.3.0/24"}, {Cidr: "2001:db8::/64"}}
 					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							Name:        swag.String("some-cluster-name"),
-							PullSecret:  swag.String(fakePullSecret),
-							APIVips:     apiVips,
-							IngressVips: ingressVips,
+							Name:            swag.String("some-cluster-name"),
+							PullSecret:      swag.String(fakePullSecret),
+							APIVips:         apiVips,
+							IngressVips:     ingressVips,
+							MachineNetworks: machineNetworks,
 						},
 					})
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
@@ -4037,6 +4038,8 @@ var _ = Describe("cluster", func() {
 						ClusterUpdateParams: &models.V2ClusterUpdateParams{
 							UserManagedNetworking: swag.Bool(false),
 							VipDhcpAllocation:     swag.Bool(true),
+							APIVips:               []*models.APIVip{},
+							IngressVips:           []*models.IngressVip{},
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
@@ -4630,9 +4633,9 @@ var _ = Describe("cluster", func() {
 			Context("DHCP", func() {
 
 				var (
-					apiVip             = "10.11.12.15"
-					ingressVip         = "10.11.12.16"
-					primaryMachineCIDR = models.Subnet("10.11.0.0/16")
+					apiVip             = "1.2.3.15"
+					ingressVip         = "1.2.3.16"
+					primaryMachineCIDR = models.Subnet("1.2.3.0/24")
 				)
 
 				verifyMachineCIDRTimestampUpdated := func(beforeTimestamp time.Time) {
@@ -20144,6 +20147,14 @@ var _ = Describe("Dual-stack cluster", func() {
 					MachineNetworks: []*models.MachineNetwork{
 						{Cidr: "10.0.0.0/16"}, // IPv4 first - consistent
 						{Cidr: "2001:db8::/64"},
+					},
+					APIVips: []*models.APIVip{
+						{IP: "10.0.0.1"}, // IPv4 first
+						{IP: "2001:db8::1"},
+					},
+					IngressVips: []*models.IngressVip{
+						{IP: "10.0.0.2"}, // IPv4 first
+						{IP: "2001:db8::2"},
 					},
 				}
 

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -1107,6 +1107,63 @@ var _ = Describe("ValidateNetworkCIDRs", func() {
 	})
 })
 
+var _ = Describe("ValidateClusterUpdateVIPAddresses - partial network updates", func() {
+	var cluster common.Cluster
+
+	BeforeEach(func() {
+		cluster = common.Cluster{
+			Cluster: models.Cluster{
+				OpenshiftVersion: "4.14.0",
+				CPUArchitecture:  "x86_64",
+				MachineNetworks: []*models.MachineNetwork{
+					{Cidr: "192.168.1.0/24"},
+					{Cidr: "2001:db8::/64"},
+				},
+				ServiceNetworks: []*models.ServiceNetwork{
+					{Cidr: "172.30.0.0/16"},
+					{Cidr: "fd02::/112"},
+				},
+				ClusterNetworks: []*models.ClusterNetwork{
+					{Cidr: "10.128.0.0/14", HostPrefix: 23},
+					{Cidr: "fd01::/48", HostPrefix: 64},
+				},
+				APIVips: []*models.APIVip{
+					{IP: "192.168.1.100"},
+					{IP: "2001:db8::100"},
+				},
+				IngressVips: []*models.IngressVip{
+					{IP: "192.168.1.101"},
+					{IP: "2001:db8::101"},
+				},
+			},
+		}
+	})
+
+	It("preserves MachineNetworks when only updating ClusterNetworks in dual-stack cluster", func() {
+		params := &models.V2ClusterUpdateParams{
+			ClusterNetworks: []*models.ClusterNetwork{
+				{Cidr: "10.128.0.0/15", HostPrefix: 22},
+				{Cidr: "fd01::/48", HostPrefix: 66},
+			},
+		}
+
+		err := ValidateClusterUpdateVIPAddresses(true, &cluster, params, nil)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("allows updating only APIVips in dual-stack cluster", func() {
+		params := &models.V2ClusterUpdateParams{
+			APIVips: []*models.APIVip{
+				{IP: "192.168.1.102"},
+				{IP: "2001:db8::102"},
+			},
+		}
+
+		err := ValidateClusterUpdateVIPAddresses(true, &cluster, params, nil)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+})
+
 func TestCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cluster validations tests")


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-22553

**Root Cause**

The ValidateClusterUpdateVIPAddresses function assigned network and VIP parameters directly from the update request without falling back to the cluster's existing values when parameters were nil.
VIPs were initialized from `params.APIVips` and `params.IngressVips` directly, so if only one was provided, the other was treated as empty (length 0) instead of using the cluster's existing value

Network configurations (ClusterNetworks, ServiceNetworks, MachineNetworks) were assigned from params without checking for nil, so unspecified networks became empty during validation instead of preserving cluster's existing values.

**The Fix**
1. Use cluster's existing APIVips/IngressVips as defaults, override only when user provides new values in the update request
2. Networks - Fallback to cluster values when params are nil:
If `params.ClusterNetworks` is nil, use `cluster.ClusterNetworks`
If `params.ServiceNetworks` is nil, use `cluster.ServiceNetworks`
If `params.MachineNetworks` is nil, use `cluster.MachineNetworks`
3. DHCP mode handling - Refactored for clarity:
Only clear VIPs when explicitly switching to DHCP mode AND user didn't provide VIPs
If user sends VIPs + DHCP=true, let validation fail with appropriate error message

**Changes**

internal/cluster/validations/validations.go - Fixed fallback logic for VIPs and network configurations
internal/cluster/validations/validation_test.go - Added test cases for partial network updates on dual-stack clusters
internal/bminventory/inventory_test.go - Fixed test data consistency and added VIPs to dual-stack test params
