### PR TITLE
NO-ISSUE: Remove urlAuth from credentials endpoint

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1064,9 +1064,6 @@ func init() {
             ]
           },
           {
-            "urlAuth": []
-          },
-          {
             "agentAuth": []
           }
         ],
@@ -12571,9 +12568,6 @@ func init() {
             "userAuth": [
               "user"
             ]
-          },
-          {
-            "urlAuth": []
           },
           {
             "agentAuth": []

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2111,7 +2111,6 @@ paths:
         - installer
       security:
         - userAuth: [user]
-        - urlAuth: []
         - agentAuth: []
       description: Downloads credentials relating to the installed/installing cluster.
       operationId: V2DownloadClusterCredentials


### PR DESCRIPTION
We never create presigned urls for this endpoint so there's no reason to allow urlAuth for it.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Modified authentication requirements for the cluster credentials download endpoint. The endpoint now exclusively supports user and agent authentication methods. URL-based authentication has been removed from this operation. Users accessing this endpoint must authenticate through user or agent credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->