### PR TITLE
MGMT-22370: Add exponential backoff to agent image pull

### DIFF
--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -108,6 +108,22 @@ IMAGE=$(echo $1 | sed 's/[@:].*//')
 podman images | grep $IMAGE || podman rmi --force $1 || true
 `
 
+const agentPullImage = `#!/usr/bin/sh
+IMAGE=$1
+DELAY=5
+MAX_DELAY=300
+podman image exists "$IMAGE" && exit 0
+while true; do
+    podman pull "$IMAGE" && exit 0
+    echo "Pull failed for $IMAGE, retrying in ${DELAY}s..."
+    sleep $DELAY
+    DELAY=$((DELAY * 2))
+    if [ $DELAY -gt $MAX_DELAY ]; then
+        DELAY=$MAX_DELAY
+    fi
+done
+`
+
 const okdBinariesOverlayTemplate = `#!/bin/env bash
 set -eux
 # Fetch an image with OKD rpms
@@ -303,6 +319,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"PullSecretToken":     pullSecretToken,
 		"AGENT_MOTD":          url.PathEscape(agentMessageOfTheDay),
 		"AGENT_FIX_BZ1964591": url.PathEscape(agentFixBZ1964591),
+		"AGENT_PULL_IMAGE":    url.PathEscape(agentPullImage),
 		"IPv6_CONF":           url.PathEscape(common.Ipv6DuidDiscoveryConf),
 		"PULL_SECRET":         url.PathEscape(infraEnv.PullSecret),
 		"RH_ROOT_CA":          rhCa,

--- a/internal/ignition/templates/agent.service
+++ b/internal/ignition/templates/agent.service
@@ -12,7 +12,8 @@ Environment=no_proxy={{.NoProxy}}{{if .PullSecretToken}}
 Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}{{end}}
 TimeoutStartSec={{.AgentTimeoutStartSec}}
 ExecStartPre=/usr/local/bin/agent-fix-bz1964591 {{.AgentDockerImg}}
-ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin {{.AgentDockerImg}} cp /usr/bin/agent /hostbin
+ExecStartPre=/usr/local/bin/agent-pull-image {{.AgentDockerImg}}
+ExecStartPre=podman run --pull=never --privileged --rm -v /usr/local/bin:/hostbin {{.AgentDockerImg}} cp /usr/bin/agent /hostbin
 ExecStart=/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id {{.infraEnvId}} --agent-version {{.AgentDockerImg}} --insecure={{.SkipCertVerification}}  {{if .HostCACertPath}}--cacert {{.HostCACertPath}}{{end}}
 
 [Unit]

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -75,6 +75,15 @@
     },
     {
       "overwrite": true,
+      "path": "/usr/local/bin/agent-pull-image",
+      "mode": 493,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.AGENT_PULL_IMAGE}}" }
+    },
+    {
+      "overwrite": true,
       "path": "/etc/motd",
       "mode": 420,
       "user": {


### PR DESCRIPTION
When the agent's container image pull fails, systemd retries every 3 seconds forever (RestartSec=3, StartLimitInterval=0), flooding the registry. In staging, one host made 1836 attempts in 1.5 hours.

Add a wrapper script (agent-pull-image) that handles image pulling with exponential backoff (5s → 10s → 20s → 40s → 80s → 160s → 300s cap). The script skips the pull entirely if the image is already cached locally, and never stops retrying.

This reduces registry load from ~1200 to ~48 attempts/hour per host (~96% reduction).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic retry logic with exponential backoff for container image pulls to improve handling of transient network failures.
  
* **Bug Fixes**
  * Agent service now explicitly pulls required container images before startup to ensure availability and prevent initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->