### PR TITLE
Add k8s and openshift dependency groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,20 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      openshift:
+        patterns:
+          - "github.com/openshift/*"
       go-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          - "github.com/openshift/*"
     labels:
       - "approved"
       - "lgtm"


### PR DESCRIPTION
## Summary
- Add `k8s` group to consolidate `k8s.io/*` and `sigs.k8s.io/*` dependency updates
- Add `openshift` group to consolidate `github.com/openshift/*` dependency updates
- Update `go-dependencies` group to exclude k8s and openshift patterns to avoid duplicate grouping

This reduces noise from individual dependency update PRs by grouping related Kubernetes and OpenShift library updates together.

## Related PRs
- https://github.com/openshift/kube-compare/pull/253
- https://github.com/openshift/backplane-cli/pull/1111
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/648
- https://github.com/openshift/containernetworking-plugins/pull/74
- https://github.com/openshift/ingress-node-firewall/pull/276
- https://github.com/openshift/oc-mirror/pull/1285
- https://github.com/openshift/pf-status-relay-operator/pull/69

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Verify dependabot can parse the configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)