### PR TITLE
MGMT-20634: Revert global DNS workaround as RHEL-91250 resolved

### DIFF
--- a/pkg/staticnetworkconfig/backward_compatibility.go
+++ b/pkg/staticnetworkconfig/backward_compatibility.go
@@ -25,73 +25,6 @@ func (s *StaticNetworkConfigGenerator) NMStatectlServiceSupported(version string
 	return versionOK, nil
 }
 
-// CheckConfigForGlobalDnsCase detect whether any of the host-provided YAML configurations contain an interface with auto-dns: false, dhcp: true.
-// TODO: This is a temporary workaround and should be removed once the auto-dns:false, dhcp:true bug is fixed
-func (s *StaticNetworkConfigGenerator) CheckConfigForGlobalDnsCase(staticNetworkConfigStr string) (bool, error) {
-	staticNetworkConfig, err := s.decodeStaticNetworkConfig(staticNetworkConfigStr)
-	if err != nil {
-		s.log.WithError(err).Errorf("Failed to decode static network config")
-		return false, err
-	}
-
-	for _, hostConfig := range staticNetworkConfig {
-		isIncludeAutoDnsSetToFalse, err := s.hasDisabledAutoDnsWithDhcp(hostConfig.NetworkYaml)
-		if err != nil {
-			return false, err
-		}
-		if isIncludeAutoDnsSetToFalse {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (s *StaticNetworkConfigGenerator) hasDisabledAutoDnsWithDhcp(networksYaml string) (bool, error) {
-	var config map[string]interface{}
-
-	// Unmarshal the YAML string into the config struct
-	err := yaml.Unmarshal([]byte(networksYaml), &config)
-	if err != nil {
-		s.log.WithError(err).Errorf("Error unmarshalling yaml")
-		return false, err
-	}
-
-	interfaces, exists := config["interfaces"]
-	if !exists || interfaces == nil {
-		return false, nil
-	}
-	interfacesSlice, ok := interfaces.([]interface{})
-	if !ok {
-		return false, nil
-	}
-
-	isDHCPButNoAutoDNS := func(ipConfig map[interface{}]interface{}) bool {
-		autoDNSDisabled := false
-		dhcpEnabled := false
-
-		if autoDns, exists := ipConfig["auto-dns"]; exists && autoDns == false {
-			autoDNSDisabled = true
-		}
-		if dhcp, exists := ipConfig["dhcp"]; exists && dhcp == true {
-			dhcpEnabled = true
-		}
-
-		return autoDNSDisabled && dhcpEnabled
-	}
-
-	for _, iface := range interfacesSlice {
-		nic := iface.(map[interface{}]interface{})
-
-		if ipv4, exists := nic["ipv4"].(map[interface{}]interface{}); exists && isDHCPButNoAutoDNS(ipv4) {
-			return true, nil
-		}
-		if ipv6, exists := nic["ipv6"].(map[interface{}]interface{}); exists && isDHCPButNoAutoDNS(ipv6) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // CheckConfigForMACIdentifier TODO: This is a temporary workaround and should be removed once the mac-identifier bug in nmstate is fixed - RHEL-72440.
 func (s *StaticNetworkConfigGenerator) CheckConfigForMACIdentifier(staticNetworkConfigStr string) (bool, error) {
 	staticNetworkConfig, err := s.decodeStaticNetworkConfig(staticNetworkConfigStr)
@@ -148,14 +81,9 @@ func (s *StaticNetworkConfigGenerator) ShouldUseNmstateService(staticNetworkConf
 		return false, err
 	}
 
-	includeAutoDnsSetToFalse, err := s.CheckConfigForGlobalDnsCase(staticNetworkConfigStr)
-	if err != nil {
-		return false, err
-	}
-
 	isNmstateServiceSupported, err := s.NMStatectlServiceSupported(openshiftVersion)
 	if err != nil {
 		return false, err
 	}
-	return isNmstateServiceSupported && !includesMACIdentifier && !includeAutoDnsSetToFalse, nil
+	return isNmstateServiceSupported && !includesMACIdentifier, nil
 }

--- a/pkg/staticnetworkconfig/backward_compatibility_test.go
+++ b/pkg/staticnetworkconfig/backward_compatibility_test.go
@@ -35,17 +35,6 @@ var _ = Describe("ShouldUseNmstateService", func() {
     address:
       - ip: 192.0.2.1
         prefix-length: 24`
-		withAutoDnsSetToFalseDhcpTrue = `interfaces:
-- ipv4:
-    auto-dns: false
-    dhcp: true
-    enabled: true
-  ipv6:
-    enabled: false
-  name: eth0
-  state: up
-  type: ethernet
-`
 	)
 	table.DescribeTable("different scenarios", func(YAML, version string, expectedResult bool) {
 		escapedYamlContent, err := escapeYAMLForJSON(YAML)
@@ -58,6 +47,5 @@ var _ = Describe("ShouldUseNmstateService", func() {
 		table.Entry("If the YAML contains a mac-identifier, and the version is >= MinimalVersionForNmstatectl,  we shouldn't use the nmstate service flow", withMacIdentifier, common.MinimalVersionForNmstatectl, false),
 		table.Entry("If the YAML contains a mac-identifier, and the version is < MinimalVersionForNmstatectl,  we shouldn't use the nmstate service flow", withMacIdentifier, "4.12", false),
 		table.Entry("If the YAML doesn't contain a mac-identifier and the version is >= MinimalVersionForNmstatectl, we should use the nmstate service flow", withoutMacIdentifier, common.MinimalVersionForNmstatectl, true),
-		table.Entry("If the YAML doesn't contain a mac-identifier, and the version < MinimalVersionForNmstatectl we shouldn't use the nmstate service flow.", withoutMacIdentifier, "4.12", false),
-		table.Entry("If the YAML contains a auto-dns: false, dhcp: true, and the version >= MinimalVersionForNmstatectl we shouldn't use the nmstate service flow.", withAutoDnsSetToFalseDhcpTrue, common.MinimalVersionForNmstatectl, false))
+		table.Entry("If the YAML doesn't contain a mac-identifier, and the version < MinimalVersionForNmstatectl we shouldn't use the nmstate service flow.", withoutMacIdentifier, "4.12", false))
 })


### PR DESCRIPTION
As [RHEL-91250](https://redhat.atlassian.net/browse/RHEL-91250) is now resolved, we can remove our workaround for global DNS.
With this fix, if a user sets `auto-dns: false` and `dhcp: true` in their `nmstate.yaml`, the flow with `nmstate.service` should correctly apply the networking configuration files.

/cc @giladravid16

How it was tested:

I used the following `nmstate` file:
```
interfaces:
  - name: eth0
    type: ethernet
    state: up
    ipv4:
      enabled: true
      auto-dns: false
      dhcp: true
dns-resolver:
  config:
    server:
      - 192.168.122.1
routes:
  config:
    - destination: 0.0.0.0/0
      next-hop-address: 192.168.122.1
      next-hop-interface: eth0
      table-id: 254
```
Then I verified that `/etc/resolv.conf` was correctly configured both during discovery and after installation.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined the static network configuration logic by removing legacy DNS-related workarounds. The system now uses a simplified approach for determining when to use the nmstate service, focusing solely on OpenShift version compatibility and network configuration identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->