### PR TITLE
MGMT-24443: watch configmap for CNI config update

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -37,10 +37,10 @@ function select_podman_client() {
   if [ "$(get_container_runtime_command)" = "podman-remote" ]; then
     if podman-remote4 info 2>&1 | grep "server API version is too old" &> /dev/null; then
       echo "using podman-remote version 3"
-      ln $(which podman-remote3) /tools/podman-remote
+      ln "$(command -v podman-remote3)" /tools/podman-remote
     else
       echo "using podman-remote version 4"
-      ln $(which podman-remote4) /tools/podman-remote
+      ln "$(command -v podman-remote4)" /tools/podman-remote
     fi
   fi
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -270,6 +270,9 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 
 		if err = r.addCustomManifests(ctx, log, clusterInstall, cluster); err != nil {
 			log.WithError(err).Error("failed to sync custom manifests")
+			// We decided to requeue with one minute timeout in order to give user a chance to fix manifest
+			// this timeout allows us not to run reconcile too much time and
+			// still have a nice feedback when user will fix the error
 			_, _ = r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
 			return ctrl.Result{RequeueAfter: longerRequeueAfterOnError}, nil
 		}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -92,6 +92,7 @@ const (
 const HighAvailabilityModeNone = "None"
 const defaultRequeueAfterOnError = 10 * time.Second
 const longerRequeueAfterOnError = 1 * time.Minute
+const ManifestConfigMapIndexField = "spec.manifestsConfigMapNames"
 
 // from https://github.com/openshift/hive/blob/04f2f4f8768b4d8aa413feb5dc5410b5f6e3dcfa/pkg/constants/constants.go#L153
 // not importing this code because it will create a lot of vendoring issues
@@ -264,6 +265,22 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
 	}
 
+	if !common.IsDay2Cluster(cluster) && r.Manifests != nil {
+		r.ensureManifestConfigMapsLabelled(ctx, log, clusterInstall)
+
+		if err = r.addCustomManifests(ctx, log, clusterInstall, cluster); err != nil {
+			log.WithError(err).Error("failed to sync custom manifests")
+			_, _ = r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
+			return ctrl.Result{RequeueAfter: longerRequeueAfterOnError}, nil
+		}
+	}
+
+	return r.reconcileExistingCluster(ctx, log, clusterDeployment, clusterInstall, cluster)
+}
+
+func (r *ClusterDeploymentsReconciler) reconcileExistingCluster(ctx context.Context, log logrus.FieldLogger,
+	clusterDeployment *hivev1.ClusterDeployment, clusterInstall *hiveext.AgentClusterInstall, cluster *common.Cluster) (ctrl.Result, error) {
+
 	// In case the Cluster is a Day 1 cluster and is installed, update the Metadata and create secrets for credentials
 	if *cluster.Status == models.ClusterStatusInstalled && swag.StringValue(cluster.Kind) == models.ClusterKindCluster {
 		return r.handleClusterInstalled(ctx, log, cluster, clusterInstall, clusterDeployment)
@@ -271,9 +288,9 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 
 	// Create Kubeconfig no-ingress if needed
 	if *cluster.Status == models.ClusterStatusInstalling || *cluster.Status == models.ClusterStatusFinalizing {
-		if err1 := r.createNoIngressKubeConfig(ctx, log, clusterDeployment, cluster, clusterInstall); err1 != nil {
-			log.WithError(err1).Error("failed to create kubeconfig no-ingress secret")
-			return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err1)
+		if err := r.createNoIngressKubeConfig(ctx, log, clusterDeployment, cluster, clusterInstall); err != nil {
+			log.WithError(err).Error("failed to create kubeconfig no-ingress secret")
+			return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
 		}
 	}
 
@@ -451,17 +468,6 @@ func (r *ClusterDeploymentsReconciler) installDay1(ctx context.Context, log logr
 	}
 
 	if ready {
-		// create custom manifests if needed before installation
-		err = r.addCustomManifests(ctx, log, clusterInstall, cluster)
-		if err != nil {
-			log.WithError(err).Error("failed to add custom manifests")
-			_, _ = r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
-			// We decided to requeue with one minute timeout in order to give user a chance to fix manifest
-			// this timeout allows us not to run reconcile too much time and
-			// still have a nice feedback when user will fix the error
-			return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
-		}
-
 		log.Infof("Installing clusterDeployment %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
 		var ic *common.Cluster
 		ic, err = r.Installer.InstallClusterInternal(ctx, installer.V2InstallClusterParams{
@@ -1445,6 +1451,42 @@ func (r *ClusterDeploymentsReconciler) getManifestConfigMap(ctx context.Context,
 	return configMap, nil
 }
 
+func (r *ClusterDeploymentsReconciler) ensureManifestConfigMapsLabelled(ctx context.Context, log logrus.FieldLogger,
+	clusterInstall *hiveext.AgentClusterInstall) {
+	for _, name := range getManifestConfigMapNames(clusterInstall) {
+		cm := &corev1.ConfigMap{}
+		key := types.NamespacedName{Namespace: clusterInstall.Namespace, Name: name}
+		if err := r.Get(ctx, key, cm); err != nil {
+			continue
+		}
+		if err := ensureConfigMapIsLabelled(ctx, r.Client, cm, key); err != nil {
+			log.WithError(err).Warnf("Failed to label manifest configmap %s", name)
+		}
+	}
+}
+
+func getManifestConfigMapNames(clusterInstall *hiveext.AgentClusterInstall) []string {
+	if clusterInstall.Spec.ManifestsConfigMapRefs != nil {
+		names := make([]string, 0, len(clusterInstall.Spec.ManifestsConfigMapRefs))
+		for _, ref := range clusterInstall.Spec.ManifestsConfigMapRefs {
+			names = append(names, ref.Name)
+		}
+		return names
+	}
+	if clusterInstall.Spec.ManifestsConfigMapRef != nil {
+		return []string{clusterInstall.Spec.ManifestsConfigMapRef.Name}
+	}
+	return nil
+}
+
+func indexManifestConfigMapNames(obj client.Object) []string {
+	aci, ok := obj.(*hiveext.AgentClusterInstall)
+	if !ok {
+		return nil
+	}
+	return getManifestConfigMapNames(aci)
+}
+
 func (r *ClusterDeploymentsReconciler) addCustomManifests(ctx context.Context, log logrus.FieldLogger,
 	clusterInstall *hiveext.AgentClusterInstall, cluster *common.Cluster) error {
 
@@ -1466,7 +1508,21 @@ func (r *ClusterDeploymentsReconciler) addCustomManifests(ctx context.Context, l
 		return nil
 	}
 
-	return r.syncManifests(ctx, log, cluster, clusterInstall, alreadyCreatedManifests)
+	err = r.syncManifests(ctx, log, cluster, clusterInstall, alreadyCreatedManifests)
+	if err != nil && len(alreadyCreatedManifests) > 0 {
+		// When sync fails (e.g. referenced ConfigMap was deleted), remove
+		// previously-synced manifests so the backend validation correctly
+		// detects their absence on the next reconcile cycle.
+		for _, manifest := range alreadyCreatedManifests {
+			log.Infof("Cleaning up manifest %s after sync failure", manifest.FileName)
+			_ = r.Manifests.DeleteClusterManifestInternal(ctx, operations.V2DeleteClusterManifestParams{
+				ClusterID: *cluster.ID,
+				FileName:  manifest.FileName,
+				Folder:    swag.String(models.ManifestFolderOpenshift),
+			})
+		}
+	}
+	return err
 }
 
 func CreateClusterParams(clusterDeployment *hivev1.ClusterDeployment, clusterInstall *hiveext.AgentClusterInstall,
@@ -1854,6 +1910,10 @@ func (r *ClusterDeploymentsReconciler) unbindAgents(ctx context.Context, log log
 }
 
 func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &hiveext.AgentClusterInstall{}, ManifestConfigMapIndexField, indexManifestConfigMapNames); err != nil {
+		return err
+	}
+
 	mapSecretToClusterDeployment := func(ctx context.Context, a client.Object) []reconcile.Request {
 		clusterDeployments := &hivev1.ClusterDeploymentList{}
 
@@ -1965,8 +2025,41 @@ func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&aiv1beta1.Agent{},
 			handler.EnqueueRequestsFromMapFunc(mapAgentToClusterDeployment),
 			agentSpecStatusChangedPredicate).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToClusterDeployment),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return obj.GetLabels()[WatchResourceLabel] == WatchResourceValue
+			}))).
 		WatchesRawSource(&source.Channel{Source: clusterDeploymentUpdates}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
+}
+
+func (r *ClusterDeploymentsReconciler) mapConfigMapToClusterDeployment(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := logutil.FromContext(ctx, r.Log).WithFields(logrus.Fields{
+		"configmap":           obj.GetName(),
+		"configmap_namespace": obj.GetNamespace(),
+	})
+
+	aciList := &hiveext.AgentClusterInstallList{}
+	if err := r.List(ctx, aciList,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{ManifestConfigMapIndexField: obj.GetName()}); err != nil {
+		log.WithError(err).Error("failed to list AgentClusterInstalls for ConfigMap mapper")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(aciList.Items))
+	for i := range aciList.Items {
+		aci := &aciList.Items[i]
+		log.Debugf("ConfigMap %s matches ACI %s, enqueueing ClusterDeployment %s",
+			obj.GetName(), aci.Name, aci.Spec.ClusterDeploymentRef.Name)
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: aci.Namespace,
+				Name:      aci.Spec.ClusterDeploymentRef.Name,
+			},
+		})
+	}
+	return requests
 }
 
 // updateStatus is updating all the AgentClusterInstall Conditions.

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
+	operations "github.com/openshift/assisted-service/restapi/operations/manifests"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/apis/hive/v1/aws"
 	"github.com/pkg/errors"
