### PR TITLE
[release-ocm-2.17] MGMT-23755: Validate and trim MCS certificate data for ignition override

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -34,6 +34,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
+	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/common/ignition"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
@@ -1599,7 +1600,7 @@ func (r *BMACReconciler) createIgnitionWithMCSCert(ctx context.Context, spokeCli
 			Name:      src.name,
 		}
 		if err = spokeClient.Get(ctx, key, configMap); err == nil {
-			certData = configMap.Data[src.key]
+			certData = strings.TrimSpace(configMap.Data[src.key])
 			break
 		}
 		// Only try the next source if the configmap doesn't exist.
@@ -1612,7 +1613,10 @@ func (r *BMACReconciler) createIgnitionWithMCSCert(ctx context.Context, spokeCli
 		return encodedMCSCrt, ignitionWithMCSCert, err
 	}
 	if len(certData) == 0 {
-		return encodedMCSCrt, ignitionWithMCSCert, fmt.Errorf("Configmap %s/%s does not contain CA certificate data", configMap.Namespace, configMap.Name)
+		return encodedMCSCrt, ignitionWithMCSCert, fmt.Errorf("ConfigMap %s/%s does not contain CA certificate data", configMap.Namespace, configMap.Name)
+	}
+	if err = validations.ValidatePEMCertificateBundle(certData); err != nil {
+		return encodedMCSCrt, ignitionWithMCSCert, fmt.Errorf("ConfigMap %s/%s contains invalid CA certificate data: %w", configMap.Namespace, configMap.Name, err)
 	}
 	encodedMCSCrt = base64.StdEncoding.EncodeToString([]byte(certData))
 	ignitionWithMCSCert, err = r.formatMCSCertificateIgnition(encodedMCSCrt)

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -42,7 +42,30 @@ import (
 )
 
 var BASIC_KUBECONFIG = `test`
-var BASIC_CERT = `test`
+
+var TEST_CA_CERT = `-----BEGIN CERTIFICATE-----
+MIIB+jCCAWOgAwIBAgIUHYXgAzuMB1SPO/O2h3zc9jdzXlAwDQYJKoZIhvcNAQEL
+BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNjA0MjgxOTIwMTdaFw0zNjA0MjUxOTIw
+MTdaMA8xDTALBgNVBAMMBHRlc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
+AK9FjzHGW5YZ9bXlVztSZ3hwYmwgSJ+urFfxuxQXm5NxPArYTy0mtEbaVbQmWTGs
+lXhPswGQjVQp2ZIfglN8G2nI4HydJB/+bkyYGCe7uUyaVm3ABASvkAfyEdjMrrGl
+CpScyvga3sMZoMeIHYqX/xWnhOHkL5WxTuffqrMFwefPAgMBAAGjUzBRMB0GA1Ud
+DgQWBBRiuYDtIHWKyqm+ZReN8tBHC/JumzAfBgNVHSMEGDAWgBRiuYDtIHWKyqm+
+ZReN8tBHC/JumzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4GBAHUo
+tC8kB7HiXFUnpKxYmAsPs8ogTJxJR0CqDAukihAcBFcdK9w3J1x5KRY1LXQq6PCw
+RrLG4Jd2y9q40rXRUMaLKo9zZPWBSNtK8203EARzTpGtTe4ePN4ZPzMaCLLSE/v5
+P/lWAhXmWgP6xArUj0X22q1QzH4n0BJ6BX1weGRT
+-----END CERTIFICATE-----`
+
+var TEST_CA_CERT_2 = `-----BEGIN CERTIFICATE-----
+MIIBSDCB76ADAgECAgEBMAoGCCqGSM49BAMCMBQxEjAQBgNVBAMTCXRlc3QtY2Et
+MjAeFw0yNjA0MjgxOTI0MjVaFw0zNjA0MjUxOTI0MjVaMBQxEjAQBgNVBAMTCXRl
+c3QtY2EtMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJ4JUfGt4Z+/RMLTBj+7
+8vjSpIARRNRoKnFSYxFT4QDAzPBuFiI4hS99OOc2wuOW/1HD4jD4VVz5TZdfkSW2
+rbejMjAwMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFBUX/GK82/Lfgb4aE2rr
+BKYRGM3LMAoGCCqGSM49BAMCA0gAMEUCIEng94ZWndeZxx8XvpXkKbYAsv56NKbi
+wR4QNmTniFNDAiEA6bV/XiJ9jEiHZyxO5qC9KhM80qK0EY480XUhoaLVJ+U=
+-----END CERTIFICATE-----`
 
 var _ = Describe("bmac reconcile", func() {
 	var (
@@ -1550,7 +1573,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-machine-config-operator",
 					},
 					Data: map[string]string{
-						"ca-bundle.crt": BASIC_CERT,
+						"ca-bundle.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -1572,7 +1595,7 @@ var _ = Describe("bmac reconcile", func() {
 
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).NotTo(Equal(""))
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring("dGVzdA=="))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))))
 
 				By("Checking the spoke BMH exists and is correct")
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, host_day2.Name)
@@ -1610,7 +1633,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-machine-config-operator",
 					},
 					Data: map[string]string{
-						"ca-bundle.crt": BASIC_CERT,
+						"ca-bundle.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -1643,7 +1666,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).NotTo(Equal(""))
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring("dGVzdA=="))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))))
 
 				By("Checking the spoke BMH exists and is correct")
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, host_day2.Name)
@@ -1746,7 +1769,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-machine-config-operator",
 					},
 					Data: map[string]string{
-						"ca-bundle.crt": BASIC_CERT,
+						"ca-bundle.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -1765,7 +1788,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations).NotTo(HaveKey(BMH_SPOKE_CREATED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).NotTo(Equal(""))
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring("dGVzdA=="))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))))
 
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, host.Name)
 
