### PR TITLE
MGMT-20701: host re-registration improvement

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2116,6 +2116,69 @@ var _ = Describe("HandlePreInstallationChanges", func() {
 		Expect(db.Take(&cluster, "id = ?", clusterId).Error).NotTo(HaveOccurred())
 		Expect(cluster.LastInstallationPreparation.Status).Should(Equal(models.LastInstallationPreparationStatusSuccess))
 	})
+
+	It("should re-trigger HandlePreInstallSuccess when all hosts are preparing-successful but LastInstallationPreparation.Status is NotStarted", func() {
+		// This test verifies the re-trigger logic in processClusterMonitoring.
+		// The logic is tested by manually calling HandlePreInstallSuccess after setting up the conditions,
+		// since processClusterMonitoring is private and only called from ClusterMonitoring.
+		// Full integration testing happens through ClusterMonitoring in integration tests.
+
+		// Update the existing cluster (created in BeforeEach) to preparing-for-installation
+		// with LastInstallationPreparation.Status = NotStarted
+		// (simulating a host re-registration scenario where LastInstallationPreparation was reset)
+		var cluster common.Cluster
+		Expect(db.Take(&cluster, "id = ?", clusterId).Error).ShouldNot(HaveOccurred())
+		cluster.Status = swag.String(models.ClusterStatusPreparingForInstallation)
+		cluster.StatusInfo = swag.String(statusInfoPreparingForInstallation)
+		cluster.PullSecretSet = true
+		cluster.BaseDNSDomain = "test.com"
+		cluster.OpenshiftVersion = testing.ValidOCPVersionForNonStandardHAOCPControlPlane
+		cluster.ControlPlaneCount = 1
+		cluster.LastInstallationPreparation = models.LastInstallationPreparation{
+			Status: models.LastInstallationPreparationStatusNotStarted,
+			Reason: constants.InstallationPreparationReasonNotPerformed,
+		}
+		Expect(db.Save(&cluster).Error).ShouldNot(HaveOccurred())
+
+		// Create a host in preparing-successful state
+		hostId := strfmt.UUID(uuid.New().String())
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		Expect(db.Create(&models.Host{
+			ID:         &hostId,
+			InfraEnvID: infraEnvId,
+			ClusterID:  &clusterId,
+			Role:       models.HostRoleMaster,
+			Status:     swag.String(models.HostStatusPreparingSuccessful),
+		}).Error).ShouldNot(HaveOccurred())
+
+		// Load cluster with hosts
+		clusterWithHosts, err := common.GetClusterFromDBWithHosts(db, clusterId)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify the condition that triggers re-trigger: all hosts preparing-successful and LastInstallationPreparation.Status = NotStarted
+		allHostsPrepared := true
+		for _, h := range clusterWithHosts.Hosts {
+			if swag.StringValue(h.Status) != models.HostStatusPreparingSuccessful {
+				allHostsPrepared = false
+				break
+			}
+		}
+		Expect(allHostsPrepared).Should(BeTrue())
+		Expect(clusterWithHosts.LastInstallationPreparation.Status).Should(Equal(models.LastInstallationPreparationStatusNotStarted))
+
+		// Mock expectations - HandlePreInstallSuccess will be called and send an event
+		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithClusterIdMatcher(clusterId.String()))).Times(1)
+
+		// Manually trigger HandlePreInstallSuccess to simulate what processClusterMonitoring would do
+		capi.HandlePreInstallSuccess(ctx, clusterWithHosts)
+
+		// Verify LastInstallationPreparation.Status was updated to Success
+		var updatedCluster models.Cluster
+		Expect(db.Take(&updatedCluster, "id = ?", clusterId.String()).Error).ShouldNot(HaveOccurred())
+		Expect(updatedCluster.LastInstallationPreparation.Status).Should(Equal(models.LastInstallationPreparationStatusSuccess))
+		Expect(updatedCluster.LastInstallationPreparation.Reason).Should(Equal(constants.InstallationPreparationReasonSuccess))
+	})
 })
 
 var _ = Describe("SetVipsData", func() {

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -437,6 +437,20 @@ func (mr *MockTransitionHandlerMockRecorder) PostRegisterDuringInstallation(sw, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRegisterDuringInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).PostRegisterDuringInstallation), sw, args)
 }
 
