### PR TITLE
MGMT-23738: Flaky test: "Move Agent to another infraenv" fails with Kubernetes conflict error

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/common/ignition"
+	"github.com/openshift/assisted-service/internal/controller/patch"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
 	"github.com/openshift/assisted-service/models"
@@ -204,52 +205,6 @@ func (r reconcileError) Stop(ctx context.Context) bool {
 	return true
 }
 
-// isEmptyPatch returns true if the patch data contains no meaningful changes.
-// With MergeFromWithOptimisticLock, a no-op patch still includes
-// {"metadata":{"resourceVersion":"..."}}, so we check for that case too.
-func isEmptyPatch(data []byte) bool {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		return false
-	}
-	if len(m) == 0 {
-		return true
-	}
-	if len(m) == 1 {
-		if md, ok := m["metadata"]; ok {
-			var mdm map[string]json.RawMessage
-			if err := json.Unmarshal(md, &mdm); err != nil {
-				return false
-			}
-			if len(mdm) == 1 {
-				_, hasRV := mdm["resourceVersion"]
-				return hasRV
-			}
-			return len(mdm) == 0
-		}
-	}
-	return false
-}
-
-func (r *BMACReconciler) patchIfNeeded(ctx context.Context, obj client.Object, patch client.Patch, log logrus.FieldLogger) error {
-	data, err := patch.Data(obj)
-	if err != nil {
-		return fmt.Errorf("failed to compute patch data: %w", err)
-	}
-	if isEmptyPatch(data) {
-		return nil
-	}
-	log.Debugf("Patching %s/%s", obj.GetNamespace(), obj.GetName())
-	if err := r.Client.Patch(ctx, obj, patch); err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Debugf("Object %s/%s not found during patch, skipping", obj.GetNamespace(), obj.GetName())
-			return nil
-		}
-		return fmt.Errorf("failed to patch object: %w", err)
-	}
-	return nil
-}
-
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 
 func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrlResult ctrl.Result, retErr error) {
@@ -276,7 +231,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 
 	bmhPatch := client.MergeFromWithOptions(bmh.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	defer func() {
-		if err := r.patchIfNeeded(ctx, bmh, bmhPatch, log); err != nil {
+		if err := patch.IfNeeded(ctx, r.Client, bmh, bmhPatch, log); err != nil {
 			log.WithError(err).Error("failed to patch BMH")
 			retErr = errors.Join(retErr, err)
 		}
@@ -295,7 +250,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 		})
 		agentPatch := client.MergeFromWithOptions(agent.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		defer func() {
-			if err := r.patchIfNeeded(ctx, agent, agentPatch, log); err != nil {
+			if err := patch.IfNeeded(ctx, r.Client, agent, agentPatch, log); err != nil {
 				log.WithError(err).Error("failed to patch Agent")
 				retErr = errors.Join(retErr, err)
 			}

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -4476,20 +4476,6 @@ var _ = Describe("getChecksumAndURL", func() {
 	})
 })
 
-var _ = Describe("isEmptyPatch", func() {
-	DescribeTable("correctly identifies empty patches",
-		func(data string, expected bool) {
-			Expect(isEmptyPatch([]byte(data))).To(Equal(expected))
-		},
-		Entry("empty JSON object", `{}`, true),
-		Entry("metadata with only resourceVersion", `{"metadata":{"resourceVersion":"12345"}}`, true),
-		Entry("metadata with empty object", `{"metadata":{}}`, true),
-		Entry("metadata with resourceVersion and other fields", `{"metadata":{"resourceVersion":"12345","annotations":{"foo":"bar"}}}`, false),
-		Entry("non-metadata field", `{"spec":{"online":true}}`, false),
-		Entry("invalid JSON", `not-json`, false),
-	)
-})
-
 func newAgentWithClusterReference(name string, namespace string, ipv4address string, ipv6address string, macaddress string, clusterName string, agentBMHLabel string, creationTime time.Time) *v1beta1.Agent {
 	agent := newAgent(name, namespace, v1beta1.AgentSpec{})
 	agent.Status.Inventory = v1beta1.HostInventory{

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -3,9 +3,11 @@ package controllers
 import (
 	"context"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/controller/patch"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -13,7 +15,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -108,89 +109,74 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 	}
 
 	if err == nil {
-		log.Debugf("Agent CR %s already exists", hostId)
-		key := types.NamespacedName{Name: hostId, Namespace: infraEnvCR.Namespace}
-		// fetch previous by KubeKey
-		h, err2 := u.hostApi.GetHostByKubeKey(key)
-		if err2 != nil && !errors.Is(err2, gorm.ErrRecordNotFound) {
-			return errors.Wrapf(err2, "Failed to GetHostByKubeKey Name: %s Namespace: %s", key.Name, key.Namespace)
-		}
-
-		if err2 == nil {
-			if cluster != nil && h.ClusterID != nil && *h.ClusterID == *cluster.ID {
-				log.Debugf("Agent CR %s already exists, same cluster %s", hostId, h.ClusterID)
-				return nil
-			}
-			if h.InfraEnvID == *infraenv.ID {
-				log.Debugf("Agent CR %s already exists, same infraEnv %s", hostId, h.InfraEnvID)
-				return nil
-			}
-			//delete previous host
-			if err3 := u.hostApi.UnRegisterHost(ctx, &h.Host); err3 != nil {
-				return errors.Wrapf(err3, "Failed to UnRegisterHost ID: %s ClusterID: %s", h.ID.String(), h.ClusterID.String())
-			}
-		}
-		//Reset spec
-		labels := map[string]string{aiv1beta1.InfraEnvNameLabel: infraEnvCR.Name}
-		if infraEnvCR.Spec.AgentLabels != nil {
-			for k, v := range infraEnvCR.Spec.AgentLabels {
-				labels[k] = v
-			}
-		}
-
-		if err := u.updateAgentCR(ctx, namespacedName, labels, infraEnvCR, cluster); err != nil {
-			return err
-		}
-		// Update 'kube_key_namespace' in Host
-		if err := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnvCR.Namespace); err != nil {
-			return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
-		}
-		log.Infof("Updated Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnvCR.Namespace, clusterName, hostId)
+		return u.updateExistingAgentCR(ctx, log, hostId, host, infraenv, infraEnvCR, cluster, clusterName)
 	}
 
 	return nil
 }
 
-func (u *CRDUtils) updateAgentCR(ctx context.Context, namespacedName types.NamespacedName, labels map[string]string, infraEnvCR *aiv1beta1.InfraEnv, cluster *common.Cluster) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		current := &aiv1beta1.Agent{}
-		if err := u.client.Get(ctx, namespacedName, current); err != nil {
-			return err
-		}
+func hostBelongsToSameCluster(h *common.Host, cluster *common.Cluster) bool {
+	return cluster != nil && h.ClusterID != nil && *h.ClusterID == *cluster.ID
+}
 
-		updatedhost := &aiv1beta1.Agent{
-			Spec: aiv1beta1.AgentSpec{
-				Approved:                false,
-				Hostname:                "",
-				MachineConfigPool:       "",
-				Role:                    "",
-				InstallationDiskID:      "",
-				InstallerArgs:           "",
-				IgnitionConfigOverrides: "",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            namespacedName.Name,
-				Namespace:       namespacedName.Namespace,
-				Labels:          labels,
-				ResourceVersion: current.ResourceVersion,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: infraEnvCR.APIVersion,
-						Kind:       infraEnvCR.Kind,
-						Name:       infraEnvCR.Name,
-						UID:        infraEnvCR.UID,
-					},
-				},
-			},
+func hostBelongsToSameInfraEnv(h *common.Host, infraEnvID strfmt.UUID) bool {
+	return h.InfraEnvID == infraEnvID
+}
+
+func (u *CRDUtils) updateExistingAgentCR(ctx context.Context, log logrus.FieldLogger, hostId string, host *aiv1beta1.Agent, infraenv *common.InfraEnv, infraEnvCR *aiv1beta1.InfraEnv, cluster *common.Cluster, clusterName string) error {
+	log.Debugf("Agent CR %s already exists", hostId)
+	key := types.NamespacedName{Name: hostId, Namespace: infraEnvCR.Namespace}
+	h, err := u.hostApi.GetHostByKubeKey(key)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return errors.Wrapf(err, "Failed to GetHostByKubeKey Name: %s Namespace: %s", key.Name, key.Namespace)
+	}
+
+	if err == nil && hostBelongsToSameCluster(h, cluster) {
+		log.Debugf("Agent CR %s already exists, same cluster %s", hostId, h.ClusterID)
+		return nil
+	}
+	if err == nil && hostBelongsToSameInfraEnv(h, *infraenv.ID) {
+		log.Debugf("Agent CR %s already exists, same infraEnv %s", hostId, h.InfraEnvID)
+		return nil
+	}
+	if err == nil {
+		if err3 := u.hostApi.UnRegisterHost(ctx, &h.Host); err3 != nil {
+			return errors.Wrapf(err3, "Failed to UnRegisterHost ID: %s ClusterID: %s", h.ID.String(), h.ClusterID.String())
 		}
-		if cluster != nil && cluster.KubeKeyNamespace != "" {
-			updatedhost.Spec.ClusterDeploymentName = &aiv1beta1.ClusterReference{
-				Name:      cluster.KubeKeyName,
-				Namespace: cluster.KubeKeyNamespace,
-			}
+	}
+
+	//Reset spec
+	p := client.MergeFrom(host.DeepCopy())
+	host.Spec = aiv1beta1.AgentSpec{}
+	if cluster != nil && cluster.KubeKeyNamespace != "" {
+		host.Spec.ClusterDeploymentName = &aiv1beta1.ClusterReference{
+			Name:      cluster.KubeKeyName,
+			Namespace: cluster.KubeKeyNamespace,
 		}
-		return u.client.Update(ctx, updatedhost)
-	})
+	}
+	labels := map[string]string{aiv1beta1.InfraEnvNameLabel: infraEnvCR.Name}
+	if infraEnvCR.Spec.AgentLabels != nil {
+		for k, v := range infraEnvCR.Spec.AgentLabels {
+			labels[k] = v
+		}
+	}
+	host.Labels = labels
+	host.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: infraEnvCR.APIVersion,
+			Kind:       infraEnvCR.Kind,
+			Name:       infraEnvCR.Name,
+			UID:        infraEnvCR.UID,
+		},
+	}
+	if err := patch.IfNeeded(ctx, u.client, host, p, log); err != nil {
+		return err
+	}
+	if err := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnvCR.Namespace); err != nil {
+		return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
+	}
+	log.Infof("Updated Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnvCR.Namespace, clusterName, hostId)
+	return nil
 }
 
 type DummyCRDUtils struct{}

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -13,6 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -137,6 +138,26 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 			}
 		}
 
