### PR TITLE
MGMT-23861: Revert MGMT-22385 for oci iscsi day2

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -603,11 +603,19 @@ func hasDay2UnknownMachineNetwork(cluster *common.Cluster, host *models.Host, lo
 	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
 		return false
 	}
+
+	// In case of OCI, we do want to configure the iSCSI NIC because it's the only NIC that is auto configured
+	if common.IsOciExternalIntegrationEnabled(cluster.Platform) {
+		return false
+	}
+
 	machineNetworkCIDR := network.GetPrimaryMachineCidrForUserManagedNetwork(cluster, log)
 	if machineNetworkCIDR == "" {
 		log.Infof("Host %s in cluster %s: skipping iSCSI ip= kernel args (Day2 iSCSI/multipath with unknown machine network)", host.ID, *cluster.ID)
+
 		return true
 	}
+
 	return false
 }
 

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1135,6 +1135,98 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1"]`))
 	})
+	It("Day2 OCI iSCSI installation disk - ip kernel args added when machine network unknown (not skipped like non-OCI Day2)", func() {
+		cluster.Kind = swag.String(models.ClusterKindAddHostsCluster)
+		cluster.MachineNetworks = nil
+		cluster.Platform = &models.Platform{
+			Type: models.PlatformTypeExternal.Pointer(),
+			External: &models.PlatformExternal{
+				PlatformName:           swag.String(common.ExternalPlatformNameOci),
+				CloudControllerManager: swag.String(models.PlatformExternalCloudControllerManagerExternal),
+			},
+		}
+		host.InstallerArgs = ""
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.80"
+					}
+				}
+			],
+			"interfaces":[
+				{
+					"mac_address": "01:02:03:04:05:06",
+					"ipv4_addresses":["10.56.20.80/25"]
+				},
+				{
+					"mac_address": "07:08:09:0A:0B:0C",
+					"ipv4_addresses":["192.168.1.10/24"]
+				}
+			]
+		}`, models.DriveTypeISCSI)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp"]`))
+	})
+	It("Day2 OCI multipath iSCSI installation disk - ip kernel args added when machine network unknown", func() {
+		cluster.Kind = swag.String(models.ClusterKindAddHostsCluster)
+		cluster.MachineNetworks = nil
+		cluster.Platform = &models.Platform{
+			Type: models.PlatformTypeExternal.Pointer(),
+			External: &models.PlatformExternal{
+				PlatformName:           swag.String(common.ExternalPlatformNameOci),
+				CloudControllerManager: swag.String(models.PlatformExternalCloudControllerManagerExternal),
+			},
+		}
+		host.InstallerArgs = ""
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"name": "dm-0"
+				},
+				{
+					"id": "iscsi-id-1",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.80"
+					},
+					"holders": "dm-0"
+				},
+				{
+					"id": "iscsi-id-2",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.81"
+					},
+					"holders": "dm-0"
+				}
+			],
+			"interfaces":[
+				{
+					"mac_address": "01:02:03:04:05:06",
+					"ipv4_addresses":["10.56.20.80/25"]
+				},
+				{
+					"mac_address": "07:08:09:0A:0B:0C",
+					"ipv4_addresses":["10.56.20.81/25"]
+				},
+				{
+					"mac_address": "0D:0E:0F:10:11:12",
+					"ipv4_addresses":["192.168.1.10/24"]
+				}
+			]
+		}`, models.DriveTypeMultipath, models.DriveTypeISCSI, models.DriveTypeISCSI)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp","--append-karg","ip=07-08-09-0A-0B-0C:dhcp"]`))
+	})
 	It("Day2 iSCSI installation disk - ip kernel args added when machine network known", func() {
 		cluster.Kind = swag.String(models.ClusterKindAddHostsCluster)
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

It seems that https://github.com/openshift/assisted-service/pull/8837 may have introduce a regression for OCI platform. 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OCI Day2 handling so external OCI integrations no longer trigger an incorrect "unknown machine network" condition and ensure proper iSCSI kernel arguments are applied during Day2 installs.

* **Tests**
  * Added tests covering OCI external Day2 installation scenarios, including iSCSI and multipath iSCSI argument behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->