+// PostRegisterDuringPreparingForInstallation mocks base method.
+func (m *MockTransitionHandler) PostRegisterDuringPreparingForInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostRegisterDuringPreparingForInstallation", sw, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PostRegisterDuringPreparingForInstallation indicates an expected call of PostRegisterDuringPreparingForInstallation.
+func (mr *MockTransitionHandlerMockRecorder) PostRegisterDuringPreparingForInstallation(sw, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRegisterDuringPreparingForInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).PostRegisterDuringPreparingForInstallation), sw, args)
+}
+
 // PostRegisterDuringReboot mocks base method.
 func (m *MockTransitionHandler) PostRegisterDuringReboot(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -127,13 +127,25 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeRegisterHost,
 		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusPreparingForInstallation),
+			stateswitch.State(models.HostStatusPreparingSuccessful),
+		},
+		DestinationState: stateswitch.State(models.HostStatusKnown),
+		PostTransition:   th.PostRegisterDuringPreparingForInstallation,
+		Documentation: stateswitch.TransitionRuleDoc{
+			Name:        "Re-registration during preparation",
+			Description: "When a host re-registers during preparing-for-installation, we preserve inventory and bootstrap flag, reset to 'known' status, and reset LastInstallationPreparation to allow state machine re-evaluation",
+		},
+	})
+
+	sm.AddTransitionRule(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRegisterHost,
+		SourceStates: []stateswitch.State{
 			stateswitch.State(models.HostStatusDiscovering),
 			stateswitch.State(models.HostStatusKnown),
 			stateswitch.State(models.HostStatusDisconnected),
 			stateswitch.State(models.HostStatusInsufficient),
 			stateswitch.State(models.HostStatusResettingPendingUserAction),
-			stateswitch.State(models.HostStatusPreparingForInstallation),
-			stateswitch.State(models.HostStatusPreparingSuccessful),
 			stateswitch.State(models.HostStatusBinding),
 			stateswitch.State(models.HostStatusPendingForInput),
 		},


### PR DESCRIPTION
### [MGMT-20701](https://issues.redhat.com//browse/MGMT-20701): Fix SNO cluster stuck in preparing-for-installation after host re-registration

**Problem**
Clusters get stuck in `preparing-for-installation` and timeout when a host re-registers during preparation. The cluster never transitions to installing even after all hosts become `preparing-successful` again. The problem was detected in SNO clusters with NMState operator specifically, however it seems more generic, and any cluster install can stuck when the agent starts registering again in the critical time window.

**Root Cause**
When a host re-registers during `preparing-for-installation`, the existing re-registration handler resets the host to discovering and clears inventory and bootstrap. This triggers `UnPreparingtHostsExist`, moving the cluster to `insufficient`. Additionally, `LastInstallationPreparation.Status` remains `Success` from the first attempt, preventing the state machine from re-evaluating once all hosts are ready again.

**Solution**
Added a dedicated `PostRegisterDuringPreparingForInstallation` handler that preserves inventory and bootstrap, resets the host to `known` (avoiding `UnPreparingtHostsExist`), and resets `LastInstallationPreparation.Status` to `NotStarted` to allow re-evaluation. The cluster monitoring loop re-triggers `HandlePreInstallSuccess` when all hosts are `preparing-successful` but `LastInstallationPreparation.Status` is `NotStarted`, enabling the transition to installing.

**Files Changed**
assisted-service/internal/host/transition.go: Added `PostRegisterDuringPreparingForInstallation` handler
assisted-service/internal/host/statemachine.go: Added state machine rule routing preparation states to the new handler
assisted-service/internal/cluster/cluster.go: Added re-trigger logic in `processClusterMonitoring`
(+ unit tests)

**Tests**
Integration testing confirmed the fix works with SNO, SNO+NMState and multinode deployments where host re-registration occurs during preparation (restarted bootstrap node during the critical phase, which always caused installation timeout without the fix).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
