### PR TITLE
MGMT-23509: Allow restoring soft deleted hosts

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5811,6 +5811,15 @@ func (b *bareMetalInventory) GetInfraEnvByKubeKey(key types.NamespacedName) (*co
 
 func (b *bareMetalInventory) CreateHostInKubeKeyNamespace(ctx context.Context, kubeKey types.NamespacedName, host *models.Host) error {
 	log := logutil.FromContext(ctx, b.log)
+
+	// Delete any previous record of the host if it was soft deleted,
+	// no error will be returned if the host didn't exist.
+	// This follows the same pattern as RegisterHost.
+	if err := common.DeleteSoftDeletedHost(b.db, host.ID.String(), host.InfraEnvID.String()); err != nil {
+		log.WithError(err).Errorf("Error while deleting soft-deleted host %s", host.ID.String())
+		return err
+	}
+
 	hostToCreate := &common.Host{
 		Host:                    *host,
 		KubeKeyNamespace:        kubeKey.Namespace,

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -22321,3 +22321,335 @@ var _ = Describe("Primary IP Stack Functionality", func() {
 		})
 	})
 })
+
+var _ = Describe("GetCommonHostInternal", func() {
+	var (
+		bm     *bareMetalInventory
+		cfg    Config
+		db     *gorm.DB
+		ctx    = context.Background()
+		dbName string
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		bm = createInventory(db, cfg)
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("should find existing host by composite key", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		hostID := strfmt.UUID(uuid.New().String())
+
+		// Create infra env
+		infraEnv := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+		// Create host
+		host := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+		}
+		Expect(db.Create(host).Error).ToNot(HaveOccurred())
+
+		// Test GetCommonHostInternal
+		foundHost, err := bm.GetCommonHostInternal(ctx, infraEnvID.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost).ToNot(BeNil())
+		Expect(foundHost.ID.String()).To(Equal(hostID.String()))
+		Expect(foundHost.InfraEnvID.String()).To(Equal(infraEnvID.String()))
+	})
+
+	It("should return error when host not found", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		hostID := strfmt.UUID(uuid.New().String())
+
+		// Test GetCommonHostInternal with non-existent host
+		foundHost, err := bm.GetCommonHostInternal(ctx, infraEnvID.String(), hostID.String())
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+		Expect(foundHost).To(BeNil())
+	})
+
+	It("should not find soft-deleted host", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		hostID := strfmt.UUID(uuid.New().String())
+
+		// Create infra env
+		infraEnv := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete host
+		host := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+		}
+		Expect(db.Create(host).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host).Error).ToNot(HaveOccurred())
+
+		// Test GetCommonHostInternal should not find soft-deleted host
+		foundHost, err := bm.GetCommonHostInternal(ctx, infraEnvID.String(), hostID.String())
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+		Expect(foundHost).To(BeNil())
+	})
+
+	It("should find correct host when same ID exists in different infra envs", func() {
+		hostID := strfmt.UUID(uuid.New().String())
+		infraEnvID1 := strfmt.UUID(uuid.New().String())
+		infraEnvID2 := strfmt.UUID(uuid.New().String())
+
+		// Create two infra envs
+		infraEnv1 := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID1,
+			},
+		}
+		Expect(db.Create(infraEnv1).Error).ToNot(HaveOccurred())
+
+		infraEnv2 := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID2,
+			},
+		}
+		Expect(db.Create(infraEnv2).Error).ToNot(HaveOccurred())
+
+		// Create same host ID in both infra envs
+		host1 := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID1,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+		}
+		Expect(db.Create(host1).Error).ToNot(HaveOccurred())
+
+		host2 := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID2,
+				Status:     swag.String(models.HostStatusDiscovering),
+			},
+		}
+		Expect(db.Create(host2).Error).ToNot(HaveOccurred())
+
+		// Test GetCommonHostInternal finds correct host for each infra env
+		foundHost1, err := bm.GetCommonHostInternal(ctx, infraEnvID1.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost1).ToNot(BeNil())
+		Expect(foundHost1.InfraEnvID.String()).To(Equal(infraEnvID1.String()))
+		Expect(*foundHost1.Status).To(Equal(models.HostStatusKnown))
+
+		foundHost2, err := bm.GetCommonHostInternal(ctx, infraEnvID2.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost2).ToNot(BeNil())
+		Expect(foundHost2.InfraEnvID.String()).To(Equal(infraEnvID2.String()))
+		Expect(*foundHost2.Status).To(Equal(models.HostStatusDiscovering))
+	})
+})
+
+var _ = Describe("CreateHostInKubeKeyNamespace", func() {
+	var (
+		bm     *bareMetalInventory
+		cfg    Config
+		db     *gorm.DB
+		ctx    = context.Background()
+		dbName string
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		bm = createInventory(db, cfg)
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("should create host when no previous record exists", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		hostID := strfmt.UUID(uuid.New().String())
+		kubeKey := types.NamespacedName{
+			Name:      hostID.String(),
+			Namespace: "test-namespace",
+		}
+
+		// Create infra env
+		infraEnv := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+		// Create host model
+		host := &models.Host{
+			ID:         &hostID,
+			InfraEnvID: infraEnvID,
+			Status:     swag.String(models.HostStatusDiscovering),
+		}
+
+		// Test CreateHostInKubeKeyNamespace
+		err := bm.CreateHostInKubeKeyNamespace(ctx, kubeKey, host)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify host was created
+		foundHost, err := common.GetHostFromDB(db, infraEnvID.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost).ToNot(BeNil())
+		Expect(foundHost.ID.String()).To(Equal(hostID.String()))
+		Expect(foundHost.InfraEnvID.String()).To(Equal(infraEnvID.String()))
+		Expect(foundHost.KubeKeyNamespace).To(Equal(kubeKey.Namespace))
+	})
+
+	It("should hard-delete soft-deleted host and create new one", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		hostID := strfmt.UUID(uuid.New().String())
+		kubeKey := types.NamespacedName{
+			Name:      hostID.String(),
+			Namespace: "test-namespace",
+		}
+
+		// Create infra env
+		infraEnv := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete a host
+		oldHost := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+			KubeKeyNamespace: "old-namespace",
+		}
+		Expect(db.Create(oldHost).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(oldHost).Error).ToNot(HaveOccurred())
+
+		// Verify host is soft-deleted
+		var count int64
+		Expect(db.Model(&common.Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+
+		// Verify soft-deleted host exists with Unscoped
+		Expect(db.Unscoped().Model(&common.Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+
+		// Create new host with same ID
+		newHost := &models.Host{
+			ID:         &hostID,
+			InfraEnvID: infraEnvID,
+			Status:     swag.String(models.HostStatusDiscovering),
+		}
+
+		// Test CreateHostInKubeKeyNamespace
+		err := bm.CreateHostInKubeKeyNamespace(ctx, kubeKey, newHost)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify new host was created (not soft-deleted)
+		foundHost, err := common.GetHostFromDB(db, infraEnvID.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost).ToNot(BeNil())
+		Expect(foundHost.ID.String()).To(Equal(hostID.String()))
+		Expect(foundHost.InfraEnvID.String()).To(Equal(infraEnvID.String()))
+		Expect(*foundHost.Status).To(Equal(models.HostStatusDiscovering))
+		Expect(foundHost.KubeKeyNamespace).To(Equal(kubeKey.Namespace))
+
+		// Verify only one record exists (old soft-deleted record was hard-deleted)
+		Expect(db.Unscoped().Model(&common.Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+	})
+
+	It("should only delete soft-deleted host with matching composite key", func() {
+		hostID := strfmt.UUID(uuid.New().String())
+		infraEnvID1 := strfmt.UUID(uuid.New().String())
+		infraEnvID2 := strfmt.UUID(uuid.New().String())
+		kubeKey := types.NamespacedName{
+			Name:      hostID.String(),
+			Namespace: "test-namespace",
+		}
+
+		// Create two infra envs
+		infraEnv1 := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID1,
+			},
+		}
+		Expect(db.Create(infraEnv1).Error).ToNot(HaveOccurred())
+
+		infraEnv2 := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID2,
+			},
+		}
+		Expect(db.Create(infraEnv2).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete host in infraEnv1
+		host1 := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID1,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+		}
+		Expect(db.Create(host1).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host1).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete host in infraEnv2
+		host2 := &common.Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID2,
+				Status:     swag.String(models.HostStatusKnown),
+			},
+		}
+		Expect(db.Create(host2).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host2).Error).ToNot(HaveOccurred())
+
+		// Create new host in infraEnv1 only
+		newHost := &models.Host{
+			ID:         &hostID,
+			InfraEnvID: infraEnvID1,
+			Status:     swag.String(models.HostStatusDiscovering),
+		}
+
+		// Test CreateHostInKubeKeyNamespace
+		err := bm.CreateHostInKubeKeyNamespace(ctx, kubeKey, newHost)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify new host exists in infraEnv1
+		foundHost, err := common.GetHostFromDB(db, infraEnvID1.String(), hostID.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(foundHost).ToNot(BeNil())
+
+		// Verify soft-deleted host in infraEnv2 still exists (was not deleted)
+		var count int64
+		Expect(db.Unscoped().Model(&common.Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID2.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+
+		// Verify the record is actually soft-deleted (not active)
+		Expect(db.Model(&common.Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID2.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+	})
+})

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -533,6 +533,17 @@ func GetClusterHostFromDB(db *gorm.DB, clusterId, hostId string) (*Host, error) 
 	return &host, nil
 }
 
+// DeleteSoftDeletedHost hard-deletes any soft-deleted host with the given composite key (ID, InfraEnvID).
+// This is used before registering or creating a host to prevent primary key conflicts.
+// Returns nil if no soft-deleted host exists.
+func DeleteSoftDeletedHost(db *gorm.DB, hostId, infraEnvId string) error {
+	err := db.Unscoped().Where("deleted_at IS NOT NULL").Delete(&Host{}, "id = ? and infra_env_id = ?", hostId, infraEnvId).Error
+	if err != nil {
+		return errors.Wrapf(err, "error while trying to delete soft-deleted host %s in infra env %s from db", hostId, infraEnvId)
+	}
+	return nil
+}
+
 func GetHostFromDBWhere(db *gorm.DB, where ...interface{}) (*Host, error) {
 	var host Host
 

--- a/internal/common/db_test.go
+++ b/internal/common/db_test.go
@@ -494,3 +494,133 @@ func ipv6Cluster(clusterID strfmt.UUID) *Cluster {
 		},
 	}
 }
