### PR TITLE
MGMT-23971: Add a timeout for installing-pending-user-action

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -232,10 +232,6 @@ func mapHostsByStatus(c *common.Cluster, role models.HostRole) map[string][]*mod
 	return hostMap
 }
 
-func MapHostsByStatus(c *common.Cluster) map[string][]*models.Host {
-	return mapHostsByStatus(c, "")
-}
-
 func UpdateMachineNetwork(db *gorm.DB, cluster *common.Cluster, machineNetwork []string) error {
 	if len(machineNetwork) > 2 {
 		return common.NewApiError(http.StatusInternalServerError,

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -189,22 +189,6 @@ func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, er
 	return masterNodesIds, nil
 }
 
-func HostsInStatus(c *common.Cluster, statuses []string) (masters, arbiters, workers int) {
-	for _, host := range c.Hosts {
-		if funk.ContainsString(statuses, swag.StringValue(host.Status)) {
-			switch common.GetEffectiveRole(host) {
-			case models.HostRoleMaster, models.HostRoleBootstrap:
-				masters++
-			case models.HostRoleArbiter:
-				arbiters++
-			case models.HostRoleWorker:
-				workers++
-			}
-		}
-	}
-	return
-}
-
 func UpdateMachineNetwork(db *gorm.DB, cluster *common.Cluster, machineNetwork []string) error {
 	if len(machineNetwork) > 2 {
 		return common.NewApiError(http.StatusInternalServerError,

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -190,9 +190,9 @@ func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, er
 }
 
 func HostsInStatus(c *common.Cluster, statuses []string) (int, int, int) {
-	mappedMastersByRole := MapMasterHostsByStatus(c)
-	mappedArbitersByRole := MapArbiterHostsByStatus(c)
-	mappedWorkersByRole := MapWorkersHostsByStatus(c)
+	mappedMastersByRole := mapHostsByStatus(c, models.HostRoleMaster)
+	mappedArbitersByRole := mapHostsByStatus(c, models.HostRoleArbiter)
+	mappedWorkersByRole := mapHostsByStatus(c, models.HostRoleWorker)
 	mastersInSomeInstallingStatus := 0
 	arbitersInSomeInstallingStatus := 0
 	workersInSomeInstallingStatus := 0
@@ -203,18 +203,6 @@ func HostsInStatus(c *common.Cluster, statuses []string) (int, int, int) {
 		workersInSomeInstallingStatus += len(mappedWorkersByRole[status])
 	}
 	return mastersInSomeInstallingStatus, arbitersInSomeInstallingStatus, workersInSomeInstallingStatus
-}
-
-func MapMasterHostsByStatus(c *common.Cluster) map[string][]*models.Host {
-	return mapHostsByStatus(c, models.HostRoleMaster)
-}
-
-func MapArbiterHostsByStatus(c *common.Cluster) map[string][]*models.Host {
-	return mapHostsByStatus(c, models.HostRoleArbiter)
-}
-
-func MapWorkersHostsByStatus(c *common.Cluster) map[string][]*models.Host {
-	return mapHostsByStatus(c, models.HostRoleWorker)
 }
 
 func mapHostsByStatus(c *common.Cluster, role models.HostRole) map[string][]*models.Host {

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -189,35 +189,20 @@ func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, er
 	return masterNodesIds, nil
 }
 
-func HostsInStatus(c *common.Cluster, statuses []string) (int, int, int) {
-	mappedMastersByRole := mapHostsByStatus(c, models.HostRoleMaster)
-	mappedArbitersByRole := mapHostsByStatus(c, models.HostRoleArbiter)
-	mappedWorkersByRole := mapHostsByStatus(c, models.HostRoleWorker)
-	mastersInSomeInstallingStatus := 0
-	arbitersInSomeInstallingStatus := 0
-	workersInSomeInstallingStatus := 0
-
-	for _, status := range statuses {
-		mastersInSomeInstallingStatus += len(mappedMastersByRole[status])
-		arbitersInSomeInstallingStatus += len(mappedArbitersByRole[status])
-		workersInSomeInstallingStatus += len(mappedWorkersByRole[status])
-	}
-	return mastersInSomeInstallingStatus, arbitersInSomeInstallingStatus, workersInSomeInstallingStatus
-}
-
-func mapHostsByStatus(c *common.Cluster, role models.HostRole) map[string][]*models.Host {
-	hostMap := make(map[string][]*models.Host)
+func HostsInStatus(c *common.Cluster, statuses []string) (masters, arbiters, workers int) {
 	for _, host := range c.Hosts {
-		if role != "" && common.GetEffectiveRole(host) != role {
-			continue
-		}
-		if _, ok := hostMap[swag.StringValue(host.Status)]; ok {
-			hostMap[swag.StringValue(host.Status)] = append(hostMap[swag.StringValue(host.Status)], host)
-		} else {
-			hostMap[swag.StringValue(host.Status)] = []*models.Host{host}
+		if funk.ContainsString(statuses, swag.StringValue(host.Status)) {
+			switch common.GetEffectiveRole(host) {
+			case models.HostRoleMaster, models.HostRoleBootstrap:
+				masters++
+			case models.HostRoleArbiter:
+				arbiters++
+			case models.HostRoleWorker:
+				workers++
+			}
 		}
 	}
-	return hostMap
+	return
 }
 
 func UpdateMachineNetwork(db *gorm.DB, cluster *common.Cluster, machineNetwork []string) error {

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -257,7 +257,7 @@ func (th *transitionHandler) createClusterCompletionStatusInfo(ctx context.Conte
 		statusInfo = StatusInfoDegraded
 		statusInfo += ". Failed OLM operators: " + strings.Join(statuses[models.OperatorTypeOlm][models.OperatorStatusFailed], ", ")
 	} else {
-		_, _, installedWorkers := HostsInStatus(cluster, []string{models.HostStatusInstalled})
+		_, _, installedWorkers := common.HostsInStatus(cluster, []string{models.HostStatusInstalled})
 		if installedWorkers < common.NumberOfWorkers(cluster) {
 			statusInfo = StatusInfoNotAllWorkersInstalled
 		}
@@ -418,7 +418,7 @@ func (th *transitionHandler) IsFinalizing(sw stateswitch.StateSwitch, args state
 	sCluster, ok := sw.(*stateCluster)
 	installedStatus := []string{models.HostStatusInstalled}
 
-	if ok && th.enoughMastersAndWorkers(sCluster, installedStatus) {
+	if ok && common.HasEnoughMastersAndWorkers(sCluster.cluster, installedStatus) {
 		th.log.Infof("Cluster %s has at least required number of installed hosts, "+
 			"cluster is finalizing.", sCluster.cluster.ID)
 		return true, nil
@@ -431,7 +431,7 @@ func (th *transitionHandler) IsInstalling(sw stateswitch.StateSwitch, args state
 	sCluster, _ := sw.(*stateCluster)
 	installingStatuses := []string{models.HostStatusInstalling, models.HostStatusInstallingInProgress,
 		models.HostStatusInstalled, models.HostStatusInstallingPendingUserAction, models.HostStatusPreparingSuccessful}
-	return th.enoughMastersAndWorkers(sCluster, installingStatuses), nil
+	return common.HasEnoughMastersAndWorkers(sCluster.cluster, installingStatuses), nil
 }
 
 // check if we should stay in installing state
@@ -505,52 +505,6 @@ func (th *transitionHandler) PostUpdateFinalizingAMSConsoleUrl(sw stateswitch.St
 	params.updatedCluster = updatedCluster
 	log.Infof("Updated console-url in AMS subscription with id %s", subscriptionID)
 	return nil
-}
-
-// enoughMastersAndWorkers returns whether the number of master and worker nodes in the specified cluster with the given status
-// meets the required criteria. The conditions are as follows:
-//   - For SNO (Single Node OpenShift), there must be exactly one master node and zero worker nodes.
-//   - For High Availability cluster, the number of master nodes should match the user's request, and not less than the minimum. The worker node requirement depends on this request:
-//     If the user requested at least two workers, there must be at least two, indicating non-schedulable masters were intended.
-//     If the user requested fewer than two workers, any number of workers is acceptable.
-//   - For TNA Clusters the same conditions apply as for High Availability Clusters, but we also need to check that at least one arbiter node is in the correct status.
-func (th *transitionHandler) enoughMastersAndWorkers(sCluster *stateCluster, statuses []string) bool {
-	mastersInSomeInstallingStatus, arbitersInSomeInstallingStatus, workersInSomeInstallingStatus := HostsInStatus(sCluster.cluster, statuses)
-
-	if sCluster.cluster.ControlPlaneCount == 1 {
-		return mastersInSomeInstallingStatus == common.AllowedNumberOfMasterHostsInNoneHaMode &&
-			workersInSomeInstallingStatus == common.AllowedNumberOfWorkersInNoneHaMode
-	}
-
-	// hosts roles are known at this stage
-	masters, arbiters, workers, _ := common.GetHostsByEachRole(&sCluster.cluster.Cluster, false)
-	numberOfExpectedMasters := len(masters)
-	numberOfExpectedArbiters := len(arbiters)
-
-	minMasterHostsNeeded := common.MinMasterHostsNeededForInstallationInHaMode
-	if numberOfExpectedArbiters != 0 {
-		minMasterHostsNeeded = common.MinMasterHostsNeededForInstallationInHaArbiterMode
-		// validate arbiters
-		if arbitersInSomeInstallingStatus == 0 {
-			return false
-		}
-	}
-	if common.IsClusterTopologyTwoNodesWithFencing(sCluster.cluster) {
-		minMasterHostsNeeded = common.AllowedNumberOfMasterHostsInTwoNodesWithFencing
-	}
-
-	// validate masters
-	if numberOfExpectedMasters < minMasterHostsNeeded ||
-		mastersInSomeInstallingStatus < numberOfExpectedMasters {
-		return false
-	}
-
-	numberOfExpectedWorkers := len(workers)
-
-	// validate workers
-	return numberOfExpectedWorkers < common.MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode ||
-		numberOfExpectedWorkers >= common.MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode &&
-			workersInSomeInstallingStatus >= common.MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode
 }
 
 // check if installation reach to timeout

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -912,3 +912,65 @@ func ValidateClusterSupportsFencingCredentials(cluster *Cluster) error {
 
 	return nil
 }
+
+func HostsInStatus(c *Cluster, statuses []string) (masters, arbiters, workers int) {
+	for _, host := range c.Hosts {
+		if funk.ContainsString(statuses, swag.StringValue(host.Status)) {
+			switch GetEffectiveRole(host) {
+			case models.HostRoleMaster, models.HostRoleBootstrap:
+				masters++
+			case models.HostRoleArbiter:
+				arbiters++
+			case models.HostRoleWorker:
+				workers++
+			}
+		}
+	}
+	return
+}
+
+// HasEnoughMastersAndWorkers returns whether the number of master and worker nodes in the specified cluster with the given status
+// meets the required criteria. The conditions are as follows:
+//   - For SNO (Single Node OpenShift), there must be exactly one master node and zero worker nodes.
+//   - For High Availability cluster, the number of master nodes should match the user's request, and not less than the minimum. The worker node requirement depends on this request:
+//     If the user requested at least two workers, there must be at least two, indicating non-schedulable masters were intended.
+//     If the user requested fewer than two workers, any number of workers is acceptable.
+//   - For TNA Clusters the same conditions apply as for High Availability Clusters, but we also need to check that at least one arbiter node is in the correct status.
+func HasEnoughMastersAndWorkers(c *Cluster, statuses []string) bool {
+	mastersInStatus, arbitersInStatus, workersInStatus := HostsInStatus(c, statuses)
+
+	if c.ControlPlaneCount == 1 {
+		return mastersInStatus == AllowedNumberOfMasterHostsInNoneHaMode &&
+			workersInStatus == AllowedNumberOfWorkersInNoneHaMode
+	}
+
+	// hosts roles are known at this stage
+	masters, arbiters, workers, _ := GetHostsByEachRole(&c.Cluster, false)
+	numberOfExpectedMasters := len(masters)
+	numberOfExpectedArbiters := len(arbiters)
+
+	minMasterHostsNeeded := MinMasterHostsNeededForInstallationInHaMode
+	if numberOfExpectedArbiters != 0 {
+		minMasterHostsNeeded = MinMasterHostsNeededForInstallationInHaArbiterMode
+		// validate arbiters
+		if arbitersInStatus == 0 {
+			return false
+		}
+	}
+	if IsClusterTopologyTwoNodesWithFencing(c) {
+		minMasterHostsNeeded = AllowedNumberOfMasterHostsInTwoNodesWithFencing
+	}
+
+	// validate masters
+	if numberOfExpectedMasters < minMasterHostsNeeded ||
+		mastersInStatus < numberOfExpectedMasters {
+		return false
+	}
+
+	numberOfExpectedWorkers := len(workers)
+
+	// validate workers
+	return numberOfExpectedWorkers < MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode ||
+		numberOfExpectedWorkers >= MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode &&
+			workersInStatus >= MinimumNumberOfWorkersForNonSchedulableMastersClusterInHaMode
+}

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -824,3 +824,390 @@ func createClusterFromHosts(hosts []*models.Host) Cluster {
 		},
 	}
 }
+
+var _ = Describe("HostsInStatus", func() {
+	It("should return zero counts for empty cluster", func() {
+		cluster := createClusterFromHosts([]*models.Host{})
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(0))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(0))
+	})
+
+	It("should count masters in specified status", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(2))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(0))
+	})
+
+	It("should count arbiters in specified status", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleArbiter, models.HostStatusKnown),
+			createHost(models.HostRoleArbiter, models.HostStatusInsufficient),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(2))
+		Expect(arbiters).To(Equal(1))
+		Expect(workers).To(Equal(0))
+	})
+
+	It("should count workers in specified status", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleWorker, models.HostStatusKnown),
+			createHost(models.HostRoleWorker, models.HostStatusKnown),
+			createHost(models.HostRoleWorker, models.HostStatusInsufficient),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(1))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(2))
+	})
+
+	It("should count hosts with multiple statuses", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusInstalling),
+			createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+			createHost(models.HostRoleWorker, models.HostStatusKnown),
+			createHost(models.HostRoleWorker, models.HostStatusInstalling),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown, models.HostStatusInstalling})
+
+		Expect(masters).To(Equal(2))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(2))
+	})
+
+	It("should handle bootstrap hosts as masters", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleBootstrap, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(2))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(0))
+	})
+
+	It("should use effective role for auto-assigned hosts", func() {
+		hostId1 := strfmt.UUID(uuid.New().String())
+		clusterId1 := strfmt.UUID(uuid.New().String())
+		hostId2 := strfmt.UUID(uuid.New().String())
+		clusterId2 := strfmt.UUID(uuid.New().String())
+		hostId3 := strfmt.UUID(uuid.New().String())
+		clusterId3 := strfmt.UUID(uuid.New().String())
+
+		hosts := []*models.Host{
+			{
+				ID:            &hostId1,
+				InfraEnvID:    strfmt.UUID(uuid.New().String()),
+				ClusterID:     &clusterId1,
+				Role:          models.HostRoleAutoAssign,
+				SuggestedRole: models.HostRoleMaster,
+				Status:        swag.String(models.HostStatusKnown),
+			},
+			{
+				ID:            &hostId2,
+				InfraEnvID:    strfmt.UUID(uuid.New().String()),
+				ClusterID:     &clusterId2,
+				Role:          models.HostRoleAutoAssign,
+				SuggestedRole: models.HostRoleWorker,
+				Status:        swag.String(models.HostStatusKnown),
+			},
+			{
+				ID:            &hostId3,
+				InfraEnvID:    strfmt.UUID(uuid.New().String()),
+				ClusterID:     &clusterId3,
+				Role:          models.HostRoleAutoAssign,
+				SuggestedRole: models.HostRoleArbiter,
+				Status:        swag.String(models.HostStatusKnown),
+			},
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(1))
+		Expect(arbiters).To(Equal(1))
+		Expect(workers).To(Equal(1))
+	})
+
+	It("should return zero when no hosts match status", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+			createHost(models.HostRoleWorker, models.HostStatusPendingForInput),
+		}
+		cluster := createClusterFromHosts(hosts)
+		masters, arbiters, workers := HostsInStatus(&cluster, []string{models.HostStatusKnown})
+
+		Expect(masters).To(Equal(0))
+		Expect(arbiters).To(Equal(0))
+		Expect(workers).To(Equal(0))
+	})
+})
+
+var _ = Describe("HasEnoughMastersAndWorkers", func() {
+	Context("single node", func() {
+		It("should return true with exactly 1 master and 0 workers", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 1
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false with 1 master and 1 worker", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 1
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false with 0 masters", func() {
+			cluster := createClusterFromHosts([]*models.Host{})
+			cluster.ControlPlaneCount = 1
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false with 2 masters", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 1
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("highly available", func() {
+		It("should return true with 3 masters and 0 workers", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return true with 3 masters and 1 worker", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return true with 3 masters and 2+ workers when all are in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false with 3 masters expected but only 2 in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when expecting 2+ workers but only 1 in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusInsufficient),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return true with 5 masters", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 5
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false with less than minimum masters", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 3
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("two node with arbiter", func() {
+		It("should return true with 2 masters, 1 arbiter", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleArbiter, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false with 2 masters but 0 arbiters in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleArbiter, models.HostStatusInsufficient),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false with only 1 master in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+				createHost(models.HostRoleArbiter, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return true with 2 masters, 1 arbiter, and workers", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleArbiter, models.HostStatusKnown),
+				createHost(models.HostRoleWorker, models.HostStatusKnown),
+			}
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Context("two nodes with fencing", func() {
+		It("should return true with 2 masters with fencing credentials", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+			}
+			hosts[0].FencingCredentials = "fencing_credentials"
+			hosts[1].FencingCredentials = "fencing_credentials"
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false with only 1 master in status", func() {
+			hosts := []*models.Host{
+				createHost(models.HostRoleMaster, models.HostStatusKnown),
+				createHost(models.HostRoleMaster, models.HostStatusInsufficient),
+			}
+			hosts[0].FencingCredentials = "fencing_credentials"
+			hosts[1].FencingCredentials = "fencing_credentials"
+			cluster := createClusterFromHosts(hosts)
+			cluster.ControlPlaneCount = 2
+
+			result := HasEnoughMastersAndWorkers(&cluster, []string{models.HostStatusKnown})
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	It("should count hosts in any of the specified statuses with multiple status values", func() {
+		hosts := []*models.Host{
+			createHost(models.HostRoleMaster, models.HostStatusKnown),
+			createHost(models.HostRoleMaster, models.HostStatusInstalling),
+			createHost(models.HostRoleMaster, models.HostStatusInstalled),
+		}
+		cluster := createClusterFromHosts(hosts)
+		cluster.ControlPlaneCount = 3
+
+		result := HasEnoughMastersAndWorkers(&cluster, []string{
+			models.HostStatusKnown,
+			models.HostStatusInstalling,
+			models.HostStatusInstalled,
+		})
+		Expect(result).To(BeTrue())
+	})
+})

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -48,6 +48,7 @@ const (
 	statusInfoHostReadyToBeBound                                          = "Host is ready to be bound to a cluster"
 	statusInfoBinding                                                     = "Host is waiting to be bound to the cluster"
 	statusRebootTimeout                                                   = "Host timed out when pulling the configuration files. Verify in the host console that the host boots from the OpenShift installation disk $INSTALLATION_DISK and has network access to the cluster API. The installation will resume after the host successfully boots and can access the cluster API"
+	statusInfoPendingUserActionTimeout                                    = "Host failed to boot from the installation disk within the expected time."
 	statusInfoUnbinding                                                   = "Host is waiting to be unbound from the cluster"
 	statusInfoRebootingDay2                                               = "Host has rebooted and no further updates will be posted. Please check console for progress and to possibly approve pending CSRs"
 	statusInfoRebootingForReclaim                                         = "Host is rebooting into the discovery image"

--- a/internal/host/config.go
+++ b/internal/host/config.go
@@ -17,13 +17,14 @@ type PrepareConfig struct {
 type Config struct {
 	PrepareConfig PrepareConfig
 	LogTimeoutConfig
-	EnableAutoAssign         bool                    `envconfig:"ENABLE_AUTO_ASSIGN" default:"true"`
-	ResetTimeout             time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
-	MonitorBatchSize         int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
-	DisabledHostvalidations  DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:""` // Which host validations to disable (should not run in preprocess)
-	BootstrapHostMAC         string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
-	MaxHostDisconnectionTime time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
-	EnableVirtualInterfaces  bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
+	EnableAutoAssign                   bool                    `envconfig:"ENABLE_AUTO_ASSIGN" default:"true"`
+	ResetTimeout                       time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
+	MonitorBatchSize                   int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
+	DisabledHostvalidations            DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:""` // Which host validations to disable (should not run in preprocess)
+	BootstrapHostMAC                   string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
+	MaxHostDisconnectionTime           time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
+	EnableVirtualInterfaces            bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
+	InstallingPendingUserActionTimeout time.Duration           `envconfig:"HOST_INSTALLING_PENDING_USER_ACTION_TIMEOUT" default:"60m"`
 	// Per-host monitor refresh timeout to bound time spent refreshing a single host during monitoring
 	MonitorPerHostTimeout time.Duration `envconfig:"HOST_MONITOR_PER_HOST_TIMEOUT" default:"2m"`
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -51,11 +51,12 @@ var (
 
 var _ = BeforeEach(func() {
 	defaultConfig = &Config{
-		ResetTimeout:             3 * time.Minute,
-		EnableAutoAssign:         true,
-		MonitorBatchSize:         100,
-		DisabledHostvalidations:  defaultDisabledHostValidations,
-		MaxHostDisconnectionTime: MaxHostDisconnectionTime,
+		ResetTimeout:                       3 * time.Minute,
+		EnableAutoAssign:                   true,
+		MonitorBatchSize:                   100,
+		DisabledHostvalidations:            defaultDisabledHostValidations,
+		MaxHostDisconnectionTime:           MaxHostDisconnectionTime,
+		InstallingPendingUserActionTimeout: 60 * time.Minute,
 	}
 	err := defaultConfig.Complete()
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -41,6 +41,21 @@ func (m *MockTransitionHandler) EXPECT() *MockTransitionHandlerMockRecorder {
 	return m.recorder
 }
 
+// ClusterWouldSucceedWithoutHost mocks base method.
+func (m *MockTransitionHandler) ClusterWouldSucceedWithoutHost(sw stateswitch.StateSwitch, arg1 stateswitch.TransitionArgs) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterWouldSucceedWithoutHost", sw, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClusterWouldSucceedWithoutHost indicates an expected call of ClusterWouldSucceedWithoutHost.
+func (mr *MockTransitionHandlerMockRecorder) ClusterWouldSucceedWithoutHost(sw, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterWouldSucceedWithoutHost", reflect.TypeOf((*MockTransitionHandler)(nil).ClusterWouldSucceedWithoutHost), sw, arg1)
+}
+
 // HasClusterError mocks base method.
 func (m *MockTransitionHandler) HasClusterError(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -71,6 +71,21 @@ func (mr *MockTransitionHandlerMockRecorder) HasInstallationInProgressTimedOut(s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstallationInProgressTimedOut", reflect.TypeOf((*MockTransitionHandler)(nil).HasInstallationInProgressTimedOut), sw, arg1)
 }
 
+// HasPendingUserActionTimedOut mocks base method.
+func (m *MockTransitionHandler) HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, arg1 stateswitch.TransitionArgs) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasPendingUserActionTimedOut", sw, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasPendingUserActionTimedOut indicates an expected call of HasPendingUserActionTimedOut.
+func (mr *MockTransitionHandlerMockRecorder) HasPendingUserActionTimedOut(sw, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPendingUserActionTimedOut", reflect.TypeOf((*MockTransitionHandler)(nil).HasPendingUserActionTimedOut), sw, arg1)
+}
+
 // HasStatusTimedOut mocks base method.
 func (m *MockTransitionHandler) HasStatusTimedOut(timeout time.Duration) stateswitch.Condition {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -933,6 +933,19 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		},
 	})
 
+	sm.AddTransitionRule(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRefresh,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstallingPendingUserAction)},
+		Condition:        th.HasPendingUserActionTimedOut,
+		DestinationState: stateswitch.State(models.HostStatusError),
+		PostTransition:   th.PostRefreshHost(statusInfoPendingUserActionTimeout),
+		Documentation: stateswitch.TransitionRuleDoc{
+			Name:        "Host pending user action timeout",
+			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state. This allows clusters to succeed if they have sufficient remaining hosts (e.g., workers can fail as long as minimum count is met).",
+		},
+	})
+
 	// Noop transitions for cluster error
 	for _, state := range []stateswitch.State{
 		stateswitch.State(models.HostStatusInstalling),

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -937,12 +937,15 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		TransitionType: TransitionTypeRefresh,
 		SourceStates: []stateswitch.State{
 			stateswitch.State(models.HostStatusInstallingPendingUserAction)},
-		Condition:        th.HasPendingUserActionTimedOut,
+		Condition: stateswitch.And(
+			th.HasPendingUserActionTimedOut,
+			th.ClusterWouldSucceedWithoutHost,
+		),
 		DestinationState: stateswitch.State(models.HostStatusError),
 		PostTransition:   th.PostRefreshHost(statusInfoPendingUserActionTimeout),
 		Documentation: stateswitch.TransitionRuleDoc{
-			Name:        "Host pending user action timeout",
-			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state. This allows clusters to succeed if they have sufficient remaining hosts (e.g., workers can fail as long as minimum count is met).",
+			Name:        "Host pending user action timeout with cluster viability check",
+			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state ONLY if the cluster can still succeed without this host. This prevents timing out hosts that are required for cluster success (e.g., masters in a 3-node cluster), giving users more time to fix boot order issues for critical hosts.",
 		},
 	})
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -38,6 +38,7 @@ type TransitionHandler interface {
 	HasClusterError(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	HasInstallationInProgressTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
+	ClusterWouldSucceedWithoutHost(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasStatusTimedOut(timeout time.Duration) stateswitch.Condition
 	HostNotResponsiveWhilePreparingInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
@@ -758,6 +759,29 @@ func (th *transitionHandler) HasPendingUserActionTimedOut(sw stateswitch.StateSw
 		return false, errors.New("HasPendingUserActionTimedOut incompatible type of StateSwitch")
 	}
 	return time.Since(time.Time(sHost.host.StatusUpdatedAt)) > th.config.InstallingPendingUserActionTimeout, nil
+}
+
+func (th *transitionHandler) ClusterWouldSucceedWithoutHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
+	sHost, ok := sw.(*stateHost)
+	if !ok {
+		return false, errors.New("ClusterWouldSucceedWithoutHost incompatible type of StateSwitch")
+	}
+	params, ok := args.(*TransitionArgsRefreshHost)
+	if !ok {
+		return false, errors.New("ClusterWouldSucceedWithoutHost invalid argument")
+	}
+
+	// Get the cluster with all hosts
+	if sHost.host.ClusterID == nil {
+		return false, errors.New("cluster ID must not be nil")
+	}
+	cluster, err := common.GetClusterFromDBWithHosts(params.db, *sHost.host.ClusterID)
+	if err != nil {
+		th.log.WithError(err).Errorf("failed to get cluster %s", sHost.host.ClusterID)
+		return false, err
+	}
+
+	return common.HasEnoughMastersAndWorkers(cluster, []string{models.HostStatusInstalled}), nil
 }
 
 func (th *transitionHandler) PostHostPreparationTimeout() stateswitch.PostTransition {

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -37,6 +37,7 @@ type transitionHandler struct {
 type TransitionHandler interface {
 	HasClusterError(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	HasInstallationInProgressTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
+	HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasStatusTimedOut(timeout time.Duration) stateswitch.Condition
 	HostNotResponsiveWhilePreparingInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
@@ -749,6 +750,14 @@ func (th *transitionHandler) HasInstallationInProgressTimedOut(sw stateswitch.St
 	}
 
 	return time.Since(time.Time(sHost.host.Progress.StageUpdatedAt)) > maxDuration, nil
+}
+
+func (th *transitionHandler) HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error) {
+	sHost, ok := sw.(*stateHost)
+	if !ok {
+		return false, errors.New("HasPendingUserActionTimedOut incompatible type of StateSwitch")
+	}
+	return time.Since(time.Time(sHost.host.StatusUpdatedAt)) > th.config.InstallingPendingUserActionTimeout, nil
 }
 
 func (th *transitionHandler) PostHostPreparationTimeout() stateswitch.PostTransition {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2384,6 +2384,47 @@ var _ = Describe("Refresh Host", func() {
 
 	})
 
+	Context("host installing-pending-user-action timeout", func() {
+		BeforeEach(func() {
+			pr.EXPECT().IsHostSupported(commontesting.EqPlatformType(models.PlatformTypeVsphere), gomock.Any()).Return(false, nil).AnyTimes()
+			mockDefaultClusterHostRequirements(mockHwValidator)
+
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusInstallingPendingUserAction)
+			cluster = hostutil.GenerateTestCluster(clusterId)
+			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
+		})
+
+		It("times out when host is in state for more than the timeout value", func() {
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
+				eventstest.WithHostIdMatcher(hostId.String()),
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
+				eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusError))))
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusError))
+			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(statusInfoPendingUserActionTimeout))
+		})
+
+		It("remains when host is in state for less than the timeout value", func() {
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-30 * time.Minute))
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+		})
+	})
+
 	Context("Installation disk error handling in status info", func() {
 		BeforeEach(func() {
 			pr.EXPECT().IsHostSupported(commontesting.EqPlatformType(models.PlatformTypeVsphere), gomock.Any()).Return(false, nil).AnyTimes()

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2394,7 +2394,14 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 		})
 
-		It("times out when host is in state for more than the timeout value", func() {
+		It("times out when host is in state for more than the timeout value and is not required for success", func() {
+			// Create 3 master hosts in installed status so the cluster can succeed without the timed-out worker
+			for range 3 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
 			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
@@ -2411,6 +2418,26 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
 			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusError))
 			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(statusInfoPendingUserActionTimeout))
+		})
+
+		It("remains when host is required for success", func() {
+			// Create 2 master hosts in installed status
+			for range 2 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
+			// third master in pending-user-action should remain there even after 90 minutes
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			host.Role = models.HostRoleMaster
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
 		})
 
 		It("remains when host is in state for less than the timeout value", func() {


### PR DESCRIPTION
Hosts in `installing-pending-user-action` were stalling entire clusters even if the cluster would install fine without them. This commit adds a timeout for hosts in this state so that the cluster can succeed when the required minimum number of nodes have already installed.

This is especially important in cases where very large clusters are being installed (~100 nodes). In these kinds of cases, one or two worker nodes shouldn't force the user to reinstall the entire thing if they don't want to monitor the multi-hour install process for hosts failing to reboot.

Assisted-By: Claude Code

## List all the issues related to this PR

Resolves https://redhat.atlassian.net/browse/MGMT-23971

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested this manually by creating a cluster with 3 CP nodes and 3 workers. I didn't allow one of the workers to reboot after installation. I set the timeout env var down to 10 minutes and watched as the worker moved to error and the cluster successfully installed without it.

Additionally I tested a compact (only 3 CP nodes) cluster and saw that the timeout did _not_ trigger when one of the control plane nodes was in `installing-pending-user-action` for longer than the timeout.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installations awaiting user action now time out after 60 minutes by default (configurable); stalled hosts show a clear timeout status and may be marked error.
  * Hosts are only marked failed on timeout if the cluster can still succeed without them.

* **Bug Fixes**
  * Improved master/arbiter/worker counting and validation for more accurate cluster completion decisions.

* **Tests**
  * Added tests covering timeout behavior and host/cluster counting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->