### PR TITLE
MGMT-24393: Assisted Service IPv6 checks fails comparative

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -743,6 +743,13 @@ func (b *bareMetalInventory) RegisterClusterInternal(ctx context.Context, kubeKe
 
 	monitoredOperators := b.operatorManagerApi.GetSupportedOperatorsByType(models.OperatorTypeBuiltin)
 
+	for _, v := range params.NewClusterParams.APIVips {
+		v.IP = models.IP(network.NormalizeIP(string(v.IP)))
+	}
+	for _, v := range params.NewClusterParams.IngressVips {
+		v.IP = models.IP(network.NormalizeIP(string(v.IP)))
+	}
+
 	cluster = &common.Cluster{
 		Cluster: models.Cluster{
 			ID:                           &id,
@@ -2773,7 +2780,7 @@ func wereClusterVipsUpdated(clusterVips []string, paramVips []string) bool {
 		return true
 	}
 	for i := range clusterVips {
-		if clusterVips[i] != paramVips[i] {
+		if network.NormalizeIP(clusterVips[i]) != network.NormalizeIP(paramVips[i]) {
 			return true
 		}
 	}
@@ -3791,8 +3798,8 @@ func (b *bareMetalInventory) processDhcpAllocationResponse(ctx context.Context, 
 		log.WithError(err).Warnf("Json unmarshal dhcp allocation from host %s", host.ID.String())
 		return err
 	}
-	apiVip := dhcpAllocationReponse.APIVipAddress.String()
-	ingressVip := dhcpAllocationReponse.IngressVipAddress.String()
+	apiVip := network.NormalizeIP(dhcpAllocationReponse.APIVipAddress.String())
+	ingressVip := network.NormalizeIP(dhcpAllocationReponse.IngressVipAddress.String())
 	primaryMachineCIDR := ""
 	if network.IsMachineCidrAvailable(cluster) {
 		primaryMachineCIDR = network.GetMachineCidrById(cluster, 0)

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1268,6 +1268,8 @@ func (m *Manager) SetVipsData(ctx context.Context, c *common.Cluster, apiVip, in
 	if db == nil {
 		db = m.db
 	}
+	apiVip = network.NormalizeIP(apiVip)
+	ingressVip = network.NormalizeIP(ingressVip)
 	log := logutil.FromContext(ctx, m.log)
 	formattedApiLease := network.FormatLease(apiVipLease)
 	formattedIngressLease := network.FormatLease(ingressVipLease)

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -173,7 +173,7 @@ func HandleApiVipBackwardsCompatibility(clusterId *strfmt.UUID, apiVip string, a
 		return vips, nil
 	}
 	// Both APIVip and APIVips were provided.
-	if apiVip != "" && len(apiVips) > 0 && apiVip != string(apiVips[0].IP) {
+	if apiVip != "" && len(apiVips) > 0 && network.NormalizeIP(apiVip) != network.NormalizeIP(string(apiVips[0].IP)) {
 		return nil, errors.New("apiVIP must be the same as the first element of apiVIPs")
 	}
 	return apiVips, nil
@@ -189,7 +189,7 @@ func HandleIngressVipBackwardsCompatibility(clusterId *strfmt.UUID, ingressVip s
 		return vips, nil
 	}
 	// Both IngressVip and IngressVips were provided.
-	if ingressVip != "" && len(ingressVips) > 0 && ingressVip != string(ingressVips[0].IP) {
+	if ingressVip != "" && len(ingressVips) > 0 && network.NormalizeIP(ingressVip) != network.NormalizeIP(string(ingressVips[0].IP)) {
 		return nil, errors.New("ingressVIP must be the same as the first element of ingressVIPs")
 	}
 	return ingressVips, nil

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/assisted-service/internal/bminventory"
 	clusterPkg "github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/requestid"
@@ -358,7 +359,7 @@ func ApiVipsArrayToStrings(vips []*models.APIVip) []string {
 
 func ApiVipsEntriesToArray(entries []string) []*models.APIVip {
 	return funk.Map(entries, func(entry string) *models.APIVip {
-		return &models.APIVip{IP: models.IP(entry)}
+		return &models.APIVip{IP: models.IP(network.NormalizeIP(entry))}
 	}).([]*models.APIVip)
 }
 
@@ -370,7 +371,7 @@ func IngressVipsArrayToStrings(vips []*models.IngressVip) []string {
 
 func IngressVipsEntriesToArray(entries []string) []*models.IngressVip {
 	return funk.Map(entries, func(entry string) *models.IngressVip {
-		return &models.IngressVip{IP: models.IP(entry)}
+		return &models.IngressVip{IP: models.IP(network.NormalizeIP(entry))}
 	}).([]*models.IngressVip)
 }
 

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -564,34 +564,32 @@ func AreClusterNetworksIdentical(n1, n2 []*models.ClusterNetwork) bool {
 
 func AreApiVipsIdentical(n1, n2 []*models.APIVip) bool {
 	if isDualStackItems(n1) && isDualStackItems(n2) {
-		// For dual-stack, order matters
 		if len(n1) != len(n2) {
 			return false
 		}
 		for i := 0; i < len(n1); i++ {
-			if n1[i].IP != n2[i].IP {
+			if !ipsEqual(n1[i].IP, n2[i].IP) {
 				return false
 			}
 		}
 		return true
 	}
-	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].IP == n2[j].IP })
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return ipsEqual(n1[i].IP, n2[j].IP) })
 }
 
 func AreIngressVipsIdentical(n1, n2 []*models.IngressVip) bool {
 	if isDualStackItems(n1) && isDualStackItems(n2) {
-		// For dual-stack, order matters
 		if len(n1) != len(n2) {
 			return false
 		}
 		for i := 0; i < len(n1); i++ {
-			if n1[i].IP != n2[i].IP {
+			if !ipsEqual(n1[i].IP, n2[i].IP) {
 				return false
 			}
 		}
 		return true
 	}
-	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].IP == n2[j].IP })
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return ipsEqual(n1[i].IP, n2[j].IP) })
 }
 
 func UpdateVipsTables(db *gorm.DB, cluster *common.Cluster, apiVipUpdated bool, ingressVipUpdated bool) error {
@@ -734,4 +732,21 @@ func NormalizeCIDR(cidr string) (string, error) {
 		return "", err
 	}
 	return ipnet.String(), nil
+}
+
+func NormalizeIP(ip string) string {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip
+	}
+	return addr.String()
+}
+
+func ipsEqual(a, b models.IP) bool {
+	ipA, errA := netip.ParseAddr(string(a))
+	ipB, errB := netip.ParseAddr(string(b))
+	if errA != nil || errB != nil {
+		return string(a) == string(b)
+	}
+	return ipA == ipB
 }

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -812,6 +812,46 @@ var _ = Describe("AreApiVipsIdentical", func() {
 			},
 			expectedResult: false,
 		},
+		{
+			name: "IPv6 expanded vs canonical",
+			n1: []*models.APIVip{
+				{IP: "2620:0052:0009:164d:0000:0000:0000:0046"},
+			},
+			n2: []*models.APIVip{
+				{IP: "2620:52:9:164d::46"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 leading zeros stripped",
+			n1: []*models.APIVip{
+				{IP: "2001:0db8:0000:0000:0000:0000:0000:0001"},
+			},
+			n2: []*models.APIVip{
+				{IP: "2001:db8::1"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 mixed case",
+			n1: []*models.APIVip{
+				{IP: "2001:0DB8::ABCD"},
+			},
+			n2: []*models.APIVip{
+				{IP: "2001:db8::abcd"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 actually different",
+			n1: []*models.APIVip{
+				{IP: "2001:db8::1"},
+			},
+			n2: []*models.APIVip{
+				{IP: "2001:db8::2"},
+			},
+			expectedResult: false,
+		},
 	}
 	for i := range tests {
 		t := tests[i]
@@ -932,11 +972,106 @@ var _ = Describe("AreIngressVipsIdentical", func() {
 			},
 			expectedResult: false,
 		},
+		{
+			name: "IPv6 expanded vs canonical",
+			n1: []*models.IngressVip{
+				{IP: "2620:0052:0009:164d:0000:0000:0000:0046"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "2620:52:9:164d::46"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 leading zeros stripped",
+			n1: []*models.IngressVip{
+				{IP: "2001:0db8:0000:0000:0000:0000:0000:0001"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "2001:db8::1"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 mixed case",
+			n1: []*models.IngressVip{
+				{IP: "2001:0DB8::ABCD"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "2001:db8::abcd"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "IPv6 actually different",
+			n1: []*models.IngressVip{
+				{IP: "2001:db8::1"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "2001:db8::2"},
+			},
+			expectedResult: false,
+		},
 	}
 	for i := range tests {
 		t := tests[i]
 		It(t.name, func() {
 			Expect(AreIngressVipsIdentical(t.n1, t.n2)).To(Equal(t.expectedResult))
+		})
+	}
+})
+
+var _ = Describe("NormalizeIP", func() {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "IPv6 expanded to canonical",
+			input:    "2620:0052:0009:164d:0000:0000:0000:0046",
+			expected: "2620:52:9:164d::46",
+		},
+		{
+			name:     "IPv6 leading zeros",
+			input:    "2001:0db8:0000:0000:0000:0000:0000:0001",
+			expected: "2001:db8::1",
+		},
+		{
+			name:     "IPv6 mixed case normalized to lowercase",
+			input:    "2001:0DB8::ABCD",
+			expected: "2001:db8::abcd",
+		},
+		{
+			name:     "IPv6 already canonical unchanged",
+			input:    "2001:db8::1",
+			expected: "2001:db8::1",
+		},
+		{
+			name:     "IPv6 loopback",
+			input:    "0000:0000:0000:0000:0000:0000:0000:0001",
+			expected: "::1",
+		},
+		{
+			name:     "IPv4 unchanged",
+			input:    "192.168.1.100",
+			expected: "192.168.1.100",
+		},
+		{
+			name:     "Empty string unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Invalid input unchanged",
+			input:    "not-an-ip",
+			expected: "not-an-ip",
+		},
+	}
+	for i := range tests {
+		t := tests[i]
+		It(t.name, func() {
+			Expect(NormalizeIP(t.input)).To(Equal(t.expected))
 		})
 	}
 })
@@ -1326,6 +1461,18 @@ var _ = Describe("Network Comparison Functions with Dual-Stack Support", func() 
 				}
 				Expect(AreApiVipsIdentical(n1, n2)).To(BeFalse())
 			})
+
+			It("should return true for dual-stack VIPs with non-canonical IPv6", func() {
+				n1 := []*models.APIVip{
+					{IP: "10.0.1.1"},
+					{IP: "2620:0052:0009:164d:0000:0000:0000:0046"},
+				}
+				n2 := []*models.APIVip{
+					{IP: "10.0.1.1"},
+					{IP: "2620:52:9:164d::46"},
+				}
+				Expect(AreApiVipsIdentical(n1, n2)).To(BeTrue())
+			})
 		})
 	})
 
@@ -1367,6 +1514,18 @@ var _ = Describe("Network Comparison Functions with Dual-Stack Support", func() 
 					{IP: "10.0.1.3"},
 				}
 				Expect(AreIngressVipsIdentical(n1, n2)).To(BeFalse())
+			})
+
+			It("should return true for dual-stack VIPs with non-canonical IPv6", func() {
+				n1 := []*models.IngressVip{
+					{IP: "10.0.1.3"},
+					{IP: "2620:0052:0009:164d:0000:0000:0000:0047"},
+				}
+				n2 := []*models.IngressVip{
+					{IP: "10.0.1.3"},
+					{IP: "2620:52:9:164d::47"},
+				}
+				Expect(AreIngressVipsIdentical(n1, n2)).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
Summary

  - Normalize IPv6 addresses to canonical form at all VIP ingestion points (controller, REST API, DHCP) and in VIP comparison functions
  - PostgreSQL's inet column auto-normalizes IPv6 (e.g. 2620:0052:0009:164d:0000:0000:0000:0046 → 2620:52:9:164d::46), but Go string comparison treated them as different, causing infinite reconciliation loops
  - Post-install, this blocked kubeconfig/kubeadmin secret creation entirely

  Changes

  - Added NormalizeIP() and ipsEqual() helpers in internal/network/utils.go
  - Updated AreApiVipsIdentical / AreIngressVipsIdentical to use inet-aware comparison
  - Normalized VIPs on ingestion in controller (common.go), REST API (inventory.go), DHCP path, and SetVipsData (cluster.go)
  - Normalized backwards-compat VIP comparisons in validations.go
  - Added unit tests covering expanded, leading-zero, mixed-case, and dual-stack IPv6 scenarios


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested). DB round-trip test - confirmed PostgreSQL normalizes IPv6 on storage regardless of input form — inserting canonical vs expanded produces identical DB values, so this fix has zero impact on stored data or downstream consumers.
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VIP handling to prevent spurious update triggers caused by different IP address formatting of semantically identical addresses.
  * Enhanced IPv6 address normalization to ensure consistent IP comparison and storage across cluster registration, validation, and DHCP operations.

* **Tests**
  * Extended test coverage for IPv6 VIP comparisons and address normalization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->