### PR TITLE
MGMT-23920: 4.22 SNO doesn't support 4 cpu cores node

### DIFF
--- a/internal/hardware/versioned-requirements.go
+++ b/internal/hardware/versioned-requirements.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	goversion "github.com/hashicorp/go-version"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -34,12 +35,9 @@ func (d *VersionedRequirementsDecoder) GetVersionedHostRequirements(version stri
 	}
 
 	if len(d.minVersions) > 0 {
-		requestedV, err := goversion.NewVersion(version)
-		if err == nil {
-			for i := len(d.minVersions) - 1; i >= 0; i-- {
-				if d.minVersions[i].version.LessThanOrEqual(requestedV) {
-					return copyVersionedHostRequirements(&d.minVersions[i].requirements), nil
-				}
+		for i := len(d.minVersions) - 1; i >= 0; i-- {
+			if isGreaterOrEqual, err := common.BaseVersionGreaterOrEqual(d.minVersions[i].requirements.Version, version); err == nil && isGreaterOrEqual {
+				return copyVersionedHostRequirements(&d.minVersions[i].requirements), nil
 			}
 		}
 	}

--- a/internal/hardware/versioned-requirements.go
+++ b/internal/hardware/versioned-requirements.go
@@ -34,11 +34,9 @@ func (d *VersionedRequirementsDecoder) GetVersionedHostRequirements(version stri
 		return copyVersionedHostRequirements(&req), nil
 	}
 
-	if len(d.minVersions) > 0 {
-		for i := len(d.minVersions) - 1; i >= 0; i-- {
-			if isGreaterOrEqual, err := common.BaseVersionGreaterOrEqual(d.minVersions[i].requirements.Version, version); err == nil && isGreaterOrEqual {
-				return copyVersionedHostRequirements(&d.minVersions[i].requirements), nil
-			}
+	for i := len(d.minVersions) - 1; i >= 0; i-- {
+		if isGreaterOrEqual, err := common.BaseVersionGreaterOrEqual(d.minVersions[i].requirements.Version, version); err == nil && isGreaterOrEqual {
+			return copyVersionedHostRequirements(&d.minVersions[i].requirements), nil
 		}
 	}
 

--- a/internal/hardware/versioned-requirements_test.go
+++ b/internal/hardware/versioned-requirements_test.go
@@ -583,6 +583,11 @@ var _ = Describe("Versioned Requirements", func() {
 			requirements, err = cfg.VersionedRequirements.GetVersionedHostRequirements("4.21.0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*requirements.SNORequirements.CPUCores).To(BeEquivalentTo(8))
+
+			// pre-release versions (e.g. ec, rc) should match as if they were the base release
+			requirements, err = cfg.VersionedRequirements.GetVersionedHostRequirements("4.22.0-ec.5")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*requirements.SNORequirements.CPUCores).To(BeEquivalentTo(4))
 		})
 
 		It("should merge partial min_version fields with default", func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pre-release version strings when matching hardware requirements so queries for pre-release builds map to the appropriate minimum-spec entry.

* **Tests**
  * Added test coverage for pre-release version scenarios to verify correct hardware requirement selection and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->