+
+var _ = Describe("DeleteSoftDeletedHost", func() {
+	var (
+		db         *gorm.DB
+		dbName     string
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		hostID     = strfmt.UUID(uuid.New().String())
+	)
+
+	BeforeEach(func() {
+		db, dbName = PrepareTestDB()
+
+		// Create infraEnv
+		infraEnv := &InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		DeleteTestDB(db, dbName)
+	})
+
+	It("should successfully delete a soft-deleted host", func() {
+		// Create and soft-delete a host
+		host := &Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+			},
+		}
+		Expect(db.Create(host).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host).Error).ToNot(HaveOccurred())
+
+		// Verify host is soft-deleted (not found in normal query)
+		var count int64
+		Expect(db.Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+
+		// Verify soft-deleted host exists with Unscoped
+		Expect(db.Unscoped().Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+
+		// Delete soft-deleted host
+		err := DeleteSoftDeletedHost(db, hostID.String(), infraEnvID.String())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify host is completely removed
+		Expect(db.Unscoped().Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+	})
+
+	It("should not delete an active (non-soft-deleted) host", func() {
+		// Create active host
+		host := &Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+			},
+		}
+		Expect(db.Create(host).Error).ToNot(HaveOccurred())
+
+		// Attempt to delete soft-deleted host (should be no-op)
+		err := DeleteSoftDeletedHost(db, hostID.String(), infraEnvID.String())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify active host still exists
+		var count int64
+		Expect(db.Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+	})
+
+	It("should succeed when no host exists at all", func() {
+		// Call on non-existent host
+		err := DeleteSoftDeletedHost(db, hostID.String(), infraEnvID.String())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify no host exists
+		var count int64
+		Expect(db.Unscoped().Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+	})
+
+	It("should only delete host with matching composite key", func() {
+		otherInfraEnvID := strfmt.UUID(uuid.New().String())
+
+		// Create another infraEnv
+		otherInfraEnv := &InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &otherInfraEnvID,
+			},
+		}
+		Expect(db.Create(otherInfraEnv).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete host in first infraEnv
+		host1 := &Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: infraEnvID,
+			},
+		}
+		Expect(db.Create(host1).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host1).Error).ToNot(HaveOccurred())
+
+		// Create and soft-delete host with same ID in different infraEnv
+		host2 := &Host{
+			Host: models.Host{
+				ID:         &hostID,
+				InfraEnvID: otherInfraEnvID,
+			},
+		}
+		Expect(db.Create(host2).Error).ToNot(HaveOccurred())
+		Expect(db.Delete(host2).Error).ToNot(HaveOccurred())
+
+		// Delete soft-deleted host in first infraEnv only
+		err := DeleteSoftDeletedHost(db, hostID.String(), infraEnvID.String())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify first host is deleted
+		var count int64
+		Expect(db.Unscoped().Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), infraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(0)))
+
+		// Verify second host still exists (soft-deleted)
+		Expect(db.Unscoped().Model(&Host{}).Where("id = ? AND infra_env_id = ?", hostID.String(), otherInfraEnvID.String()).Count(&count).Error).ToNot(HaveOccurred())
+		Expect(count).To(Equal(int64(1)))
+	})
+})

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -2223,19 +2223,23 @@ func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, log logrus.Fie
 		clusterID = cluster.ID
 	}
 
