### PR TITLE
MGMT-23553: Automate events table bloat cleanup

### DIFF
--- a/internal/migrations/20260413120000_set_events_autovacuum_settings.go
+++ b/internal/migrations/20260413120000_set_events_autovacuum_settings.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+var setEventsAutovacuumSettingsID = "20260413120000"
+
+func setEventsAutovacuumSettings() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		// Set aggressive autovacuum thresholds for the high-churn events table
+		if err := tx.Exec(`ALTER TABLE events SET (autovacuum_vacuum_scale_factor = 0.05)`).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`ALTER TABLE events SET (autovacuum_analyze_scale_factor = 0.025)`).Error; err != nil {
+			return err
+		}
+		return nil
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		// Reset to PostgreSQL defaults
+		if err := tx.Exec(`ALTER TABLE events RESET (autovacuum_vacuum_scale_factor)`).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`ALTER TABLE events RESET (autovacuum_analyze_scale_factor)`).Error; err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       setEventsAutovacuumSettingsID,
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/20260413120000_set_events_autovacuum_settings_test.go
+++ b/internal/migrations/20260413120000_set_events_autovacuum_settings_test.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("set events autovacuum settings", func() {
+	var (
+		db     *gorm.DB
+		dbName string
+		gm     *gormigrate.Gormigrate
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, post())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	getTableOptions := func() (string, string) {
+		var vacuumScaleFactor, analyzeScaleFactor string
+		err := db.Raw(`
+			SELECT
+				COALESCE((SELECT option_value FROM pg_options_to_table(reloptions) WHERE option_name = 'autovacuum_vacuum_scale_factor'), '') as vacuum_scale_factor,
+				COALESCE((SELECT option_value FROM pg_options_to_table(reloptions) WHERE option_name = 'autovacuum_analyze_scale_factor'), '') as analyze_scale_factor
+			FROM pg_class
+			WHERE relname = 'events'
+		`).Row().Scan(&vacuumScaleFactor, &analyzeScaleFactor)
+		Expect(err).ToNot(HaveOccurred())
+		return vacuumScaleFactor, analyzeScaleFactor
+	}
+
+	It("Migrates down and up", func() {
+		// Initial state - no custom settings
+		vacuumBefore, analyzeBefore := getTableOptions()
+		Expect(vacuumBefore).To(BeEmpty())
+		Expect(analyzeBefore).To(BeEmpty())
+
+		// Migrate forward
+		Expect(gm.MigrateTo(setEventsAutovacuumSettingsID)).ToNot(HaveOccurred())
+
+		vacuumAfter, analyzeAfter := getTableOptions()
+		Expect(vacuumAfter).To(Equal("0.05"))
+		Expect(analyzeAfter).To(Equal("0.025"))
+
+		// Rollback
+		Expect(gm.RollbackMigration(setEventsAutovacuumSettings())).ToNot(HaveOccurred())
+
+		vacuumRolledBack, analyzeRolledBack := getTableOptions()
+		Expect(vacuumRolledBack).To(BeEmpty())
+		Expect(analyzeRolledBack).To(BeEmpty())
+
+		// Migrate forward again
+		Expect(gm.MigrateTo(setEventsAutovacuumSettingsID)).ToNot(HaveOccurred())
+
+		vacuumFinal, analyzeFinal := getTableOptions()
+		Expect(vacuumFinal).To(Equal("0.05"))
+		Expect(analyzeFinal).To(Equal("0.025"))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -51,6 +51,7 @@ func post() []*gormigrate.Migration {
 		addHostsByClusterIdIndex(),
 		addHostsByInfraEnvIdIndex(),
 		populatePrimaryIPStackForExistingClusters(),
+		setEventsAutovacuumSettings(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })

--- a/openshift/template-monitoring-postgres.yaml
+++ b/openshift/template-monitoring-postgres.yaml
@@ -179,6 +179,35 @@ objects:
               usage: "GAUGE"
               description: "Disk space used by the database"
 
+      pg_index_size:
+        cache_seconds: 30
+        query: |
+          SELECT
+            current_database() AS datname,
+            n.nspname AS schemaname,
+            c.relname AS tablename,
+            i.indexrelname AS indexname,
+            pg_relation_size(i.indexrelid) AS size_bytes
+          FROM pg_stat_user_indexes i
+          JOIN pg_class c ON c.oid = i.relid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+        metrics:
+          - datname:
+              usage: "LABEL"
+              description: "Name of current database"
+          - schemaname:
+              usage: "LABEL"
+              description: "Name of the schema"
+          - tablename:
+              usage: "LABEL"
+              description: "Name of the table"
+          - indexname:
+              usage: "LABEL"
+              description: "Name of the index"
+          - size_bytes:
+              usage: "GAUGE"
+              description: "Size of the index in bytes"
+
 
       pg_stat_activity_idle:
         query: |

--- a/openshift/template-postgres-reindex.yaml
+++ b/openshift/template-postgres-reindex.yaml
@@ -1,0 +1,124 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: postgres-reindex
+objects:
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: postgres-reindex
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+      spec:
+        activeDeadlineSeconds: 10800
+        backoffLimit: 2
+        ttlSecondsAfterFinished: 86400
+        template:
+          metadata:
+            labels:
+              app: postgres-reindex
+          spec:
+            serviceAccountName: postgres-maintenance
+            restartPolicy: Never
+            containers:
+            - name: postgres-reindex
+              image: quay.io/sclorg/postgresql-13-c9s
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+              env:
+              - name: PGHOST
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: db.host
+              - name: PGPORT
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: db.port
+              - name: PGDATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: db.name
+              - name: PGUSER
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: db.user
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: db.password
+              - name: PGSSLMODE
+                value: ${PG_SSLMODE}
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+
+                set -euxo pipefail
+
+                TARGET_TABLES="${TARGET_TABLES}"
+
+                echo "Starting reindex operation at $(date)"
+                echo "Database: $PGDATABASE on $PGHOST:$PGPORT"
+                echo "Target tables: $TARGET_TABLES"
+
+                # Test connection
+                if ! psql -c "SELECT version();" > /dev/null 2>&1; then
+                  echo "ERROR: Failed to connect to database"
+                  exit 1
+                fi
+
+                echo "Connection successful"
+
+                # Process each table
+                for TABLE in $TARGET_TABLES; do
+                  echo ""
+                  echo "=== Reindexing table $TABLE ==="
+                  START_TIME=$(date +%s)
+                  psql -c "REINDEX TABLE CONCURRENTLY public.\"$TABLE\";"
+                  END_TIME=$(date +%s)
+                  DURATION=$((END_TIME - START_TIME))
+                  echo "Table $TABLE reindexed successfully in ${DURATION} seconds"
+                done
+
+                echo ""
+                echo "Reindex operation completed successfully at $(date)"
+parameters:
+- name: DB_SECRET_NAME
+  description: Name of the secret containing database credentials
+  required: true
+- name: TARGET_TABLES
+  description: Space-separated list of tables to reindex
+  required: true
+- name: SCHEDULE
+  description: Cron schedule for the reindex job
+  value: "0 14 * * 4"
+- name: CPU_REQUEST
+  description: CPU request for the reindex container
+  value: 100m
+- name: CPU_LIMIT
+  description: CPU limit for the reindex container
+  value: 500m
+- name: MEMORY_REQUEST
+  description: Memory request for the reindex container
+  value: 256Mi
+- name: MEMORY_LIMIT
+  description: Memory limit for the reindex container
+  value: 512Mi
+- name: PG_SSLMODE
+  description: PostgreSQL SSL mode
+  value: require
+


### PR DESCRIPTION
### Problem

The events table is high-churn with frequent inserts and deletes, resulting in lingering tombstones and index bloat and impacting query performance.

### Solution

Configure aggressive autovacuum settings and add a reindex cronjob to periodically reclaim index bloat.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Checked current bloat on the events table and adjusted autovacuum values to clean up before significant performance impact)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database maintenance: added a reversible migration to tune autovacuum settings for the events table, with tests validating apply/rollback behavior.
* **New Features**
  * Scheduled maintenance: added a configurable PostgreSQL reindex CronJob to periodically reindex the events table and report per-index and total size metrics, duration, and reclaimed-space statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->