@@ -1786,7 +1809,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-machine-config-operator",
 					},
 					Data: map[string]string{
-						"ca-bundle.crt": BASIC_CERT,
+						"ca-bundle.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -1808,7 +1831,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).NotTo(Equal(""))
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring("dGVzdA=="))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))))
 
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, host.Name)
 
@@ -1903,7 +1926,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-machine-config-operator",
 					},
 					Data: map[string]string{
-						"ca-bundle.crt": BASIC_CERT,
+						"ca-bundle.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -1933,8 +1956,8 @@ var _ = Describe("bmac reconcile", func() {
 			})
 
 			It("should prefer machine-config-server-ca over kube-system/root-ca", func() {
-				mcsCert := "mcs-ca-cert"
-				kubeCert := "kube-root-cert"
+				mcsCert := TEST_CA_CERT
+				kubeCert := TEST_CA_CERT_2
 
 				Expect(bmhr.spokeClient.Create(ctx, &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1975,7 +1998,7 @@ var _ = Describe("bmac reconcile", func() {
 						Name:      "root-ca",
 						Namespace: "kube-system",
 					},
-					Data: map[string]string{"ca.crt": BASIC_CERT},
+					Data: map[string]string{"ca.crt": TEST_CA_CERT},
 				})).ShouldNot(HaveOccurred())
 
 				for range [3]int{} {
@@ -1988,7 +2011,7 @@ var _ = Describe("bmac reconcile", func() {
 				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
-				encodedCert := base64.StdEncoding.EncodeToString([]byte(BASIC_CERT))
+				encodedCert := base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(encodedCert))
 			})
 
@@ -2003,7 +2026,7 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-config",
 					},
 					Data: map[string]string{
-						"ca.crt": BASIC_CERT,
+						"ca.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
@@ -2023,13 +2046,82 @@ var _ = Describe("bmac reconcile", func() {
 						Namespace: "openshift-config",
 					},
 					Data: map[string]string{
-						"ca.crt": BASIC_CERT,
+						"ca.crt": TEST_CA_CERT,
 					},
 				}
 				Expect(bmhr.spokeClient.Create(ctx, configMap)).ShouldNot(HaveOccurred())
 				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
 				Expect(err).To(BeNil())
 				Expect(result).To(Equal(ctrl.Result{}))
+			})
+
+			It("should trim whitespace from certificate data", func() {
+				certWithWhitespace := "  \n\t" + TEST_CA_CERT + "\n  \t\n"
+				Expect(bmhr.spokeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-config-server-ca",
+						Namespace: "openshift-machine-config-operator",
+					},
+					Data: map[string]string{"ca-bundle.crt": certWithWhitespace},
+				})).ShouldNot(HaveOccurred())
+
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
+
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
+
+				overrides := updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]
+				encodedTrimmed := base64.StdEncoding.EncodeToString([]byte(TEST_CA_CERT))
+				encodedUntrimmed := base64.StdEncoding.EncodeToString([]byte(certWithWhitespace))
+				Expect(overrides).To(ContainSubstring(encodedTrimmed))
+				Expect(overrides).NotTo(ContainSubstring(encodedUntrimmed))
+			})
+
+			It("should reject invalid PEM certificate data", func() {
+				Expect(bmhr.spokeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-config-server-ca",
+						Namespace: "openshift-machine-config-operator",
+					},
+					Data: map[string]string{"ca-bundle.crt": "not-a-valid-certificate"},
+				})).ShouldNot(HaveOccurred())
+
+				// First reconcile advances past agent/cluster setup; cert validation runs on the second pass.
+				_, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				_, err = bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("openshift-machine-config-operator/machine-config-server-ca contains invalid CA certificate data"))
+			})
+
+			It("should accept a certificate bundle with multiple PEM blocks", func() {
+				certBundle := TEST_CA_CERT + "\n" + TEST_CA_CERT_2
+				Expect(bmhr.spokeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-config-server-ca",
+						Namespace: "openshift-machine-config-operator",
+					},
+					Data: map[string]string{"ca-bundle.crt": certBundle},
+				})).ShouldNot(HaveOccurred())
+
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
+
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_AGENT_IGNITION_CONFIG_OVERRIDES))
+				encodedBundle := base64.StdEncoding.EncodeToString([]byte(certBundle))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]).To(ContainSubstring(encodedBundle))
 			})
 		})
 	})


### PR DESCRIPTION
Trim and validate certificates fetched from spoke cluster ConfigMaps as well-formed PEM before base64-encoding into ignition config overrides. Uses existing ValidatePEMCertificateBundle.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md