### PR TITLE
MGMT-24236: Exclude post-installation hosts from pending-user-action timeout

### DIFF
--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -130,6 +130,21 @@ func (mr *MockTransitionHandlerMockRecorder) HostNotResponsiveWhilePreparingInst
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostNotResponsiveWhilePreparingInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).HostNotResponsiveWhilePreparingInstallation), sw, args)
 }
 
+// IsClusterPostInstallation mocks base method.
+func (m *MockTransitionHandler) IsClusterPostInstallation(sw stateswitch.StateSwitch, arg1 stateswitch.TransitionArgs) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsClusterPostInstallation", sw, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsClusterPostInstallation indicates an expected call of IsClusterPostInstallation.
+func (mr *MockTransitionHandlerMockRecorder) IsClusterPostInstallation(sw, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterPostInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).IsClusterPostInstallation), sw, arg1)
+}
+
 // IsDay2Host mocks base method.
 func (m *MockTransitionHandler) IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -940,12 +940,13 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		Condition: stateswitch.And(
 			th.HasPendingUserActionTimedOut,
 			th.ClusterWouldSucceedWithoutHost,
+			stateswitch.Not(th.IsClusterPostInstallation),
 		),
 		DestinationState: stateswitch.State(models.HostStatusError),
 		PostTransition:   th.PostRefreshHost(statusInfoPendingUserActionTimeout),
 		Documentation: stateswitch.TransitionRuleDoc{
-			Name:        "Host pending user action timeout with cluster viability check",
-			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state ONLY if the cluster can still succeed without this host. This prevents timing out hosts that are required for cluster success (e.g., masters in a 3-node cluster), giving users more time to fix boot order issues for critical hosts.",
+			Name:        "Host pending user action timeout with cluster viability check (day1 only)",
+			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state ONLY if the cluster can still succeed without this host AND the cluster is still in initial installation (not post-installation). This prevents timing out hosts that are required for cluster success (e.g., masters in a 3-node cluster) and prevents timing out hosts being added to already-installed clusters where users explicitly want those specific hosts to join.",
 		},
 	})
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -39,6 +39,7 @@ type TransitionHandler interface {
 	HasInstallationInProgressTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	ClusterWouldSucceedWithoutHost(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
+	IsClusterPostInstallation(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasStatusTimedOut(timeout time.Duration) stateswitch.Condition
 	HostNotResponsiveWhilePreparingInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
@@ -782,6 +783,30 @@ func (th *transitionHandler) ClusterWouldSucceedWithoutHost(sw stateswitch.State
 	}
 
 	return common.HasEnoughMastersAndWorkers(cluster, []string{models.HostStatusInstalled}), nil
+}
+
+func (th *transitionHandler) IsClusterPostInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
+	sHost, ok := sw.(*stateHost)
+	if !ok {
+		return false, errors.New("IsClusterPostInstallation incompatible type of StateSwitch")
+	}
+	params, ok := args.(*TransitionArgsRefreshHost)
+	if !ok {
+		return false, errors.New("IsClusterPostInstallation invalid argument")
+	}
+
+	// Get the cluster status
+	if sHost.host.ClusterID == nil {
+		return false, errors.New("cluster ID must not be nil")
+	}
+	var cluster common.Cluster
+	err := params.db.Select("status").Take(&cluster, "id = ?", sHost.host.ClusterID.String()).Error
+	if err != nil {
+		return false, err
+	}
+
+	status := swag.StringValue(cluster.Status)
+	return status == models.ClusterStatusInstalled || status == models.ClusterStatusAddingHosts, nil
 }
 
 func (th *transitionHandler) PostHostPreparationTimeout() stateswitch.PostTransition {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2450,6 +2450,56 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
 			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
 		})
+
+		It("remains when cluster is already installed (post-installation host addition)", func() {
+			// Create 3 master hosts in installed status so cluster is viable
+			for range 3 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
+			// Set cluster status to installed (post-installation state)
+			Expect(db.Model(&cluster).Update("status", models.ClusterStatusInstalled).Error).ShouldNot(HaveOccurred())
+
+			// Host has been stuck for > timeout but should NOT timeout because cluster is post-installation
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			host.Role = models.HostRoleWorker
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+		})
+
+		It("remains when cluster is adding hosts (imported cluster)", func() {
+			// Create 3 master hosts in installed status so cluster is viable
+			for range 3 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
+			// Set cluster status to adding-hosts (imported cluster state)
+			Expect(db.Model(&cluster).Updates(map[string]interface{}{
+				"status": models.ClusterStatusAddingHosts,
+				"kind":   models.ClusterKindAddHostsCluster,
+			}).Error).ShouldNot(HaveOccurred())
+
+			// Host has been stuck for > timeout but should NOT timeout because cluster is post-installation
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			host.Role = models.HostRoleWorker
+			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+		})
 	})
 
 	Context("Installation disk error handling in status info", func() {


### PR DESCRIPTION
Hosts being added to already-installed clusters (either after initial installation or to imported clusters) should not timeout when stuck in installing-pending-user-action state. These hosts are intentionally being added by users who expect them to join, unlike day1 installation where some hosts can be sacrificed for cluster success.

Before this change:
- Day1 hosts: would timeout after 60min if cluster could succeed without them (working as intended)
- Hosts added to installed clusters: would also timeout (incorrect - users explicitly want these specific hosts)

After this change:
- Added IsClusterPostInstallation() check to identify clusters in 'installed' or 'adding-hosts' status
- Timeout transition now requires cluster to be in initial installation (not post-installation)
- Covers both scenarios:
  1. Day1 cluster that completed, then a failed host re-registers
  2. Imported cluster (day2) with hosts being added

The fix checks cluster status rather than host kind because:
- Hosts added to installed day1 clusters have Kind="Host" (not day2 kind)
- Only hosts added to imported clusters get Kind="AddToExistingClusterHost"
- Cluster status ('installed'/'adding-hosts' vs 'installing') correctly identifies whether the cluster is operational regardless of cluster kind

Resolves https://redhat.atlassian.net/browse/MGMT-24236

Caused by https://github.com/openshift/assisted-service/pull/10202

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

1. Created a 3-node compact cluster
2. Added a worker node and prevented it from rebooting correctly
3. Waited past the timeout
4. Observed the host remain in installing-pending-user-action
5. Fixed boot order
6. Observed host finish installation

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed host status handling to prevent incorrect error states when hosts are added to already-installed clusters during expansion operations.

* **Tests**
  * Added tests verifying correct behavior for hosts awaiting user action in post-installation cluster scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->