### PR TITLE
NO-ISSUE: Remove unused RegisterAddHostsOCPCluster functions

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -79,8 +79,6 @@ var ClusterOwnerFileNames = []string{
 type RegistrationAPI interface {
 	// Register a new cluster (handles all cluster types based on Kind field)
 	RegisterCluster(ctx context.Context, c *common.Cluster) error
-	// Register a new add-host-ocp cluster
-	RegisterAddHostsOCPCluster(c *common.Cluster, db *gorm.DB) error
 	//deregister cluster
 	DeregisterCluster(ctx context.Context, c *common.Cluster) error
 }
@@ -267,10 +265,6 @@ func (m *Manager) RegisterCluster(ctx context.Context, c *common.Cluster) error 
 		eventgen.SendClusterRegistrationSucceededEvent(ctx, m.eventsHandler, *c.ID, models.ClusterKindAddHostsCluster)
 	}
 	return nil
-}
-
-func (m *Manager) RegisterAddHostsOCPCluster(c *common.Cluster, db *gorm.DB) error {
-	return m.registrationAPI.RegisterAddHostsOCPCluster(c, db)
 }
 
 func (m *Manager) DeregisterCluster(ctx context.Context, c *common.Cluster) error {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -60,20 +60,6 @@ func (mr *MockRegistrationAPIMockRecorder) DeregisterCluster(ctx, c any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterCluster", reflect.TypeOf((*MockRegistrationAPI)(nil).DeregisterCluster), ctx, c)
 }
 
-// RegisterAddHostsOCPCluster mocks base method.
-func (m *MockRegistrationAPI) RegisterAddHostsOCPCluster(c *common.Cluster, db *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterAddHostsOCPCluster", c, db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterAddHostsOCPCluster indicates an expected call of RegisterAddHostsOCPCluster.
-func (mr *MockRegistrationAPIMockRecorder) RegisterAddHostsOCPCluster(c, db any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAddHostsOCPCluster", reflect.TypeOf((*MockRegistrationAPI)(nil).RegisterAddHostsOCPCluster), c, db)
-}
-
 // RegisterCluster mocks base method.
 func (m *MockRegistrationAPI) RegisterCluster(ctx context.Context, c *common.Cluster) error {
 	m.ctrl.T.Helper()
@@ -539,20 +525,6 @@ func (m *MockAPI) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm
 func (mr *MockAPIMockRecorder) RefreshStatus(ctx, c, db any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshStatus", reflect.TypeOf((*MockAPI)(nil).RefreshStatus), ctx, c, db)
-}
-
-// RegisterAddHostsOCPCluster mocks base method.
-func (m *MockAPI) RegisterAddHostsOCPCluster(c *common.Cluster, db *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterAddHostsOCPCluster", c, db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterAddHostsOCPCluster indicates an expected call of RegisterAddHostsOCPCluster.
-func (mr *MockAPIMockRecorder) RegisterAddHostsOCPCluster(c, db any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAddHostsOCPCluster", reflect.TypeOf((*MockAPI)(nil).RegisterAddHostsOCPCluster), c, db)
 }
 
 // RegisterCluster mocks base method.

--- a/internal/cluster/registrar.go
+++ b/internal/cluster/registrar.go
@@ -83,17 +83,6 @@ func (r *registrar) registerCluster(cluster *common.Cluster) error {
 	})
 }
 
-func (r *registrar) RegisterAddHostsOCPCluster(c *common.Cluster, db *gorm.DB) error {
-	c.Status = swag.String(models.ClusterStatusAddingHosts)
-	c.StatusInfo = swag.String(StatusInfoReady)
-	err := db.Create(c).Error
-	if err != nil {
-		r.log.WithError(err).Errorf("Failed to create OCP cluster in DB")
-		return err
-	}
-	return nil
-}
-
 func (r *registrar) DeregisterCluster(ctx context.Context, cluster *common.Cluster) error {
 	var err error
 


### PR DESCRIPTION
Last caller was removed in d7af0b3992665729ba4e7421f5a4b177f5ecb419

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal cluster registration implementation, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->