### PR TITLE
MGMT-24393: Fix IPv6 VIP comparison to handle non-canonical notation

### DIFF
--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -562,36 +562,43 @@ func AreClusterNetworksIdentical(n1, n2 []*models.ClusterNetwork) bool {
 	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].Cidr == n2[j].Cidr && n1[i].HostPrefix == n2[j].HostPrefix })
 }
 
+func ipsEqual(a, b models.IP) bool {
+	parsedA := net.ParseIP(string(a))
+	parsedB := net.ParseIP(string(b))
+	if parsedA == nil || parsedB == nil {
+		return a == b
+	}
+	return parsedA.Equal(parsedB)
+}
+
 func AreApiVipsIdentical(n1, n2 []*models.APIVip) bool {
 	if isDualStackItems(n1) && isDualStackItems(n2) {
-		// For dual-stack, order matters
 		if len(n1) != len(n2) {
 			return false
 		}
 		for i := 0; i < len(n1); i++ {
-			if n1[i].IP != n2[i].IP {
+			if !ipsEqual(n1[i].IP, n2[i].IP) {
 				return false
 			}
 		}
 		return true
 	}
-	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].IP == n2[j].IP })
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return ipsEqual(n1[i].IP, n2[j].IP) })
 }
 
 func AreIngressVipsIdentical(n1, n2 []*models.IngressVip) bool {
 	if isDualStackItems(n1) && isDualStackItems(n2) {
-		// For dual-stack, order matters
 		if len(n1) != len(n2) {
 			return false
 		}
 		for i := 0; i < len(n1); i++ {
-			if n1[i].IP != n2[i].IP {
+			if !ipsEqual(n1[i].IP, n2[i].IP) {
 				return false
 			}
 		}
 		return true
 	}
-	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].IP == n2[j].IP })
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return ipsEqual(n1[i].IP, n2[j].IP) })
 }
 
 func UpdateVipsTables(db *gorm.DB, cluster *common.Cluster, apiVipUpdated bool, ingressVipUpdated bool) error {

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -812,6 +812,40 @@ var _ = Describe("AreApiVipsIdentical", func() {
 			},
 			expectedResult: false,
 		},
+		{
+			name: "IPv6 expanded vs canonical notation",
+			n1: []*models.APIVip{
+				{IP: "fd9e:0001:0000:0000:0000:0000:0000:0bb8"},
+			},
+			n2: []*models.APIVip{
+				{IP: "fd9e:1::bb8"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Dual-stack with IPv6 expanded vs canonical",
+			n1: []*models.APIVip{
+				{IP: "172.20.5.100"},
+				{IP: "fd9e:0001:0000:0000:0000:0000:0000:0bb8"},
+			},
+			n2: []*models.APIVip{
+				{IP: "172.20.5.100"},
+				{IP: "fd9e:1::bb8"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Different IPv6 addresses with different notation",
+			n1: []*models.APIVip{
+				{IP: "172.20.5.100"},
+				{IP: "fd9e:0001:0000:0000:0000:0000:0000:0bb8"},
+			},
+			n2: []*models.APIVip{
+				{IP: "172.20.5.100"},
+				{IP: "fd9e:1::cc9"},
+			},
+			expectedResult: false,
+		},
 	}
 	for i := range tests {
 		t := tests[i]
@@ -929,6 +963,40 @@ var _ = Describe("AreIngressVipsIdentical", func() {
 				{
 					IP: "2.2.3.0",
 				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "IPv6 expanded vs canonical notation",
+			n1: []*models.IngressVip{
+				{IP: "fc00:0a23:0000:0000:0000:0000:0000:007f"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "fc00:a23::7f"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Dual-stack with IPv6 expanded vs canonical",
+			n1: []*models.IngressVip{
+				{IP: "10.35.72.5"},
+				{IP: "fc00:0a23:0000:0000:0000:0000:0000:007f"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "10.35.72.5"},
+				{IP: "fc00:a23::7f"},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Different IPv6 addresses with different notation",
+			n1: []*models.IngressVip{
+				{IP: "10.35.72.5"},
+				{IP: "fc00:0a23:0000:0000:0000:0000:0000:007f"},
+			},
+			n2: []*models.IngressVip{
+				{IP: "10.35.72.5"},
+				{IP: "fc00:a23::80"},
 			},
 			expectedResult: false,
 		},
@@ -1457,3 +1525,4 @@ var _ = Describe("Network Comparison Functions with Dual-Stack Support", func() 
 		})
 	})
 })
+


### PR DESCRIPTION
When an AgentClusterInstall specifies dual-stack API/Ingress VIPs using non-canonical (expanded) IPv6 notation (e.g. `fd9e:0001:0000:0000:0000:0000:0000:0bb8`), PostgreSQL normalizes it to canonical form (`fd9e:1::bb8`) on storage. The VIP comparison functions `AreApiVipsIdentical()` and `AreIngressVipsIdentical()` used direct string equality, so the spec value and DB value never matched — causing an infinite reconciliation loop.

**Fix:** Added an `ipsEqual()` helper that parses both IPs with `net.ParseIP()` before comparing, so both notations resolve to the same representation. Falls back to string comparison for unparseable values.

I have not tested the code, yet. To create an environment for that would take very long time. For an, in theory, easy fix. Maybe, just a review would be oka.

Code co-authored with Claude Code

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [MGMT-24393](https://issues.redhat.com/browse/MGMT-24393)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved IP address comparison logic to properly handle IPv6 addresses in different notation formats (expanded and canonical).
  * Enhanced dual-stack IPv6 configuration handling with more robust equivalence checking.

* **Tests**
  * Added comprehensive test coverage for IPv6 address equivalence scenarios and dual-stack configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->