### PR TITLE
ACM-33186: Revert Renovate configuration for Hive updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,29 +10,11 @@
     "enabledManagers": [
         "custom.regex",
         "tekton",
-        "gomod",
         "rpm-lockfile"
     ],
     "tekton": {
         "managerFilePatterns": [
             "/^.tekton/*/"
-        ]
-    },
-    "gomod": {
-        "postUpdateOptions": [
-            "gomodUpdateImportPaths",
-            "gomodTidy"
-        ],
-        "packageRules": [
-            {
-                "matchManagers": [
-                    "gomod"
-                ],
-                "matchDepTypes": [
-                    "indirect"
-                ],
-                "enabled": false
-            }
         ]
     },
     "customManagers": [
@@ -217,26 +199,6 @@
             "matchManagers": [
                 "rpm-lockfile"
             ]
-        },
-        {
-            "matchManagers": [
-                "gomod"
-            ],
-            "enabled": false
-        },
-        {
-            "matchManagers": [
-                "gomod"
-            ],
-            "matchPackageNames": [
-                "github.com/openshift/hive/apis"
-            ],
-            "groupName": "Hive API Synchronization",
-            "addLabels": [
-                "hive-api",
-                "api-sync"
-            ],
-            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
Revert the Renovate/MintMaker configuration that enables hive/apis digest tracking.
MintMaker generates bare commit hashes instead of proper Go pseudo-versions,
which breaks go.mod.

Reverts changes from [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to disable automated Go module dependency processing and remove associated update rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->