### PR TITLE
MGMT-20499: Always generate iSCSI NIC reapply manifest for day2 host support

### DIFF
--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -1204,7 +1204,7 @@ var _ = Describe("nic reaaply manifest", func() {
 			cluster.Cluster.Hosts = []*models.Host{&hostWithMultipathiSCSI, &hostWithSSD}
 			Expect(manifestsGeneratorApi.AddNicReapply(ctx, log, &cluster)).ShouldNot(HaveOccurred())
 		})
-		It("not added when one of the host installs on an Multipath FC drive", func() {
+		It("added when one of the host installs on an Multipath FC drive (manifest is always added)", func() {
 			inventory := fmt.Sprintf(`{
 			"disks":[
 				{
@@ -1224,10 +1224,18 @@ var _ = Describe("nic reaaply manifest", func() {
 				Inventory:          inventory,
 				InstallationDiskID: "install-id",
 			}
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Times(2).Return(&models.Manifest{
+				FileName: "manifest.yaml",
+				Folder:   models.ManifestFolderOpenshift,
+			}, nil)
 			cluster.Cluster.Hosts = []*models.Host{&hostWithMultipathFC, &hostWithSSD}
 			Expect(manifestsGeneratorApi.AddNicReapply(ctx, log, &cluster)).ShouldNot(HaveOccurred())
 		})
-		It("not added when no hosts installs on an iSCSI/ Multipath iSCSI drive", func() {
+		It("added even when no hosts install on an iSCSI drive to support day2 hosts", func() {
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Times(2).Return(&models.Manifest{
+				FileName: "manifest.yaml",
+				Folder:   models.ManifestFolderOpenshift,
+			}, nil)
 			cluster.Cluster.Hosts = []*models.Host{&hostWithSSD, &hostWithSSD}
 			Expect(manifestsGeneratorApi.AddNicReapply(ctx, log, &cluster)).ShouldNot(HaveOccurred())
 		})


### PR DESCRIPTION
A machine config manifest was introduced to work around OCPBUGS-26580, where DNS is not properly set up on first boot when booting from iSCSI storage.

However, this manifest was only added during day1 installation when iSCSI disks were detected. This caused day2 nodes with iSCSI disks to fail joining clusters that had no iSCSI disks on day1, because the workaround manifest was not present in the cluster.

This PR changes the behavior to always add the workaround manifest. The script installed by the manifest is a no-op if no iSCSI disks are detected, making this change safe.

Related: https://issues.redhat.com/browse/OCPBUGS-26580

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
