### PR TITLE
MGMT-22297: fallback path for add-ntp-sources.sh

### DIFF
--- a/internal/ignition/templates/add-ntp-sources.service
+++ b/internal/ignition/templates/add-ntp-sources.service
@@ -1,6 +1,8 @@
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/add-ntp-sources.sh
+# In RHCOS (ostree), /usr is read-only and ignition redirects /usr/local to /var/usrlocal.
+# Use a shell command to check both paths for fail-safe execution.
+ExecStart=/bin/bash -c 'if [ -f /usr/local/bin/add-ntp-sources.sh ]; then /usr/local/bin/add-ntp-sources.sh; elif [ -f /var/usrlocal/bin/add-ntp-sources.sh ]; then /var/usrlocal/bin/add-ntp-sources.sh; else echo "Error: add-ntp-sources.sh not found in /usr/local/bin or /var/usrlocal/bin"; exit 1; fi'
 
 [Unit]
 Before=chronyd.service


### PR DESCRIPTION
Addidtional fix for [MGMT-22297](https://issues.redhat.com//browse/MGMT-22297).

The QE test was still failing because the `add-ntp-sources.service` script created for the previous fix wasn't executing, since in RHCOS `/usr` is read-only, so ignition redirects `/usr/local/bin` to `/var/usrlocal/bin`. The logs show the script was written to `/sysroot/var/usrlocal/bin/add-ntp-sources.sh`. `/usr/local` should be a symlink to `/var/usrlocal`, but it may not exist when the service runs early in boot.

This new fix updates `add-ntp-sources.service` to handle both paths.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