+		if err := u.updateAgentCR(ctx, namespacedName, labels, infraEnvCR, cluster); err != nil {
+			return err
+		}
+		// Update 'kube_key_namespace' in Host
+		if err := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnvCR.Namespace); err != nil {
+			return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
+		}
+		log.Infof("Updated Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnvCR.Namespace, clusterName, hostId)
+	}
+
+	return nil
+}
+
+func (u *CRDUtils) updateAgentCR(ctx context.Context, namespacedName types.NamespacedName, labels map[string]string, infraEnvCR *aiv1beta1.InfraEnv, cluster *common.Cluster) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &aiv1beta1.Agent{}
+		if err := u.client.Get(ctx, namespacedName, current); err != nil {
+			return err
+		}
+
 		updatedhost := &aiv1beta1.Agent{
 			Spec: aiv1beta1.AgentSpec{
 				Approved:                false,
@@ -148,10 +169,10 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 				IgnitionConfigOverrides: "",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            hostId,
-				Namespace:       infraEnvCR.Namespace,
+				Name:            namespacedName.Name,
+				Namespace:       namespacedName.Namespace,
 				Labels:          labels,
-				ResourceVersion: host.ResourceVersion,
+				ResourceVersion: current.ResourceVersion,
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion: infraEnvCR.APIVersion,
@@ -162,22 +183,14 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 				},
 			},
 		}
