### PR TITLE
MGMT-23230: Add MachineConfig for AMD GPU kernel module blacklist

### DIFF
--- a/internal/operators/amdgpu/amd_gpu_manifests_test.go
+++ b/internal/operators/amdgpu/amd_gpu_manifests_test.go
@@ -45,4 +45,17 @@ var _ = Describe("Manifest generation", func() {
 		err = yaml.Unmarshal(customManifest, &object)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("Includes MachineConfig for amdgpu kernel module blacklist", func() {
+		_, customManifest, err := operator.GenerateManifests(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		rendered := string(customManifest)
+		Expect(rendered).To(ContainSubstring("kind: MachineConfig"))
+		Expect(rendered).To(ContainSubstring("99-amdgpu-module-blacklist-worker"))
+		Expect(rendered).To(ContainSubstring("99-amdgpu-module-blacklist-master"))
+		Expect(rendered).To(ContainSubstring("machineconfiguration.openshift.io/role: worker"))
+		Expect(rendered).To(ContainSubstring("machineconfiguration.openshift.io/role: master"))
+		Expect(rendered).To(ContainSubstring("/etc/modprobe.d/amdgpu-blacklist.conf"))
+		Expect(rendered).To(ContainSubstring("YmxhY2tsaXN0IGFtZGdwdQo=")) // "blacklist amdgpu\n"
+	})
 })

--- a/internal/operators/amdgpu/templates/custom/amdgpu_module_blacklist.yaml
+++ b/internal/operators/amdgpu/templates/custom/amdgpu_module_blacklist.yaml
@@ -1,0 +1,35 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-amdgpu-module-blacklist-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/modprobe.d/amdgpu-blacklist.conf
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain;base64,YmxhY2tsaXN0IGFtZGdwdQo=
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-amdgpu-module-blacklist-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/modprobe.d/amdgpu-blacklist.conf
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain;base64,YmxhY2tsaXN0IGFtZGdwdQo=


### PR DESCRIPTION
## Summary

Add MachineConfig to blacklist amdgpu in-tree kernel module, required for AMD GPU out-of-tree driver installation. Includes configurations for both worker and master nodes to support SNO and multi-node deployments.

This blacklist is also required for gpu-operator upgrade scenarios, as the in-tree amdgpu module can interfere with loading new driver versions during the upgrade lifecycle.

**Changes:**
- Add amdgpu_module_blacklist.yaml template with worker and master MachineConfigs
- Blacklist configuration: `/etc/modprobe.d/amdgpu-blacklist.conf` (blacklist amdgpu)
- Add test to validate MachineConfig generation

**Reference:** https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module

**Jira:** https://issues.redhat.com/browse/MGMT-23230

## List all the issues related to this PR

- [x] Bug fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [x] Operator Managed Deployments
- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] None

Template change only. Unit tests validate MachineConfig generation.