### PR TITLE
OCPBUGS-81843: Prefer multipath disk in ABI disk selection

### DIFF
--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -138,7 +138,7 @@ func applyRootDeviceHints(log *log.Logger, host *models.Host, inventory *models.
 
 	diskID := "/dev/not-found-by-hints"
 	if len(acceptableDisks) > 0 {
-		diskID = acceptableDisks[0].ID
+		diskID = hostutil.GetPreferredDiskID(acceptableDisks)
 		log.Infof("Selecting disk %s for installation", diskID)
 	} else {
 		log.Info("No disk found matching root device hints")

--- a/cmd/agentbasedinstaller/host_config_test.go
+++ b/cmd/agentbasedinstaller/host_config_test.go
@@ -1,0 +1,112 @@
+package agentbasedinstaller
+
+import (
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+var _ = Describe("applyRootDeviceHints", func() {
+	Context("when multiple disks match WWN hint and one is multipath", func() {
+		It("should prefer the multipath disk over raw FC paths", func() {
+			testLogger, _ := test.NewNullLogger()
+
+			wwn := "0x1111111111111111"
+			rdh := &bmh_v1alpha1.RootDeviceHints{
+				WWN: wwn,
+			}
+
+			// Simulate FC multipath: two raw FC paths and one multipath device, all sharing the same WWN
+			inventory := &models.Inventory{
+				Disks: []*models.Disk{
+					{
+						ID:        "/dev/sda",
+						Path:      "/dev/sda",
+						DriveType: models.DriveTypeFC,
+						Wwn:       wwn,
+						InstallationEligibility: models.DiskInstallationEligibility{
+							Eligible: true,
+						},
+					},
+					{
+						ID:        "/dev/sdb",
+						Path:      "/dev/sdb",
+						DriveType: models.DriveTypeFC,
+						Wwn:       wwn,
+						InstallationEligibility: models.DiskInstallationEligibility{
+							Eligible: true,
+						},
+					},
+					{
+						ID:        "/dev/dm-0",
+						Path:      "/dev/dm-0",
+						DriveType: models.DriveTypeMultipath,
+						Wwn:       wwn,
+						InstallationEligibility: models.DiskInstallationEligibility{
+							Eligible: true,
+						},
+					},
+				},
+			}
+
+			host := &models.Host{
+				InstallationDiskID: "",
+			}
+
+			updateParams := &models.HostUpdateParams{}
+
+			applied := applyRootDeviceHints(testLogger, host, inventory, rdh, updateParams)
+
+			Expect(applied).To(BeTrue())
+			Expect(updateParams.DisksSelectedConfig).To(HaveLen(1))
+			Expect(*updateParams.DisksSelectedConfig[0].ID).To(Equal("/dev/dm-0"), "should prefer multipath device over raw FC paths")
+		})
+
+		It("should select the first disk when no multipath device exists", func() {
+			testLogger, _ := test.NewNullLogger()
+
+			wwn := "0x1111111111111111"
+			rdh := &bmh_v1alpha1.RootDeviceHints{
+				WWN: wwn,
+			}
+
+			// Two FC paths, no multipath device
+			inventory := &models.Inventory{
+				Disks: []*models.Disk{
+					{
+						ID:        "/dev/sda",
+						Path:      "/dev/sda",
+						DriveType: models.DriveTypeFC,
+						Wwn:       wwn,
+						InstallationEligibility: models.DiskInstallationEligibility{
+							Eligible: true,
+						},
+					},
+					{
+						ID:        "/dev/sdb",
+						Path:      "/dev/sdb",
+						DriveType: models.DriveTypeFC,
+						Wwn:       wwn,
+						InstallationEligibility: models.DiskInstallationEligibility{
+							Eligible: true,
+						},
+					},
+				},
+			}
+
+			host := &models.Host{
+				InstallationDiskID: "",
+			}
+
+			updateParams := &models.HostUpdateParams{}
+
+			applied := applyRootDeviceHints(testLogger, host, inventory, rdh, updateParams)
+
+			Expect(applied).To(BeTrue())
+			Expect(updateParams.DisksSelectedConfig).To(HaveLen(1))
+			Expect(*updateParams.DisksSelectedConfig[0].ID).To(Equal("/dev/sda"), "should select first disk when no multipath exists")
+		})
+	})
+})

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1268,7 +1268,7 @@ func (r *BMACReconciler) findInstallationDiskID(devices []aiv1beta1.HostDisk, hi
 
 	acceptable := hostutil.GetAcceptableDisksWithHints(disks, hints)
 	if len(acceptable) > 0 {
-		return getDiskID(acceptable)
+		return hostutil.GetPreferredDiskID(acceptable)
 	}
 
 	// If hints are provided but we did not find an eligible disk, we need to raise an error.
@@ -1279,18 +1279,6 @@ func (r *BMACReconciler) findInstallationDiskID(devices []aiv1beta1.HostDisk, hi
 	// the Agent Reconciler), we let the assisted installer handle error caused by the incorrect
 	// disk further in the process.
 	return "/dev/not-found-by-hints"
-}
-
-// Given a list of acceptable disks,
-// find the multipath disk ID, if it exists,
-// otherwise return the ID of the first disk in the list.
-func getDiskID(disks []*models.Disk) string {
-	for _, disk := range disks {
-		if strings.EqualFold(string(disk.DriveType), string(models.DriveTypeMultipath)) {
-			return disk.ID
-		}
-	}
-	return disks[0].ID
 }
 
 // Finds the agents related to this ClusterDeployment

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -424,6 +424,18 @@ func GetIgnitionEndpointAndCert(cluster *common.Cluster, host *models.Host, logg
 	return ignitionEndpointUrl, cert, nil
 }
 
+// GetPreferredDiskID returns the ID of the preferred installation disk from a list of acceptable disks.
+// If any disk is a multipath device, it is preferred over raw paths (e.g. FC or iSCSI).
+// Otherwise, the first disk in the list is returned.
+func GetPreferredDiskID(disks []*models.Disk) string {
+	for _, disk := range disks {
+		if strings.EqualFold(string(disk.DriveType), string(models.DriveTypeMultipath)) {
+			return disk.ID
+		}
+	}
+	return disks[0].ID
+}
+
 func GetDisksOfHolderByType(allDisks []*models.Disk, holderDisk *models.Disk, driveTypeFilter models.DriveType) []*models.Disk {
 	disksOfHolder := GetAllDisksOfHolder(allDisks, holderDisk)
 	return lo.Filter(disksOfHolder, func(d *models.Disk, _ int) bool { return d.DriveType == driveTypeFilter })


### PR DESCRIPTION
This is a manual cherry-pick of [#10091](https://github.com/openshift/assisted-service/pull/10091) to `release-4.21`. The automated cherry-pick failed due to merge conflicts (test file doesn't exist in this branch).             

The ABI code path blindly picked acceptableDisks[0] when selecting an installation disk, ignoring multipath devices. On FC multipath systems this caused the installer to write to a raw FC path which multipathd then reclaimed, resulting in ENODEV on mount.

Move the existing getDiskID() multipath preference logic (added for ZTP in [MGMT-18545](https://redhat.atlassian.net/browse/MGMT-18545)) to a shared hostutil.GetPreferredDiskID() and use it from both the BMAC controller and ABI code paths.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