@@ -437,6 +438,7 @@ var _ = Describe("cluster reconcile", func() {
 		mockCRDEventsHandler           *MockCRDEventsHandler
 		mockVersions                   *versions.MockHandler
 		mockMirrorRegistries           *mirrorregistries.MockServiceMirrorRegistriesConfigBuilder
+		listManifestsHandler           func(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error)
 		defaultClusterSpec             hivev1.ClusterDeploymentSpec
 		clusterName                    = "test-cluster"
 		agentClusterInstallName        = "test-cluster-aci"
@@ -499,6 +501,13 @@ var _ = Describe("cluster reconcile", func() {
 		mockManifestsApi = manifestsapi.NewMockClusterManifestsInternals(mockCtrl)
 		mockVersions = versions.NewMockHandler(mockCtrl)
 		mockMirrorRegistries = mirrorregistries.NewMockServiceMirrorRegistriesConfigBuilder(mockCtrl)
+		listManifestsHandler = func(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error) {
+			return models.ListManifests{}, nil
+		}
+		mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error) {
+				return listManifestsHandler(ctx, params)
+			}).AnyTimes()
 		cr = &ClusterDeploymentsReconciler{
 			Client:                        c,
 			APIReader:                     c,
@@ -2113,7 +2122,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
@@ -2147,7 +2156,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2200,7 +2209,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2253,7 +2262,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2298,7 +2307,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2605,7 +2614,7 @@ var _ = Describe("cluster reconcile", func() {
 				Return(nil, errors.New(expectedErr))
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2951,9 +2960,8 @@ var _ = Describe("cluster reconcile", func() {
 			backEndCluster.Status = swag.String(models.ClusterStatusReady)
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -2963,7 +2971,7 @@ var _ = Describe("cluster reconcile", func() {
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
 			aci = getTestClusterInstall()
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterBackendErrorReason))
@@ -2992,11 +3000,9 @@ var _ = Describe("cluster reconcile", func() {
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, errors.New("error")).Times(1)
+			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, errors.Errorf("error")).Times(1)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleArbiter, true).Return(swag.Int64(0), nil).AnyTimes()
@@ -3008,7 +3014,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Update(ctx, aci)).Should(BeNil())
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
 			aci = getTestClusterInstall()
 			expectedState := fmt.Sprintf("%s %s", hiveext.ClusterBackendErrorMsg, "error")
@@ -3024,10 +3030,11 @@ var _ = Describe("cluster reconcile", func() {
 			ref := &corev1.LocalObjectReference{Name: "cluster-install-config"}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(nil, errors.New("error")).Times(1)
+			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
+			listManifestsHandler = func(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error) {
+				return nil, errors.Errorf("error")
+			}
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleArbiter, true).Return(swag.Int64(0), nil).AnyTimes()
@@ -3039,7 +3046,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Update(ctx, aci)).Should(BeNil())
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
 			aci = getTestClusterInstall()
 			expectedState := fmt.Sprintf("%s %s", hiveext.ClusterBackendErrorMsg, "error")
@@ -3071,7 +3078,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, nil).Times(1)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
@@ -3118,7 +3125,6 @@ var _ = Describe("cluster reconcile", func() {
 			By("no manifests")
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
@@ -3140,7 +3146,9 @@ var _ = Describe("cluster reconcile", func() {
 		It("Update manifests - delete old + error should be ignored", func() {
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{&models.Manifest{FileName: "test", Folder: "test"}, &models.Manifest{FileName: "test2", Folder: "test2"}}, nil).Times(1)
+			listManifestsHandler = func(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error) {
+				return models.ListManifests{&models.Manifest{FileName: "test", Folder: "test"}, &models.Manifest{FileName: "test2", Folder: "test2"}}, nil
+			}
 			mockManifestsApi.EXPECT().DeleteClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockManifestsApi.EXPECT().DeleteClusterManifestInternal(gomock.Any(), gomock.Any()).Return(errors.New("ignore it")).Times(1)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
@@ -3211,7 +3219,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, nil).Times(2)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
@@ -3279,9 +3287,8 @@ var _ = Describe("cluster reconcile", func() {
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
+
+			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -3294,7 +3301,7 @@ var _ = Describe("cluster reconcile", func() {
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
 			aci = getTestClusterInstall()
 			expectedState := fmt.Sprintf("%s Conflict in manifest names ('%s' is not unique)", hiveext.ClusterBackendErrorMsg, manifestName)
@@ -3342,9 +3349,8 @@ var _ = Describe("cluster reconcile", func() {
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
+
+			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
@@ -3357,7 +3363,7 @@ var _ = Describe("cluster reconcile", func() {
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
-			Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))
 
 			aci = getTestClusterInstall()
 			expectedState := fmt.Sprintf("%s configmaps \"%s\" not found", hiveext.ClusterBackendErrorMsg, configMapName1)
@@ -3376,7 +3382,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleMaster, true).Return(swag.Int64(3), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleWorker, true).Return(swag.Int64(2), nil).AnyTimes()
 			mockClusterApi.EXPECT().GetHostCountByRole(*backEndCluster.ID, models.HostRoleArbiter, true).Return(swag.Int64(0), nil).AnyTimes()
@@ -5544,5 +5550,165 @@ var _ = Describe("day2 cluster", func() {
 		result, err = cr.Reconcile(ctx, request)
 		Expect(err).To(BeNil())
 		Expect(result).To(Equal(ctrl.Result{}))
+	})
+})
+
+var _ = Describe("mapConfigMapToClusterDeployment", func() {
+	var (
+		c                    client.Client
+		cr                   *ClusterDeploymentsReconciler
+		ctx                  = context.Background()
+		mockCtrl             *gomock.Controller
+		mockCRDEventsHandler *MockCRDEventsHandler
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithStatusSubresource(&hiveext.AgentClusterInstall{}).
+			WithIndex(&hiveext.AgentClusterInstall{}, ManifestConfigMapIndexField, indexManifestConfigMapNames).
+			Build()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
+		cr = &ClusterDeploymentsReconciler{
+			Client:           c,
+			APIReader:        c,
+			Scheme:           scheme.Scheme,
+			Log:              common.GetTestLog(),
+			CRDEventsHandler: mockCRDEventsHandler,
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("enqueues ClusterDeployment when ConfigMap matches ManifestsConfigMapRefs", func() {
+		clusterName := "test-cd"
+		aciName := "test-aci"
+		cmName := "cni-manifests"
+
+		cd := newClusterDeployment(clusterName, testNamespace, getDefaultClusterDeploymentSpec(clusterName, aciName, "pull-secret"))
+		Expect(c.Create(ctx, cd)).ShouldNot(HaveOccurred())
+
+		aciSpec := getDefaultAgentClusterInstallSpec(clusterName)
+		aciSpec.ManifestsConfigMapRefs = []hiveext.ManifestsConfigMapReference{{Name: cmName}}
+		aci := newAgentClusterInstall(aciName, testNamespace, aciSpec, cd)
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: testNamespace,
+			},
+		}
+
+		requests := cr.mapConfigMapToClusterDeployment(ctx, cm)
+		Expect(requests).To(HaveLen(1))
+		Expect(requests[0].Name).To(Equal(clusterName))
+		Expect(requests[0].Namespace).To(Equal(testNamespace))
+	})
+
+	It("returns empty when ConfigMap does not match any ACI", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unrelated-configmap",
+				Namespace: testNamespace,
+			},
+		}
+
+		requests := cr.mapConfigMapToClusterDeployment(ctx, cm)
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("enqueues ClusterDeployment when ConfigMap matches deprecated ManifestsConfigMapRef", func() {
+		clusterName := "test-cd-legacy"
+		aciName := "test-aci-legacy"
+		cmName := "legacy-cni"
+
+		cd := newClusterDeployment(clusterName, testNamespace, getDefaultClusterDeploymentSpec(clusterName, aciName, "pull-secret"))
+		Expect(c.Create(ctx, cd)).ShouldNot(HaveOccurred())
+
+		aciSpec := getDefaultAgentClusterInstallSpec(clusterName)
+		aciSpec.ManifestsConfigMapRef = &corev1.LocalObjectReference{Name: cmName}
+		aci := newAgentClusterInstall(aciName, testNamespace, aciSpec, cd)
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: testNamespace,
+			},
+		}
+
+		requests := cr.mapConfigMapToClusterDeployment(ctx, cm)
+		Expect(requests).To(HaveLen(1))
+		Expect(requests[0].Name).To(Equal(clusterName))
+	})
+
+	It("enqueues multiple ClusterDeployments when ConfigMap is shared", func() {
+		cmName := "shared-cni"
+
+		cd1 := newClusterDeployment("cd-1", testNamespace, getDefaultClusterDeploymentSpec("cd-1", "aci-1", "pull-secret"))
+		Expect(c.Create(ctx, cd1)).ShouldNot(HaveOccurred())
+		aciSpec1 := getDefaultAgentClusterInstallSpec("cd-1")
+		aciSpec1.ManifestsConfigMapRefs = []hiveext.ManifestsConfigMapReference{{Name: cmName}}
+		aci1 := newAgentClusterInstall("aci-1", testNamespace, aciSpec1, cd1)
+		Expect(c.Create(ctx, aci1)).ShouldNot(HaveOccurred())
+
+		cd2 := newClusterDeployment("cd-2", testNamespace, getDefaultClusterDeploymentSpec("cd-2", "aci-2", "pull-secret"))
+		Expect(c.Create(ctx, cd2)).ShouldNot(HaveOccurred())
+		aciSpec2 := getDefaultAgentClusterInstallSpec("cd-2")
+		aciSpec2.ManifestsConfigMapRefs = []hiveext.ManifestsConfigMapReference{{Name: cmName}}
+		aci2 := newAgentClusterInstall("aci-2", testNamespace, aciSpec2, cd2)
+		Expect(c.Create(ctx, aci2)).ShouldNot(HaveOccurred())
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: testNamespace,
+			},
+		}
+
+		requests := cr.mapConfigMapToClusterDeployment(ctx, cm)
+		Expect(requests).To(HaveLen(2))
+		names := []string{requests[0].Name, requests[1].Name}
+		Expect(names).To(ContainElements("cd-1", "cd-2"))
+	})
+})
+
+var _ = Describe("indexManifestConfigMapNames", func() {
+	It("returns ConfigMap names from ManifestsConfigMapRefs", func() {
+		aci := &hiveext.AgentClusterInstall{
+			Spec: hiveext.AgentClusterInstallSpec{
+				ManifestsConfigMapRefs: []hiveext.ManifestsConfigMapReference{
+					{Name: "cm-a"},
+					{Name: "cm-b"},
+				},
+			},
+		}
+		result := indexManifestConfigMapNames(aci)
+		Expect(result).To(ConsistOf("cm-a", "cm-b"))
+	})
+
+	It("returns ConfigMap name from deprecated ManifestsConfigMapRef", func() {
+		aci := &hiveext.AgentClusterInstall{
+			Spec: hiveext.AgentClusterInstallSpec{
+				ManifestsConfigMapRef: &corev1.LocalObjectReference{Name: "legacy-cm"},
+			},
+		}
+		result := indexManifestConfigMapNames(aci)
+		Expect(result).To(ConsistOf("legacy-cm"))
+	})
+
+	It("returns nil when no ConfigMap refs are set", func() {
+		aci := &hiveext.AgentClusterInstall{}
+		result := indexManifestConfigMapNames(aci)
+		Expect(result).To(BeNil())
+	})
+
+	It("returns nil for non-ACI objects", func() {
+		cm := &corev1.ConfigMap{}
+		result := indexManifestConfigMapNames(cm)
+		Expect(result).To(BeNil())
 	})
 })

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -222,6 +222,8 @@ func (m *Manifests) DeleteClusterManifestInternal(ctx context.Context, params op
 		return err
 	}
 
+	// Unset feature usage if this was the last manifest. Don't fail on error
+	// because we successfully deleted the manifest as requested.
 	remaining, listErr := m.ListClusterManifestsInternal(ctx, operations.V2ListClusterManifestsParams{ClusterID: params.ClusterID})
 	if listErr != nil {
 		log.Errorf("Failed to check remaining manifests after deletion: %v", listErr)

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -99,6 +99,12 @@ func (m *Manifests) CreateClusterManifestInternal(ctx context.Context, params op
 		return nil, err
 	}
 
+	if isCustomManifest {
+		if usageErr := m.setUsage(true, params.ClusterID); usageErr != nil {
+			log.Errorf("Failed to set feature usage '%s': %v", usage.CustomManifest, usageErr)
+		}
+	}
+
 	log.Infof("Done creating manifest %s for cluster %s", path, params.ClusterID.String())
 	manifest := models.Manifest{FileName: fileName, Folder: folder, ManifestSource: manifestSource}
 	return &manifest, nil
@@ -214,6 +220,16 @@ func (m *Manifests) DeleteClusterManifestInternal(ctx context.Context, params op
 	err = m.deleteManifest(ctx, params.ClusterID, path)
 	if err != nil {
 		return err
+	}
+
+	remaining, listErr := m.ListClusterManifestsInternal(ctx, operations.V2ListClusterManifestsParams{ClusterID: params.ClusterID})
+	if listErr != nil {
+		log.Errorf("Failed to check remaining manifests after deletion: %v", listErr)
+	}
+	if listErr == nil && len(remaining) == 0 {
+		if usageErr := m.setUsage(false, params.ClusterID); usageErr != nil {
+			log.Errorf("Failed to unset feature usage '%s': %v", usage.CustomManifest, usageErr)
+		}
 	}
 
 	log.Infof("Done deleting cluster manifest %s for cluster %s", path, params.ClusterID.String())

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/manifests"
+	"github.com/openshift/assisted-service/internal/stream"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/filemiddleware"
@@ -744,6 +745,51 @@ invalid YAML content: {
 				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
 				Expect(err.Error()).To(Equal("Manifest content of file manifests/99-test.yml for cluster ID " + clusterID.String() + " has an invalid YAML format: yaml: line 4: did not find expected node content"))
 			})
+		})
+	})
+
+	Context("CreateClusterManifestInternal usage tracking", func() {
+		It("creating a non-custom manifest does not affect usage when custom manifests exist", func() {
+			mockNotifier := stream.NewMockNotifier(ctrl)
+			mockNotifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			realUsageAPI := usage.NewManager(common.GetTestLog(), mockNotifier)
+			manifestsWithRealUsage := manifests.NewManifestsAPI(db, common.GetTestLog(), mockS3Client, realUsageAPI)
+
+			clusterID := registerCluster().ID
+
+			mockUpload(2)
+			mockS3Client.EXPECT().DoesObjectExist(ctx, gomock.Any()).Return(false, nil).AnyTimes()
+
+			_, err := manifestsWithRealUsage.CreateClusterManifestInternal(ctx, operations.V2CreateClusterManifestParams{
+				ClusterID: *clusterID,
+				CreateManifestParams: &models.CreateManifestParams{
+					Content:  &contentYaml,
+					FileName: &fileNameYaml,
+				},
+			}, true)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cluster, err := common.GetClusterFromDB(db, *clusterID, common.SkipEagerLoading)
+			Expect(err).ShouldNot(HaveOccurred())
+			usages, err := usage.Unmarshal(cluster.Cluster.FeatureUsage)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(usages).To(HaveKey(usage.CustomManifest))
+
+			systemFile := "system-manifest.yaml"
+			_, err = manifestsWithRealUsage.CreateClusterManifestInternal(ctx, operations.V2CreateClusterManifestParams{
+				ClusterID: *clusterID,
+				CreateManifestParams: &models.CreateManifestParams{
+					Content:  &contentYaml,
+					FileName: &systemFile,
+				},
+			}, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cluster, err = common.GetClusterFromDB(db, *clusterID, common.SkipEagerLoading)
+			Expect(err).ShouldNot(HaveOccurred())
+			usages, err = usage.Unmarshal(cluster.Cluster.FeatureUsage)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(usages).To(HaveKey(usage.CustomManifest))
 		})
 	})
 

--- a/internal/manifests/manifests_v2.go
+++ b/internal/manifests/manifests_v2.go
@@ -5,21 +5,13 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/usage"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	operations "github.com/openshift/assisted-service/restapi/operations/manifests"
 )
 
 func (m *Manifests) V2CreateClusterManifest(ctx context.Context, params operations.V2CreateClusterManifestParams) middleware.Responder {
-	log := logutil.FromContext(ctx, m.log)
 	manifest, err := m.CreateClusterManifestInternal(ctx, params, true)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
-	}
-	err = m.setUsage(true, params.ClusterID)
-	if err != nil {
-		// We don't want to return the error - the requested manifest was set successfully,  setting the feature usage failed.
-		log.Errorf("Failed to set feature usage '%s' Error: %v. Manifest %v created by user successfully.", usage.CustomManifest, err, manifest)
 	}
 	return operations.NewV2CreateClusterManifestCreated().WithPayload(manifest)
 }
@@ -41,24 +33,9 @@ func (m *Manifests) V2ListClusterManifests(ctx context.Context, params operation
 }
 
 func (m *Manifests) V2DeleteClusterManifest(ctx context.Context, params operations.V2DeleteClusterManifestParams) middleware.Responder {
-	log := logutil.FromContext(ctx, m.log)
 	err := m.DeleteClusterManifestInternal(ctx, params)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}
-
-	// Unset feature usage if this was the last manifest. Don't fail on error because we successfully deleted the manifest as requested.
-	manifests, err := m.ListClusterManifestsInternal(ctx, operations.V2ListClusterManifestsParams{ClusterID: params.ClusterID})
-	if err != nil {
-		log.Errorf("Failed to unset feature usage '%s' Error: %v. Manifest %v deleted by user successfully.", usage.CustomManifest, err, params.FileName)
-	} else {
-		if len(manifests) == 0 {
-			err = m.setUsage(false, params.ClusterID)
-			if err != nil {
-				log.Errorf("Failed to unset feature usage '%s' Error: %v. Manifest %v deleted by user successfully.", usage.CustomManifest, err, params.FileName)
-			}
-		}
-	}
-
 	return operations.NewV2DeleteClusterManifestOK()
 }

--- a/subsystem/kubeapi/kubeapi_test.go
+++ b/subsystem/kubeapi/kubeapi_test.go
@@ -5341,6 +5341,64 @@ spec:
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterAlreadyInstallingReason)
 	})
 