-	// Check if a host with the same ID already exists (regardless of namespace)
-	// This prevents duplicate hosts and reports conflicts
-	existingHost, err := r.Installer.GetHostByIdInternal(ctx, agent.Name)
+	// Check if an active host (not deleted) with this composite key (InfraEnvID, HostID) already exists
+	existingHost, err := r.Installer.GetCommonHostInternal(ctx, infraEnv.ID.String(), agent.Name)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		r.Log.WithError(err).Errorf("Failed to check for existing host with ID %s", agent.Name)
+		r.Log.WithError(err).Errorf("Failed to check for existing host with ID %s in infraEnv %s", agent.Name, infraEnv.ID)
 		return r.updateStatus(ctx, log, agent, origAgent, nil, nil, err, true)
-	} else if err == nil && existingHost != nil {
-		errMsg := fmt.Sprintf("Host with ID %s already exists in namespace %s. Agent creation conflicts with existing host.",
-			agent.Name, existingHost.KubeKeyNamespace)
+	}
+
+	if existingHost != nil {
+		// An active host with this composite key (InfraEnvID, HostID) already exists so we should not restore it
+		errMsg := fmt.Sprintf("Host with ID %s already exists in infraEnv %s (namespace: %s). Cannot restore.",
+			agent.Name, existingHost.InfraEnvID, existingHost.KubeKeyNamespace)
 		r.Log.Error(errMsg)
 		return r.updateStatus(ctx, log, agent, origAgent, nil, nil, errors.New(errMsg), false)
 	}
 
