### PR TITLE
OCPBUGS-70300: Prevent race in agent-installer kubeconfig generation

### DIFF
--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -281,3 +281,17 @@ func (mr *MockAPIMockRecorder) UploadWithMetadata(arg0, arg1, arg2, arg3 interfa
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadWithMetadata", reflect.TypeOf((*MockAPI)(nil).UploadWithMetadata), arg0, arg1, arg2, arg3)
 }
+
+// WaitForObject mocks base method.
+func (m *MockAPI) WaitForObject(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForObject", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForObject indicates an expected call of WaitForObject.
+func (mr *MockAPIMockRecorder) WaitForObject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForObject", reflect.TypeOf((*MockAPI)(nil).WaitForObject), arg0, arg1)
+}


### PR DESCRIPTION
This is a backport of https://github.com/openshift/assisted-service/pull/8440.

This fix is specific to the agent-based installer workflow only.

Multiple concurrent requests to download kubeconfig could trigger simultaneous credential generation attempts, causing race conditions that resulted in 500 errors in disconnected environments. This fix adds database-level locking with a double-check pattern to ensure only one request generates credentials while others wait and reuse the result.

The fix only applies when installerInvoker is "agent-installer" and affects the early kubeconfig retrieval path used by the agent-based installer UI.

In addition, after generating credentials, files may not be immediately visible in S3 due to eventual consistency delays. This can cause download failures in disconnected environments where S3-compatible storage (MinIO, Ceph) may have slower consistency guarantees than AWS S3.

This fix adds retry logic with exponential backoff (100ms to 2s over 5 attempts) to wait for the file to become visible before attempting download. This handles the timing window between upload completion and object visibility.

🤖 Generated with Claude Code