### PR TITLE
MGMT-22189: Fix primary_ip_stack migration

### DIFF
--- a/internal/migrations/20251216120000_convert_primary_ip_stack_column_type.go
+++ b/internal/migrations/20251216120000_convert_primary_ip_stack_column_type.go
@@ -13,14 +13,17 @@ func convertPrimaryIPStackColumnType() *gormigrate.Migration {
 		var dataType string
 		err := tx.Raw(`
 			SELECT data_type FROM information_schema.columns 
-			WHERE table_name = 'clusters' AND column_name = 'primary_ip_stack'
+			WHERE table_schema = current_schema() 
+			  AND table_name = 'clusters' 
+			  AND column_name = 'primary_ip_stack'
 		`).Scan(&dataType).Error
 		if err != nil {
 			return err
 		}
 
-		// Only convert if column is text/varchar - skip for any other type
-		// (including integer, bigint, or if column doesn't exist)
+		// Only convert if column is a text/varchar type - skip for any other type
+		// (including integer, bigint, or if column doesn't exist/not found)
+		// PostgreSQL returns "text" for TEXT and "character varying" for VARCHAR
 		if dataType != "text" && dataType != "character varying" {
 			return nil
 		}
@@ -33,6 +36,8 @@ func convertPrimaryIPStackColumnType() *gormigrate.Migration {
 			USING CASE 
 				WHEN primary_ip_stack = 'ipv4' THEN 4 
 				WHEN primary_ip_stack = 'ipv6' THEN 6 
+				WHEN primary_ip_stack = '4' THEN 4
+				WHEN primary_ip_stack = '6' THEN 6
 				ELSE NULL 
 			END
 		`).Error
@@ -44,14 +49,16 @@ func convertPrimaryIPStackColumnType() *gormigrate.Migration {
 		var dataType string
 		err := tx.Raw(`
 			SELECT data_type FROM information_schema.columns 
-			WHERE table_name = 'clusters' AND column_name = 'primary_ip_stack'
+			WHERE table_schema = current_schema() 
+			  AND table_name = 'clusters' 
+			  AND column_name = 'primary_ip_stack'
 		`).Scan(&dataType).Error
 		if err != nil {
 			return err
 		}
 
 		// Only convert if column is integer/bigint - skip for any other type
-		// (including text, varchar, or if column doesn't exist)
+		// (including text, character varying, or if column doesn't exist)
 		if dataType != "integer" && dataType != "bigint" {
 			return nil
 		}


### PR DESCRIPTION
The primary ip stack db migration could fail and end up with mixed values such as '4' and '6' so during its migration, we want to catch that and convert them to integers as well.


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): upgraded assisted-service locally and observed the column type changing to integer
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @rccrdpccl @pastequo 