### PR TITLE
ACM-33194: Fix BMACReconciler panic on nil ProviderSpec image field

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1457,7 +1457,7 @@ func (r *BMACReconciler) getChecksumAndURL(ctx context.Context, spokeClient clie
 
 	providerSpec := machineList.Items[0].Spec.ProviderSpec.Value
 	if providerSpec == nil {
-		return checksum, url, errors.New("master machine has nil ProviderSpec"), true
+		return checksum, url, errors.New("master machine has nil ProviderSpec"), false
 	}
 
 	var providerSpecValueObj map[string]interface{}
@@ -1467,20 +1467,20 @@ func (r *BMACReconciler) getChecksumAndURL(ctx context.Context, spokeClient clie
 
 	imageRaw, ok := providerSpecValueObj["image"]
 	if !ok || imageRaw == nil {
-		return checksum, url, errors.New("master machine ProviderSpec missing 'image' field"), true
+		return checksum, url, errors.New("master machine ProviderSpec missing 'image' field"), false
 	}
 	image, ok := imageRaw.(map[string]interface{})
 	if !ok {
-		return checksum, url, errors.New("master machine ProviderSpec 'image' field has unexpected type"), true
+		return checksum, url, errors.New("master machine ProviderSpec 'image' field has unexpected type"), false
 	}
 
 	checksum, _ = image["checksum"].(string)
 	url, _ = image["url"].(string)
 	if checksum == "" {
-		return "", "", errors.New("master machine ProviderSpec 'image' missing checksum"), true
+		return "", "", errors.New("master machine ProviderSpec 'image' missing checksum"), false
 	}
 	if url == "" {
-		return "", "", errors.New("master machine ProviderSpec 'image' missing url"), true
+		return "", "", errors.New("master machine ProviderSpec 'image' missing url"), false
 	}
 
 	return checksum, url, nil, false

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1454,17 +1454,36 @@ func (r *BMACReconciler) getChecksumAndURL(ctx context.Context, spokeClient clie
 	if len(machineList.Items) == 0 {
 		return checksum, url, errors.New("There are no machines with master label"), true
 	}
-	providerSpecValue := string(machineList.Items[0].Spec.ProviderSpec.Value.Raw)
+
+	providerSpec := machineList.Items[0].Spec.ProviderSpec.Value
+	if providerSpec == nil {
+		return checksum, url, errors.New("master machine has nil ProviderSpec"), true
+	}
 
 	var providerSpecValueObj map[string]interface{}
-	err = json.Unmarshal([]byte(providerSpecValue), &providerSpecValueObj)
-	if err != nil {
+	if err = json.Unmarshal(providerSpec.Raw, &providerSpecValueObj); err != nil {
 		return checksum, url, err, false
 	}
-	image := providerSpecValueObj["image"].(map[string]interface{})
-	checksum = fmt.Sprint(image["checksum"])
-	url = fmt.Sprint(image["url"])
-	return checksum, url, err, false
+
+	imageRaw, ok := providerSpecValueObj["image"]
+	if !ok || imageRaw == nil {
+		return checksum, url, errors.New("master machine ProviderSpec missing 'image' field"), true
+	}
+	image, ok := imageRaw.(map[string]interface{})
+	if !ok {
+		return checksum, url, errors.New("master machine ProviderSpec 'image' field has unexpected type"), true
+	}
+
+	checksum, _ = image["checksum"].(string)
+	url, _ = image["url"].(string)
+	if checksum == "" {
+		return "", "", errors.New("master machine ProviderSpec 'image' missing checksum"), true
+	}
+	if url == "" {
+		return "", "", errors.New("master machine ProviderSpec 'image' missing url"), true
+	}
+
+	return checksum, url, nil, false
 }
 
 func (r *BMACReconciler) ensureSpokeMachine(ctx context.Context, log logrus.FieldLogger, spokeClient client.Client, bmh *bmh_v1alpha1.BareMetalHost, clusterDeployment *hivev1.ClusterDeployment, machineName types.NamespacedName, checksum, URL, role string) (*machinev1beta1.Machine, error) {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -3799,19 +3799,6 @@ var _ = Describe("getChecksumAndURL", func() {
 	})
 })
 
-var _ = Describe("isEmptyPatch", func() {
-	DescribeTable("correctly identifies empty patches",
-		func(data string, expected bool) {
-			Expect(isEmptyPatch([]byte(data))).To(Equal(expected))
-		},
-		Entry("empty JSON object", `{}`, true),
-		Entry("metadata with only resourceVersion", `{"metadata":{"resourceVersion":"12345"}}`, true),
-		Entry("metadata with empty object", `{"metadata":{}}`, true),
-		Entry("metadata with resourceVersion and other fields", `{"metadata":{"resourceVersion":"12345","annotations":{"foo":"bar"}}}`, false),
-		Entry("non-metadata field", `{"spec":{"online":true}}`, false),
-		Entry("invalid JSON", `not-json`, false),
-	)
-})
 func newAgentWithClusterReference(name string, namespace string, ipv4address string, ipv6address string, macaddress string, clusterName string, agentBMHLabel string, creationTime time.Time) *v1beta1.Agent {
 	agent := newAgent(name, namespace, v1beta1.AgentSpec{})
 	agent.Status.Inventory = v1beta1.HostInventory{

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -3708,6 +3708,110 @@ var _ = Describe("handleBMHFinalizer", func() {
 	})
 })
 
+var _ = Describe("getChecksumAndURL", func() {
+	var (
+		bmhr        *BMACReconciler
+		spokeClient client.Client
+		ctx         = context.Background()
+	)
+
+	BeforeEach(func() {
+		schemes := GetKubeClientSchemes()
+		spokeClient = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
+		bmhr = &BMACReconciler{}
+	})
+
+	createMasterMachine := func(rawSpec []byte) {
+		m := &machinev1beta1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "master-0",
+				Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
+				Labels:    map[string]string{MACHINE_TYPE: string(models.HostRoleMaster)},
+			},
+		}
+		if rawSpec != nil {
+			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawSpec}
+		}
+		Expect(spokeClient.Create(ctx, m)).To(Succeed())
+	}
+
+	It("returns error when no master machines exist", func() {
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(stop).To(BeTrue())
+	})
+
+	It("returns error when ProviderSpec.Value is nil", func() {
+		createMasterMachine(nil)
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("nil ProviderSpec"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns error when image field is null", func() {
+		createMasterMachine([]byte(`{"image": null}`))
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing 'image' field"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns error when image field is absent", func() {
+		createMasterMachine([]byte(`{}`))
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing 'image' field"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns error when image field is not a map", func() {
+		createMasterMachine([]byte(`{"image": "not-a-map"}`))
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unexpected type"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns error when checksum is missing", func() {
+		createMasterMachine([]byte(`{"image": {"url": "http://example.com/image"}}`))
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing checksum"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns error when url is missing", func() {
+		createMasterMachine([]byte(`{"image": {"checksum": "abc123"}}`))
+		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing url"))
+		Expect(stop).To(BeFalse())
+	})
+
+	It("returns checksum and url when both are present", func() {
+		createMasterMachine([]byte(`{"image": {"checksum": "abc123", "url": "http://example.com/image"}}`))
+		checksum, url, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stop).To(BeFalse())
+		Expect(checksum).To(Equal("abc123"))
+		Expect(url).To(Equal("http://example.com/image"))
+	})
+})
+
+var _ = Describe("isEmptyPatch", func() {
+	DescribeTable("correctly identifies empty patches",
+		func(data string, expected bool) {
+			Expect(isEmptyPatch([]byte(data))).To(Equal(expected))
+		},
+		Entry("empty JSON object", `{}`, true),
+		Entry("metadata with only resourceVersion", `{"metadata":{"resourceVersion":"12345"}}`, true),
+		Entry("metadata with empty object", `{"metadata":{}}`, true),
+		Entry("metadata with resourceVersion and other fields", `{"metadata":{"resourceVersion":"12345","annotations":{"foo":"bar"}}}`, false),
+		Entry("non-metadata field", `{"spec":{"online":true}}`, false),
+		Entry("invalid JSON", `not-json`, false),
+	)
+})
 func newAgentWithClusterReference(name string, namespace string, ipv4address string, ipv6address string, macaddress string, clusterName string, agentBMHLabel string, creationTime time.Time) *v1beta1.Agent {
 	agent := newAgent(name, namespace, v1beta1.AgentSpec{})
 	agent.Status.Inventory = v1beta1.HostInventory{


### PR DESCRIPTION
## Summary
- Add nil checks in `getChecksumAndURL` to prevent controller panic when ProviderSpec or image field is nil/malformed
- Use safe type assertions instead of bare assertions that can panic
- Errors are retryable (stopReconcileLoop=false) so the controller can recover from transient states
- Add unit tests covering all nil/malformed ProviderSpec scenarios

Backport of https://github.com/openshift/assisted-service/pull/10164 to release-ocm-2.15