### PR TITLE
[release-ocm-2.13] MGMT-24236: Exclude post-installation hosts from pending-user-action timeout

### DIFF
--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -124,6 +124,21 @@ func (mr *MockTransitionHandlerMockRecorder) HostNotResponsiveWhilePreparingInst
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostNotResponsiveWhilePreparingInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).HostNotResponsiveWhilePreparingInstallation), sw, args)
 }
 
+// IsClusterPostInstallation mocks base method.
+func (m *MockTransitionHandler) IsClusterPostInstallation(sw stateswitch.StateSwitch, arg1 stateswitch.TransitionArgs) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsClusterPostInstallation", sw, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsClusterPostInstallation indicates an expected call of IsClusterPostInstallation.
+func (mr *MockTransitionHandlerMockRecorder) IsClusterPostInstallation(sw, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterPostInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).IsClusterPostInstallation), sw, arg1)
+}
+
 // IsDay2Host mocks base method.
 func (m *MockTransitionHandler) IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -134,7 +134,7 @@ func (m *MockTransitionHandler) IsClusterPostInstallation(sw stateswitch.StateSw
 }
 
 // IsClusterPostInstallation indicates an expected call of IsClusterPostInstallation.
-func (mr *MockTransitionHandlerMockRecorder) IsClusterPostInstallation(sw, arg1 any) *gomock.Call {
+func (mr *MockTransitionHandlerMockRecorder) IsClusterPostInstallation(sw, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterPostInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).IsClusterPostInstallation), sw, arg1)
 }

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -885,12 +885,13 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		Condition: stateswitch.And(
 			th.HasPendingUserActionTimedOut,
 			th.ClusterWouldSucceedWithoutHost,
+			stateswitch.Not(th.IsClusterPostInstallation),
 		),
 		DestinationState: stateswitch.State(models.HostStatusError),
 		PostTransition:   th.PostRefreshHost(statusInfoPendingUserActionTimeout),
 		Documentation: stateswitch.TransitionRuleDoc{
-			Name:        "Host pending user action timeout with cluster viability check",
-			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state ONLY if the cluster can still succeed without this host. This prevents timing out hosts that are required for cluster success (e.g., masters in a 3-node cluster), giving users more time to fix boot order issues for critical hosts.",
+			Name:        "Host pending user action timeout with cluster viability check (day1 only)",
+			Description: "When a host is in installing-pending-user-action state for too long without recovery, transition to error state ONLY if the cluster can still succeed without this host AND the cluster is still in initial installation (not post-installation). This prevents timing out hosts that are required for cluster success (e.g., masters in a 3-node cluster) and prevents timing out hosts being added to already-installed clusters where users explicitly want those specific hosts to join.",
 		},
 	})
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -38,6 +38,7 @@ type TransitionHandler interface {
 	HasInstallationInProgressTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasPendingUserActionTimedOut(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	ClusterWouldSucceedWithoutHost(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
+	IsClusterPostInstallation(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error)
 	HasStatusTimedOut(timeout time.Duration) stateswitch.Condition
 	HostNotResponsiveWhilePreparingInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
 	IsDay2Host(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error)
@@ -702,6 +703,30 @@ func (th *transitionHandler) ClusterWouldSucceedWithoutHost(sw stateswitch.State
 	}
 
 	return common.HasEnoughMastersAndWorkers(cluster, []string{models.HostStatusInstalled}), nil
+}
+
+func (th *transitionHandler) IsClusterPostInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
+	sHost, ok := sw.(*stateHost)
+	if !ok {
+		return false, errors.New("IsClusterPostInstallation incompatible type of StateSwitch")
+	}
+	params, ok := args.(*TransitionArgsRefreshHost)
+	if !ok {
+		return false, errors.New("IsClusterPostInstallation invalid argument")
+	}
+
+	// Get the cluster status
+	if sHost.host.ClusterID == nil {
+		return false, errors.New("cluster ID must not be nil")
+	}
+	var cluster common.Cluster
+	err := params.db.Select("status").Take(&cluster, "id = ?", sHost.host.ClusterID.String()).Error
+	if err != nil {
+		return false, err
+	}
+
+	status := swag.StringValue(cluster.Status)
+	return status == models.ClusterStatusInstalled || status == models.ClusterStatusAddingHosts, nil
 }
 
 func (th *transitionHandler) PostHostPreparationTimeout() stateswitch.PostTransition {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2226,6 +2226,56 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
 			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
 		})
+
+		It("remains when cluster is already installed (post-installation host addition)", func() {
+			// Create 3 master hosts in installed status so cluster is viable
+			for range 3 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
+			// Set cluster status to installed (post-installation state)
+			Expect(db.Model(&cluster).Update("status", models.ClusterStatusInstalled).Error).ShouldNot(HaveOccurred())
+
+			// Host has been stuck for > timeout but should NOT timeout because cluster is post-installation
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			host.Role = models.HostRoleWorker
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+		})
+
+		It("remains when cluster is adding hosts (imported cluster)", func() {
+			// Create 3 master hosts in installed status so cluster is viable
+			for range 3 {
+				masterId := strfmt.UUID(uuid.New().String())
+				master := hostutil.GenerateTestHostByKind(masterId, infraEnvId, &clusterId, models.HostStatusInstalled, models.HostKindHost, models.HostRoleMaster)
+				Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
+			}
+
+			// Set cluster status to adding-hosts (imported cluster state)
+			Expect(db.Model(&cluster).Updates(map[string]interface{}{
+				"status": models.ClusterStatusAddingHosts,
+				"kind":   models.ClusterKindAddHostsCluster,
+			}).Error).ShouldNot(HaveOccurred())
+
+			// Host has been stuck for > timeout but should NOT timeout because cluster is post-installation
+			host.StatusUpdatedAt = strfmt.DateTime(time.Now().Add(-90 * time.Minute))
+			host.Role = models.HostRoleWorker
+			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+			Expect(hapi.RefreshStatus(ctx, &host, db)).To(Succeed())
+
+			var resultHost models.Host
+			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
+			Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusInstallingPendingUserAction))
+		})
 	})
 
 	Context("Installation disk error handling in status info", func() {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/assisted-service/pull/10266