### PR TITLE
NO-ISSUE: Update github.com/openshift/hive/apis digest to 6c66e20

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.5
 require (
 	github.com/openshift/assisted-service/models v0.0.0
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
-	github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba
+	github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
 	sigs.k8s.io/yaml v1.6.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -245,8 +245,8 @@ github.com/openshift/api v0.0.0-20251120220512-cb382c9eaf42 h1:Mo2FlDdoCZ+BE2W4C
 github.com/openshift/api v0.0.0-20251120220512-cb382c9eaf42/go.mod h1:d5uzF0YN2nQQFA0jIEWzzOZ+edmo6wzlGLvx5Fhz4uY=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba h1:GXPfNjWwWpi65XNnsDKqgVKiQ4EM2A3uuHgXNgtSK/4=
-github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 h1:R8iA8JQ4k+2dNgseiFoLe3UkokexpUQTNHHb05UIuR4=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/openshift/cluster-baremetal-operator v0.0.0-20240207191432-82df158cd2e9
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
-	github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba
+	github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 	github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b
 	github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b2
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f/go.mod h1:/CLsleDcQ6AFTGKJe9VL3Y4rB9DqX3fQwQv47q2/ZJc=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d h1:iQfTKBmMcwFTxxVWV7U/C6GqgIIWTKD8l5HXslvn53s=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba h1:GXPfNjWwWpi65XNnsDKqgVKiQ4EM2A3uuHgXNgtSK/4=
-github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 h1:R8iA8JQ4k+2dNgseiFoLe3UkokexpUQTNHHb05UIuR4=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
 github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b h1:SDdbzE3oW2qs7AJj4DT5gk8HDkZYR8DTT1ZfyBhECZ8=
 github.com/openshift/image-customization-controller v0.0.0-20240307203510-394809633b6b/go.mod h1:G9yHOogitMOA0R5UWFmFup00E6nik8Sns/tCYYBU7jE=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -818,7 +818,7 @@ github.com/openshift/generic-admission-server/pkg/cmd
 github.com/openshift/generic-admission-server/pkg/cmd/server
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview/generated
-# github.com/openshift/hive/apis v0.0.0-20260415205034-aa1db747a6ba
+# github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 ## explicit; go 1.24.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
Update github.com/openshift/hive/apis with proper Go pseudo-version.

See [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.