+	It("ConfigMap delete and recreate triggers re-validation of custom manifests", func() {
+		By("Create SNO cluster with Cilium network type, ConfigMap ref, and hold installation")
+		configMapName := "cni-manifests"
+		aciSNOSpec.Networking.NetworkType = models.ClusterNetworkTypeCilium
+		aciSNOSpec.ManifestsConfigMapRefs = []hiveext.ManifestsConfigMapReference{{Name: configMapName}}
+		aciSNOSpec.HoldInstallation = true
+
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSNOSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		infraEnvKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
+		configureLocalAgentClient(infraEnv.ID.String())
+		host := utils_test.TestContext.RegisterNode(ctx, *infraEnv.ID, "hostname1", utils_test.DefaultCIDRv4)
+		ips := hostutil.GenerateIPv4Addresses(1, utils_test.DefaultCIDRv4)
+		utils_test.TestContext.GenerateFullMeshConnectivity(ctx, ips[0], host)
+		key := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      host.ID.String(),
+		}
+		utils_test.TestContext.GenerateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		By("Approve Agent")
+		Eventually(func() error {
+			agent := getAgentCRD(ctx, kubeClient, key)
+			agent.Spec.Approved = true
+			return kubeClient.Update(ctx, agent)
+		}, "30s", "10s").Should(BeNil())
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+
+		By("Without ConfigMap, validation should fail for custom manifests")
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterValidatedCondition, hiveext.ClusterValidationsFailingReason)
+
+		By("Create ConfigMap with manifest data — cluster should become ready (held)")
+		content := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: cilium`
+		cm := deployOrUpdateConfigMap(ctx, kubeClient, configMapName, map[string]string{"cilium-ns.yaml": content})
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterReadyReason)
+
+		By("Delete ConfigMap — validation should fail again")
+		Expect(kubeClient.Delete(ctx, cm)).To(BeNil())
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterValidatedCondition, hiveext.ClusterValidationsFailingReason)
+
+		By("Recreate ConfigMap — cluster should become ready again")
+		cm = deployOrUpdateConfigMap(ctx, kubeClient, configMapName, map[string]string{"cilium-ns.yaml": content})
+		defer func() {
+			_ = kubeClient.Delete(ctx, cm)
+		}()
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterReadyReason)
+	})
+
 	It("delete agent and validate host deregistration", func() {
 		By("Deploy SNO cluster")
 		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)


### PR DESCRIPTION
This solves issue [MGMT-24443](https://redhat.atlassian.net/browse/MGMT-24443).
When creating custom manifest for the CNI and the config fails, deleting the config and reapplying has no effect, as its value is never refreshed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sync and lifecycle handling of custom manifests via ConfigMaps; clusters update validation/usage when ConfigMaps change.
  * Per-cluster toggle for custom-manifest usage.

* **Chores**
  * Build tooling and helper scripts improved for more reliable builds and environment detection (tool install/version bump and improved client detection).

* **Documentation**
  * Commit guidance updated to require AI-assistance attribution in assisted commits.

* **Tests**
  * New tests covering ConfigMap-driven manifest validation, mapping, and reconciliation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->