### PR TITLE
MGMT-23334: Add kata-cc runtimeclass to Assisted installer

### DIFF
--- a/internal/operators/osc/manifest.go
+++ b/internal/operators/osc/manifest.go
@@ -83,7 +83,7 @@ func generateCustomManifests(namespace string) ([]byte, error) {
 		template string
 	}{
 		{map[string]string{"TDX_MC_NAME": "99-enable-intel-tdx"}, "kataccMcManifest", kataccMcManifest},
-		{map[string]string{"NFD_NAMESPACE": "openshift-nfd", "NFD_NAME": "nfd-instance"}, "kataccNfdManifest", kataccNfdManifest},
+		{map[string]string{"NFD_NAME": "nfd-instance", "NFD_NAMESPACE": "openshift-nfd"}, "kataccNfdManifest", kataccNfdManifest},
 		{map[string]string{"OSC_RULES_NAME": "osc-rules", "NFD_NAMESPACE": "openshift-nfd"}, "oscRulesManifest", oscRulesManifest},
 		{map[string]string{"INTEL_NFR_NAME": "intel-dp-devices", "INTE_NFR_NAMESPACE": "openshift-nfd"}, "intelNfrManifest", intelNfrManifest},
 		{map[string]string{"AMD_NFR_NAME": "amd-sev-snp", "AMD_NFR_NAMESPACE": "openshift-nfd"}, "amdNfrManifest", amdNfrManifest},
@@ -135,17 +135,8 @@ spec:
   sourceNamespace: openshift-marketplace
   name: {{.OPERATOR_SOURCE_NAME}}
   installPlanApproval: Automatic
-`
-
-const oscKataconfigManifest = `
-apiVersion: kataconfiguration.openshift.io/v1
-kind: KataConfig
-metadata:
-  name: cluster-kataconfig
-  namespace: {{.OPERATOR_NAMESPACE}}
-spec:
-  enablePeerPods: false
-  logLevel: info
+  channel: stable
+  startingCSV: sandboxed-containers-operator.v1.11.1
 `
 
 const kataccMcManifest = `
@@ -276,4 +267,15 @@ metadata:
 data:
   confidential: "true"
   deploymentMode: MachineConfig
+`
+
+const oscKataconfigManifest = `
+apiVersion: kataconfiguration.openshift.io/v1
+kind: KataConfig
+metadata:
+  name: cluster-kataconfig
+  namespace: {{.OPERATOR_NAMESPACE}}
+spec:
+  enablePeerPods: false
+  logLevel: info
 `

--- a/internal/operators/osc/manifest.go
+++ b/internal/operators/osc/manifest.go
@@ -136,7 +136,6 @@ spec:
   name: {{.OPERATOR_SOURCE_NAME}}
   installPlanApproval: Automatic
   channel: stable
-  startingCSV: sandboxed-containers-operator.v1.11.1
 `
 
 const kataccMcManifest = `

--- a/internal/operators/osc/manifest.go
+++ b/internal/operators/osc/manifest.go
@@ -85,7 +85,7 @@ func generateCustomManifests(namespace string) ([]byte, error) {
 		{map[string]string{"TDX_MC_NAME": "99-enable-intel-tdx"}, "kataccMcManifest", kataccMcManifest},
 		{map[string]string{"NFD_NAME": "nfd-instance", "NFD_NAMESPACE": "openshift-nfd"}, "kataccNfdManifest", kataccNfdManifest},
 		{map[string]string{"OSC_RULES_NAME": "osc-rules", "NFD_NAMESPACE": "openshift-nfd"}, "oscRulesManifest", oscRulesManifest},
-		{map[string]string{"INTEL_NFR_NAME": "intel-dp-devices", "INTE_NFR_NAMESPACE": "openshift-nfd"}, "intelNfrManifest", intelNfrManifest},
+		{map[string]string{"INTEL_NFR_NAME": "intel-dp-devices", "INTEL_NFR_NAMESPACE": "openshift-nfd"}, "intelNfrManifest", intelNfrManifest},
 		{map[string]string{"AMD_NFR_NAME": "amd-sev-snp", "AMD_NFR_NAMESPACE": "openshift-nfd"}, "amdNfrManifest", amdNfrManifest},
 		{map[string]string{"OSC_FEATURE_GATE_NAME": "osc-feature-gates", "OPERATOR_NAMESPACE": namespace}, "oscFeaturegateManifest", oscFeaturegateManifest},
 		{map[string]string{"OPERATOR_NAMESPACE": namespace}, "oscKataconfigManifest", oscKataconfigManifest},
@@ -208,7 +208,7 @@ apiVersion: nfd.openshift.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: {{.INTEL_NFR_NAME}}
-  namespace: {{.INTE_NFR_NAMESPACE}}
+  namespace: {{.INTEL_NFR_NAMESPACE}}
 spec:
   rules:
     - name: "intel.sgx"

--- a/internal/operators/osc/manifest.go
+++ b/internal/operators/osc/manifest.go
@@ -2,6 +2,7 @@ package osc
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 )
 
@@ -73,11 +74,36 @@ func getOperatorGroup(namespace string) ([]byte, error) {
 	return executeTemplate(data, "oscOperatorGroupManifest", oscOperatorGroupManifest)
 }
 
+// generateCustomManifests generate all custom Manifests and merge them
 func generateCustomManifests(namespace string) ([]byte, error) {
-	data := map[string]string{
-		"OPERATOR_NAMESPACE": namespace,
+	// Define all template data
+	templateData := []struct {
+		data     map[string]string
+		name     string
+		template string
+	}{
+		{map[string]string{"TDX_MC_NAME": "99-enable-intel-tdx"}, "kataccMcManifest", kataccMcManifest},
+		{map[string]string{"NFD_NAMESPACE": "openshift-nfd", "NFD_NAME": "nfd-instance"}, "kataccNfdManifest", kataccNfdManifest},
+		{map[string]string{"OSC_RULES_NAME": "osc-rules", "NFD_NAMESPACE": "openshift-nfd"}, "oscRulesManifest", oscRulesManifest},
+		{map[string]string{"INTEL_NFR_NAME": "intel-dp-devices", "INTE_NFR_NAMESPACE": "openshift-nfd"}, "intelNfrManifest", intelNfrManifest},
+		{map[string]string{"AMD_NFR_NAME": "amd-sev-snp", "AMD_NFR_NAMESPACE": "openshift-nfd"}, "amdNfrManifest", amdNfrManifest},
+		{map[string]string{"OSC_FEATURE_GATE_NAME": "osc-feature-gates", "OPERATOR_NAMESPACE": namespace}, "oscFeaturegateManifest", oscFeaturegateManifest},
+		{map[string]string{"OPERATOR_NAMESPACE": namespace}, "oscKataconfigManifest", oscKataconfigManifest},
 	}
-	return executeTemplate(data, "oscKataconfigManifest", oscKataconfigManifest)
+
+	var yamlfiles [][]byte
+	// Batch Processing Template
+	for _, item := range templateData {
+		result, err := executeTemplate(item.data, item.name, item.template)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate %s: %w", item.name, err)
+		}
+		yamlfiles = append(yamlfiles, result)
+	}
+
+	// Merge all files with delimiter
+	return bytes.Join(yamlfiles, []byte("---\n")), nil
+
 }
 
 const oscNamespaceManifest = `
@@ -120,4 +146,134 @@ metadata:
 spec:
   enablePeerPods: false
   logLevel: info
+`
+
+const kataccMcManifest = `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: {{.TDX_MC_NAME}}
+spec:
+  kernelArguments:
+  - kvm_intel.tdx=1
+  - nohibernate
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - path: /etc/modules-load.d/vsock.conf
+          mode: 0644
+          contents:
+            source: data:text/plain;charset=utf-8;base64,dnNvY2stbG9vcGJhY2sK
+`
+
+const kataccNfdManifest = `
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: {{.NFD_NAME}}
+  namespace: {{.NFD_NAMESPACE}}
+spec:
+  workerConfig:
+    configData: |
+`
+
+const oscRulesManifest = `
+apiVersion: nfd.openshift.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: {{.OSC_RULES_NAME}}
+  namespace: {{.NFD_NAMESPACE}}
+spec:
+  rules:
+    - name: "runtime.kata"
+      labels:
+        "feature.node.kubernetes.io/runtime.kata": "true"
+      matchAny:
+        - matchFeatures:
+            - feature: cpu.cpuid
+              matchExpressions:
+                SSE42: {op: Exists}
+                VMX: {op: Exists}
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                kvm: {op: Exists}
+                kvm_intel: {op: Exists}
+        - matchFeatures:
+            - feature: cpu.cpuid
+              matchExpressions:
+                SSE42: {op: Exists}
+                SVM: {op: Exists}
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                kvm: {op: Exists}
+                kvm_amd: {op: Exists}
+`
+
+const intelNfrManifest = `
+apiVersion: nfd.openshift.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: {{.INTEL_NFR_NAME}}
+  namespace: {{.INTE_NFR_NAMESPACE}}
+spec:
+  rules:
+    - name: "intel.sgx"
+      labels:
+        "intel.feature.node.kubernetes.io/sgx": "true"
+      extendedResources:
+        sgx.intel.com/epc: "@cpu.security.sgx.epc"
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchExpressions:
+            SGX: {op: Exists}
+            SGXLC: {op: Exists}
+        - feature: cpu.security
+          matchExpressions:
+            sgx.enabled: {op: IsTrue}
+        - feature: kernel.config
+          matchExpressions:
+            X86_SGX: {op: Exists}
+    - name: "intel.tdx"
+      labels:
+        "intel.feature.node.kubernetes.io/tdx": "true"
+      extendedResources:
+        tdx.intel.com/keys: "@cpu.security.tdx.total_keys"
+      matchFeatures:
+        - feature: cpu.security
+          matchExpressions:
+            tdx.enabled: {op: Exists}
+`
+
+const amdNfrManifest = `
+apiVersion: nfd.openshift.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: {{.AMD_NFR_NAME}}
+  namespace: {{.AMD_NFR_NAMESPACE}}
+spec:
+  rules:
+    - name: "amd.sev-snp"
+      labels:
+        "amd.feature.node.kubernetes.io/snp": "true"
+      extendedResources:
+        sev-snp.amd.com/esids: "@cpu.security.sev.encrypted_state_ids"
+      matchFeatures:
+        - feature: cpu.security
+          matchExpressions:
+            sev.snp.enabled: { op: Exists }
+`
+
+const oscFeaturegateManifest = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.OSC_FEATURE_GATE_NAME}}
+  namespace: {{.OPERATOR_NAMESPACE}}
+data:
+  confidential: "true"
+  deploymentMode: MachineConfig
 `


### PR DESCRIPTION
This PR adds  below functions:
1. Base on kata runtimeclass, Apply kata-cc runtimeclass related manifests.
2. Adding kata-cc runtimeclass to  OCP for CoCo(confidential container)
3.  Both kata and kata-cc will be installed simultaneously when selecting to install OSC operator through the UI. 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

**How to test:**

1. Selected osc operator in Assisted installer UI

4. check osc operator via commandline

#oc get operators
NAME                                                              AGE
nfd.openshift-nfd                                                 13h
sandboxed-containers-operator.openshift-sandboxed-containers-op   13h

5. check kata runtimeclass (can see two runtimeclass)
# oc get runtimeclass
NAME      HANDLER    AGE
kata      kata       12h
kata-cc   kata-snp   13h


6. start a kata container with kata-cc runtimeclass
 #oc apply -f kata-pod.yaml

#cat kata-pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-pod
  namespace: default
spec:
  runtimeClassName: kata-cc
  containers:
  - image: quay.io/prometheus/busybox
    name: busybox
    resources: {}
    command: ["sleep", "infinity"]
    dns_search: []
    securityContext:
      privileged: true

7. check pod status
 #oc get pods
NAME       READY   STATUS    RESTARTS   AGE
kata-pod   1/1     Running   0          101s