-
-		// Update 'kube_key_namespace' in Host
-		if err1 := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnvCR.Namespace); err1 != nil {
-			return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
-		}
 		if cluster != nil && cluster.KubeKeyNamespace != "" {
 			updatedhost.Spec.ClusterDeploymentName = &aiv1beta1.ClusterReference{
 				Name:      cluster.KubeKeyName,
 				Namespace: cluster.KubeKeyNamespace,
 			}
 		}
-		log.Infof("Updating Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnvCR.Namespace, clusterName, hostId)
 		return u.client.Update(ctx, updatedhost)
-	}
-
-	return nil
+	})
 }
 
 type DummyCRDUtils struct{}

--- a/internal/controller/controllers/crd_utils_test.go
+++ b/internal/controller/controllers/crd_utils_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -13,10 +14,13 @@ import (
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"go.uber.org/mock/gomock"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var _ = Describe("create agent CR", func() {
@@ -174,6 +178,68 @@ var _ = Describe("create agent CR", func() {
 
 			err := crdUtils.CreateAgentCR(ctx, log, hostId, infraEnv, cluster)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Already existing agent update retries on conflict", func() {
+			clusterDeployment := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+			Expect(c.Create(ctx, clusterDeployment)).ShouldNot(HaveOccurred())
+			infraEnvImage := newInfraEnvImage(infraEnvName, infraEnvNamespace, v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      clusterDeployment.Name,
+					Namespace: clusterDeployment.Namespace,
+				},
+			})
+			Expect(c.Create(ctx, infraEnvImage)).ShouldNot(HaveOccurred())
+
+			hostId := uuid.New().String()
+			agent := newAgent(hostId, infraEnvNamespace, v1beta1.AgentSpec{})
+			Expect(c.Create(ctx, agent)).ShouldNot(HaveOccurred())
+
+			id := strfmt.UUID(hostId)
+			otherClusterId := strfmt.UUID(uuid.New().String())
+			infraEnvId2 := strfmt.UUID(uuid.New().String())
+			h := common.Host{
+				Host: models.Host{
+					ID:         &id,
+					ClusterID:  &otherClusterId,
+					InfraEnvID: infraEnvId,
+				},
+			}
+			infraEnv2 := &common.InfraEnv{
+				KubeKeyNamespace: infraEnvNamespace,
+				InfraEnv: models.InfraEnv{
+					ID:   &infraEnvId2,
+					Name: &infraEnvName,
+				},
+			}
+
+			mockHostApi.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&h, nil).Times(1)
+			mockHostApi.EXPECT().UnRegisterHost(ctx, gomock.Any()).Return(nil).Times(1)
+			mockHostApi.EXPECT().UpdateKubeKeyNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+			updateCount := 0
+			conflictClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(clusterDeployment, infraEnvImage, agent).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						updateCount++
+						if updateCount == 1 {
+							return k8serrors.NewConflict(
+								schema.GroupResource{Group: "agent-install.openshift.io", Resource: "agents"},
+								obj.GetName(),
+								fmt.Errorf("the object has been modified"),
+							)
+						}
+						return cl.Update(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			conflictCrdUtils := NewCRDUtils(conflictClient, mockHostApi)
+			err := conflictCrdUtils.CreateAgentCR(ctx, log, hostId, infraEnv2, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updateCount).To(Equal(2))
 		})
 
 		It("Already existing agent different infraenv same namespace", func() {

--- a/internal/controller/controllers/crd_utils_test.go
+++ b/internal/controller/controllers/crd_utils_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -14,13 +13,10 @@ import (
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"go.uber.org/mock/gomock"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var _ = Describe("create agent CR", func() {
@@ -180,7 +176,7 @@ var _ = Describe("create agent CR", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Already existing agent update retries on conflict", func() {
+		It("Already existing agent update succeeds despite concurrent modification", func() {
 			clusterDeployment := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, clusterDeployment)).ShouldNot(HaveOccurred())
 			infraEnvImage := newInfraEnvImage(infraEnvName, infraEnvNamespace, v1beta1.InfraEnvSpec{
@@ -192,8 +188,26 @@ var _ = Describe("create agent CR", func() {
 			Expect(c.Create(ctx, infraEnvImage)).ShouldNot(HaveOccurred())
 
 			hostId := uuid.New().String()
-			agent := newAgent(hostId, infraEnvNamespace, v1beta1.AgentSpec{})
+			agent := newAgent(hostId, infraEnvNamespace, v1beta1.AgentSpec{
+				Approved:                true,
+				Hostname:                "old-hostname",
+				Role:                    "master",
+				MachineConfigPool:       "worker-custom",
+				InstallationDiskID:      "/dev/sda",
+				InstallerArgs:           `["--save-partlabel","data"]`,
+				IgnitionConfigOverrides: `{"ignition":{"version":"3.1.0"}}`,
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "old-cluster",
+					Namespace: "old-namespace",
+				},
+			})
 			Expect(c.Create(ctx, agent)).ShouldNot(HaveOccurred())
+
+			namespacedName := types.NamespacedName{Name: hostId, Namespace: infraEnvNamespace}
+			concurrentAgent := &v1beta1.Agent{}
+			Expect(c.Get(ctx, namespacedName, concurrentAgent)).ShouldNot(HaveOccurred())
+			concurrentAgent.SetAnnotations(map[string]string{"reconciler": "was-here"})
+			Expect(c.Update(ctx, concurrentAgent)).ShouldNot(HaveOccurred())
 
 			id := strfmt.UUID(hostId)
 			otherClusterId := strfmt.UUID(uuid.New().String())
@@ -217,29 +231,24 @@ var _ = Describe("create agent CR", func() {
 			mockHostApi.EXPECT().UnRegisterHost(ctx, gomock.Any()).Return(nil).Times(1)
 			mockHostApi.EXPECT().UpdateKubeKeyNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-			updateCount := 0
-			conflictClient := fakeclient.NewClientBuilder().
-				WithScheme(scheme.Scheme).
-				WithObjects(clusterDeployment, infraEnvImage, agent).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-						updateCount++
-						if updateCount == 1 {
-							return k8serrors.NewConflict(
-								schema.GroupResource{Group: "agent-install.openshift.io", Resource: "agents"},
-								obj.GetName(),
-								fmt.Errorf("the object has been modified"),
-							)
-						}
-						return cl.Update(ctx, obj, opts...)
-					},
-				}).
-				Build()
-
-			conflictCrdUtils := NewCRDUtils(conflictClient, mockHostApi)
-			err := conflictCrdUtils.CreateAgentCR(ctx, log, hostId, infraEnv2, cluster)
+			err := crdUtils.CreateAgentCR(ctx, log, hostId, infraEnv2, cluster)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updateCount).To(Equal(2))
+
+			updated := &v1beta1.Agent{}
+			Expect(c.Get(ctx, namespacedName, updated)).ShouldNot(HaveOccurred())
+			Expect(updated.Annotations["reconciler"]).To(Equal("was-here"))
+			Expect(updated.Labels[v1beta1.InfraEnvNameLabel]).To(Equal(infraEnvName))
+			Expect(updated.Spec.Approved).To(BeFalse())
+			Expect(updated.Spec.Hostname).To(BeEmpty())
+			Expect(string(updated.Spec.Role)).To(BeEmpty())
+			Expect(updated.Spec.MachineConfigPool).To(BeEmpty())
+			Expect(updated.Spec.InstallationDiskID).To(BeEmpty())
+			Expect(updated.Spec.InstallerArgs).To(BeEmpty())
+			Expect(updated.Spec.IgnitionConfigOverrides).To(BeEmpty())
+			Expect(updated.Spec.ClusterDeploymentName).To(Equal(&v1beta1.ClusterReference{
+				Name:      cluster.KubeKeyName,
+				Namespace: cluster.KubeKeyNamespace,
+			}))
 		})
 
 		It("Already existing agent different infraenv same namespace", func() {

--- a/internal/controller/patch/patch.go
+++ b/internal/controller/patch/patch.go
@@ -1,0 +1,59 @@
+package patch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsEmpty returns true if the patch data contains no meaningful changes.
+// With MergeFromWithOptimisticLock, a no-op patch still includes
+// {"metadata":{"resourceVersion":"..."}}, so we check for that case too.
+func IsEmpty(data []byte) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return false
+	}
+	if len(m) == 0 {
+		return true
+	}
+	if len(m) == 1 {
+		if md, ok := m["metadata"]; ok {
+			var mdm map[string]json.RawMessage
+			if err := json.Unmarshal(md, &mdm); err != nil {
+				return false
+			}
+			if len(mdm) == 1 {
+				_, hasRV := mdm["resourceVersion"]
+				return hasRV
+			}
+			return len(mdm) == 0
+		}
+	}
+	return false
+}
+
+// IfNeeded computes the patch diff and applies it only if there are meaningful changes.
+// NotFound errors are silently ignored since the object may have been deleted during reconciliation.
+func IfNeeded(ctx context.Context, cl client.Client, obj client.Object, p client.Patch, log logrus.FieldLogger) error {
+	data, err := p.Data(obj)
+	if err != nil {
+		return fmt.Errorf("failed to compute patch data: %w", err)
+	}
+	if IsEmpty(data) {
+		return nil
+	}
+	log.Debugf("Patching %s/%s", obj.GetNamespace(), obj.GetName())
+	if err := cl.Patch(ctx, obj, p); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Debugf("Object %s/%s not found during patch, skipping", obj.GetNamespace(), obj.GetName())
+			return nil
+		}
+		return fmt.Errorf("failed to patch object: %w", err)
+	}
+	return nil
+}

--- a/internal/controller/patch/patch_suite_test.go
+++ b/internal/controller/patch/patch_suite_test.go
@@ -1,0 +1,13 @@
+package patch
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Patch Suite")
+}

--- a/internal/controller/patch/patch_test.go
+++ b/internal/controller/patch/patch_test.go
@@ -1,0 +1,102 @@
+package patch
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+var _ = Describe("IsEmpty", func() {
+	DescribeTable("correctly identifies empty patches",
+		func(data string, expected bool) {
+			Expect(IsEmpty([]byte(data))).To(Equal(expected))
+		},
+		Entry("empty JSON object", `{}`, true),
+		Entry("metadata with only resourceVersion", `{"metadata":{"resourceVersion":"12345"}}`, true),
+		Entry("metadata with empty object", `{"metadata":{}}`, true),
+		Entry("metadata with resourceVersion and other fields", `{"metadata":{"resourceVersion":"12345","annotations":{"foo":"bar"}}}`, false),
+		Entry("non-metadata field", `{"spec":{"online":true}}`, false),
+		Entry("invalid JSON", `not-json`, false),
+	)
+})
+
+var _ = Describe("IfNeeded", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+		s   *runtime.Scheme
+		log logrus.FieldLogger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		s = newScheme()
+		log = common.GetTestLog()
+	})
+
+	It("skips empty patch", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "value"},
+		}
+		c = fakeclient.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+
+		current := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, current)).To(Succeed())
+
+		p := client.MergeFrom(current.DeepCopy())
+		Expect(IfNeeded(ctx, c, current, p, log)).To(Succeed())
+	})
+
+	It("applies patch with changes", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "value"},
+		}
+		c = fakeclient.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+
+		current := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, current)).To(Succeed())
+
+		p := client.MergeFrom(current.DeepCopy())
+		current.Data["key"] = "updated"
+
+		Expect(IfNeeded(ctx, c, current, p, log)).To(Succeed())
+
+		updated := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Data["key"]).To(Equal("updated"))
+	})
+
+	It("ignores NotFound", func() {
+		c = fakeclient.NewClientBuilder().WithScheme(s).Build()
+
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "gone",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+		}
+		p := client.MergeFrom(obj.DeepCopy())
+		obj.Data = map[string]string{"new": "data"}
+
+		Expect(IfNeeded(ctx, c, obj, p, log)).To(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

  - Replace client.Update with client.MergeFrom + client.Patch in CreateAgentCR to eliminate Kubernetes optimistic concurrency conflicts when moving an agent between
  infraenvs
  - Extract shared patch.IsEmpty and patch.IfNeeded helpers from the BMAC controller into a new internal/controller/patch package for reuse across controllers
  - Extract hostBelongsToSameCluster and hostBelongsToSameInfraEnv helpers to flatten the update logic
  - Extract updateExistingAgentCR method to reduce cyclomatic complexity
  - Fix pre-existing bug where errors.Wrapf wrapped the wrong variable in the UpdateKubeKeyNS error path

  Why Patch instead of Update

  - Update sends the entire object and requires a matching ResourceVersion — if the Agent controller reconciler modifies the CR between Get and Update, the call fails
  with a 409 Conflict
  - Patch with MergeFrom sends only the diff of changed fields and does not check ResourceVersion, so concurrent reconciler updates no longer cause conflicts
  - Patch preserves metadata (annotations, finalizers) set by other controllers, which Update would wipe

  Test plan

  - [x] New test "Already existing agent update succeeds despite concurrent modification" — sets all spec fields to non-zero values, simulates a concurrent annotation
  change, verifies all spec fields are reset and the concurrent annotation is preserved
  - [x] patch.IsEmpty tests (6 cases) and patch.IfNeeded tests (skips empty, applies changes, ignores NotFound)
  - [x] All existing crd_utils tests pass (9/9)
  - [x] skipper make lint passes with 0 issues
  - [ ] CI: edge-subsystem-kubeapi-aws validates the "Move Agent to another infraenv" subsystem test no longer flakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling when an Agent exists: avoids no-op patches, preserves existing annotations, clears host-related Agent spec fields during reconciliation, and updates host metadata and namespace.

* **Tests**
  * Added a test simulating concurrent modifications that verifies annotations are preserved, the infra label is set, and Agent spec fields are cleared.

* **Refactor**
  * Centralized patching into a shared helper to standardize skip/no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->