### PR TITLE
NO-ISSUE: Fix loki and logging

### DIFF
--- a/internal/operators/loki/loki_config.go
+++ b/internal/operators/loki/loki_config.go
@@ -12,5 +12,4 @@ const (
 	SubscriptionName = "loki-operator"
 	Source           = "redhat-operators"
 	SourceNamespace  = "openshift-marketplace"
-	Channel          = "stable-6.3"
 )

--- a/internal/operators/loki/loki_manifests_test.go
+++ b/internal/operators/loki/loki_manifests_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Loki manifest generation", func() {
 		Expect(metadata["namespace"]).To(Equal(Namespace))
 
 		spec := subData["spec"].(map[string]interface{})
-		Expect(spec["channel"]).To(Equal(Channel))
 		Expect(spec["name"]).To(Equal(SubscriptionName))
 		Expect(spec["source"]).To(Equal(Source))
 		Expect(spec["sourceNamespace"]).To(Equal(SourceNamespace))

--- a/internal/operators/loki/templates/openshift/50_openshift-loki_subscription.yaml
+++ b/internal/operators/loki/templates/openshift/50_openshift-loki_subscription.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Operator.SubscriptionName }}
   namespace: {{ .Operator.Namespace }}
 spec:
-  channel: stable-6.3
   installPlanApproval: Automatic
   name: {{ .Operator.SubscriptionName }}
   source: redhat-operators

--- a/internal/operators/openshiftlogging/openshift_logging_config.go
+++ b/internal/operators/openshiftlogging/openshift_logging_config.go
@@ -12,5 +12,4 @@ const (
 	SubscriptionName = "cluster-logging"
 	Source           = "redhat-operators"
 	SourceNamespace  = "openshift-marketplace"
-	Channel          = "stable-6.3"
 )

--- a/internal/operators/openshiftlogging/openshift_logging_manifests_test.go
+++ b/internal/operators/openshiftlogging/openshift_logging_manifests_test.go
@@ -73,7 +73,6 @@ var _ = Describe("OpenShift Logging manifest generation", func() {
 		Expect(metadata["namespace"]).To(Equal(Namespace))
 
 		spec := subData["spec"].(map[string]interface{})
-		Expect(spec["channel"]).To(Equal(Channel))
 		Expect(spec["name"]).To(Equal(SubscriptionName))
 		Expect(spec["source"]).To(Equal(Source))
 		Expect(spec["sourceNamespace"]).To(Equal(SourceNamespace))

--- a/internal/operators/openshiftlogging/templates/openshift/50_openshift-logging_subscription.yaml
+++ b/internal/operators/openshiftlogging/templates/openshift/50_openshift-logging_subscription.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Operator.SubscriptionName }}
   namespace: {{ .Operator.Namespace }}
 spec:
-  channel: stable-6.3
   installPlanApproval: Automatic
   name: {{ .Operator.SubscriptionName }}
   source: redhat-operators


### PR DESCRIPTION
`loki` and `logging` operators had hard-coded channel in their subscription manifest, this PR removes it. The channel changes between OCP versions, caused failures in OCP 4.21