+	// No active host exists - CreateHostInKubeKeyNamespace will automatically delete
+	// any soft-deleted host with the same composite key (InfraEnvID, HostID) before creating the new record.
 	host, err := createNewHost(agent, clusterID, *infraEnv.ID)
 	if err != nil {
 		r.Log.WithError(err).Errorf("Failed to create Host with name '%s'", agent.Name)
@@ -2246,7 +2250,6 @@ func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, log logrus.Fie
 	if err != nil {
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 	}
-
 	return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}, nil
 }
 

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -5756,8 +5756,8 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterId, ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
-		// Mock that no existing host is found
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Mock that no existing host is found (checks composite key: ID + InfraEnvID)
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -5800,8 +5800,8 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvId}}
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
-		// Mock that no existing host is found
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Mock that no existing host is found (checks composite key: ID + InfraEnvID)
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, nil, infraEnvId)
@@ -5848,7 +5848,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
 		// Mock that no existing host is found
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -5918,7 +5918,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
 		// Mock that no existing host is found
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 		// Create Host
 		host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -6050,7 +6050,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
 			// Mock that no existing host is found
-			mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+			mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 			// Create Host
 			host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -6109,7 +6109,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
 
 			// Mock that no existing host is found
-			mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+			mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 
 			// Create Host
 			host, err := createNewHost(agent, &clusterId, infraEnvId)
@@ -6169,8 +6169,8 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 
 		// Host not found in namespace
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
-		// Check for host by ID only - conflict detected
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(existingHost, nil).Times(1)
+		// Check for host by composite key (ID, InfraEnvID) - conflict detected
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(existingHost, nil).Times(1)
 
 		// Reconcile Agent - should handle conflict via status condition, not error
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
@@ -6183,7 +6183,7 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		specSyncedCond := conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition)
 		Expect(specSyncedCond).ToNot(BeNil())
 		Expect(specSyncedCond.Status).To(Equal(corev1.ConditionFalse))
