### PR TITLE
MCO-2223: Add osImageStream install-config overrides

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -283,6 +283,7 @@ type InstallerConfigBaremetal struct {
 	Capabilities                  *Capabilities        `json:"capabilities,omitempty"`
 	FeatureSet                    configv1.FeatureSet  `json:"featureSet,omitempty"`
 	FeatureGates                  []string             `json:"featureGates,omitempty"`
+	OSImageStream                 string               `json:"osImageStream,omitempty"`
 }
 
 func (c *InstallerConfigBaremetal) Validate() error {


### PR DESCRIPTION
This change adds the osImageStream field to the AS counterpart of the install-config schema to allow overriding its value when requested from other sources like the Agent installer.

## List all the issues related to this PR

https://redhat.atlassian.net/browse/MCO-2223

- [ ] New Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OS image stream configuration support for baremetal installations, allowing customization of the image stream during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->