### PR TITLE
NO-ISSUE: Fix resource leak and inconsistency in manifest download

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1358,12 +1358,13 @@ func (m *Manager) createClusterDataFiles(ctx context.Context, c *common.Cluster,
 		if !exists {
 			continue
 		}
-		response, numberOfBytes, err := m.objectHandler.Download(ctx, objectName)
+		response, numberOfBytes, err := objectHandler.Download(ctx, objectName)
 		if err != nil {
 			log.WithError(err).Errorf("failed to download file %s from cluster while building log: %s", path, *c.ID)
 			continue
 		}
 		fileContent, err := io.ReadAll(response)
+		response.Close()
 		if err != nil {
 			log.WithError(err).Errorf("failed to read file data %s (%d) from cluster while building log: %s", path, numberOfBytes, *c.ID)
 			continue


### PR DESCRIPTION
Fix two issues identified by Claude Code in createClusterDataFiles():

1. Close the io.ReadCloser returned by Download() to prevent resource leaks when processing multiple manifests
2. Use the objectHandler parameter consistently instead of mixing m.objectHandler and objectHandler for different operations

The response body is closed immediately after io.ReadAll() rather than using defer, since this occurs in a loop and defer would accumulate all closes until function return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource management for cluster manifest downloads from object storage, ensuring proper cleanup of download streams to prevent potential leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->