-		Expect(specSyncedCond.Message).To(ContainSubstring("already exists in namespace other-namespace"))
+		Expect(specSyncedCond.Message).To(ContainSubstring("namespace: other-namespace"))
 	})
 
 	It("should create new host if no existing host found", func() {
@@ -6203,8 +6203,8 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 
 		// Host not found in namespace
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
-		// Check for host by ID only - not found
-		mockInstallerInternal.EXPECT().GetHostByIdInternal(gomock.Any(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Check for host by composite key (ID, InfraEnvID) - not found
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
 		// Create new host
 		mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(gomock.Any(), infraEnvKey, gomock.Any()).Return(nil).Times(1)
 
@@ -6212,6 +6212,48 @@ var _ = Describe("Restore Host - Reconcile an Agent with missing Host", func() {
 		result, err := hr.Reconcile(ctx, newHostRequest(agent))
 		Expect(err).To(BeNil())
 		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
+	})
+
+	It("should recreate host after soft-delete by validating composite key and passing correct namespace to CreateHostInKubeKeyNamespace", func() {
+		agent := newAgent("agent", testNamespace, v1beta1.AgentSpec{})
+		agent.ObjectMeta.Labels = map[string]string{
+			v1beta1.InfraEnvNameLabel: "infraEnvName",
+		}
+		Expect(c.Create(ctx, agent)).To(BeNil())
+
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		infraEnvKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "infraEnvName",
+		}
+		backendInfraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvId}}
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(infraEnvKey).Return(backendInfraEnv, nil).Times(1)
+
+		// Host not found in namespace (soft-deleted)
+		agentKey := types.NamespacedName{Name: agent.Name, Namespace: testNamespace}
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(agentKey).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// Check for non-deleted host by composite key - not found (confirms soft-deletion)
+		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), infraEnvId.String(), agent.Name).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		// CreateHostInKubeKeyNamespace will delete soft-deleted host and create new one
+		mockInstallerInternal.EXPECT().CreateHostInKubeKeyNamespace(
+			gomock.Any(),
+			gomock.Eq(infraEnvKey),
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, kubeKey types.NamespacedName, host *models.Host) error {
+			// Validate host argument has expected ID (agent.Name) and InfraEnvID
+			Expect(host.ID.String()).To(Equal(agent.Name), "host ID should match agent name")
+			Expect(host.InfraEnvID.String()).To(Equal(infraEnvId.String()), "host InfraEnvID should match infraEnv ID")
+			return nil
+		}).Times(1)
+
+		// Reconcile Agent - should succeed
+		result, err := hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeue}))
+
+		// Verify Agent was created successfully
+		agent = &v1beta1.Agent{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "agent", Namespace: testNamespace}, agent)).To(BeNil())
 	})
 })
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -187,13 +187,10 @@ func (m *Manager) RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB)
 			return err
 		}
 
-		// Delete any previews record of the host if it was soft deleted from the cluster,
-		// no error will be returned if the host was not existed.
-		if err := db.Unscoped().Delete(&common.Host{}, "id = ? and infra_env_id = ?", *h.ID, h.InfraEnvID).Error; err != nil {
-			return errors.Wrapf(
-				err,
-				"error while trying to delete previews record from db (if exists) of host %s in infra env %s",
-				h.ID.String(), h.InfraEnvID.String())
+		// Delete any previous record of the host if it was soft deleted from the cluster,
+		// no error will be returned if the host did not exist.
+		if err := common.DeleteSoftDeletedHost(db, h.ID.String(), h.InfraEnvID.String()); err != nil {
+			return err
 		}
 
 		host = h


### PR DESCRIPTION

A host that was soft-deleted and not removed from the DB
will prevent that same host from being restored due to
primary key conflict.

To fix this, we should delete the soft-deleted host before
we try to restore and recreate it.

This allows restoring hosts on the same hub that may have
just had a disaster scenario with the hosted cluster.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): Booted host with discovery ISO from infraenv, installed to hosted cluster, made a backup of the Agent and Infraenv CRs,
- [ ] No tests needed

### Manual test steps
1. Create BMH 
3. Create HostedCluster
4. Scaled up NodePool to install host to cluster
5. Wait until Agent finishes installing into hosted cluster
6. Make backup of Agent CR
7. Annotate all `Agent` CR with `agent.agent-install.openshift.io/skip-spoke-cleanup: true` <-- prevents Agents (hosts) from being removed from the hosted cluster as nodes
9. Delete `Agent` CR 
10. Recreate `Agent` CR
11. Observe the `Agent` get restored


## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host recreation now removes soft-deleted entries only within the same infrastructure environment before creating a new active host.
  * Restore/conflict detection respects infra-environment scope to prevent cross-environment conflicts.

* **Tests**
  * Added tests for composite-key host lookups, scoped deletion/recreation, conflict scenarios, and restoration after soft-delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->