### PR TITLE
OCPEDGE-2692: feat: support MAC address fencing credentials in ABI flow

### DIFF
--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -48,6 +48,7 @@ func loadFencingCredentials(fencingFilePath string) (map[string]*models.FencingC
 	type fencingCredentialsFile struct {
 		Credentials []struct {
 			Hostname                string  `yaml:"hostname"`
+			MACAddress              string  `yaml:"macaddress"`
 			Address                 *string `yaml:"address"`
 			Username                *string `yaml:"username"`
 			Password                *string `yaml:"password"`
@@ -63,17 +64,24 @@ func loadFencingCredentials(fencingFilePath string) (map[string]*models.FencingC
 	credentialsMap := make(map[string]*models.FencingCredentialsParams)
 
 	for _, cred := range fcFile.Credentials {
-		if cred.Hostname == "" {
-			log.Warn("Skipping fencing credential with empty hostname")
+		if cred.Hostname == "" && cred.MACAddress == "" {
+			log.Warn("Skipping fencing credential with empty hostname and MAC address")
 			continue
 		}
-		credentialsMap[cred.Hostname] = &models.FencingCredentialsParams{
+		var key string
+		if cred.Hostname != "" {
+			key = cred.Hostname
+		} else {
+			key = cred.MACAddress
+		}
+
+		credentialsMap[key] = &models.FencingCredentialsParams{
 			Address:                 cred.Address,
 			Username:                cred.Username,
 			Password:                cred.Password,
 			CertificateVerification: cred.CertificateVerification,
 		}
-		log.Infof("Loaded fencing credential for hostname: %s", cred.Hostname)
+		log.Infof("Loaded fencing credential for key: %s", key)
 	}
 
 	log.Infof("Loaded %d fencing credentials from file", len(credentialsMap))
@@ -438,8 +446,8 @@ func (hc hostConfig) Role() (*string, error) {
 }
 
 func (hc hostConfig) FencingCredentials() (*models.FencingCredentialsParams, error) {
-	// Only hostname-based configs have fencing credentials
-	if hc.hostname == "" {
+	// Only hostname-based or MAC based configs have fencing credentials
+	if hc.hostname == "" && len(hc.macAddresses) == 0 {
 		return nil, nil
 	}
 
@@ -451,7 +459,17 @@ func (hc hostConfig) FencingCredentials() (*models.FencingCredentialsParams, err
 		return nil, nil
 	}
 
-	return creds[hc.hostname], nil
+	// lookup by hostname if present
+	if hc.hostname != "" {
+		return creds[hc.hostname], nil
+	}
+	// otherwise by MAC address
+	for _, macAddress := range hc.macAddresses {
+		if _, ok := creds[macAddress]; ok {
+			return creds[macAddress], nil
+		}
+	}
+	return nil, nil
 }
 
 type HostConfigs []*hostConfig

--- a/cmd/agentbasedinstaller/host_config_test.go
+++ b/cmd/agentbasedinstaller/host_config_test.go
@@ -200,6 +200,89 @@ var _ = Describe("loadFencingCredentials", func() {
 		})
 	})
 
+	Context("when fencing-credentials.yaml has MAC-only entries", func() {
+		It("should parse and key credentials by MAC address", func() {
+			content := `credentials:
+- macaddress: aa:bb:cc:dd:ee:01
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+  certificateVerification: Disabled
+- macaddress: aa:bb:cc:dd:ee:02
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/def
+  username: admin2
+  password: password456
+  certificateVerification: Enabled
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			creds, err := loadFencingCredentials(filepath.Join(tempDir, "fencing-credentials.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds).To(HaveLen(2))
+
+			Expect(creds).To(HaveKey("aa:bb:cc:dd:ee:01"))
+			Expect(*creds["aa:bb:cc:dd:ee:01"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
+			Expect(*creds["aa:bb:cc:dd:ee:01"].Username).To(Equal("admin"))
+			Expect(*creds["aa:bb:cc:dd:ee:01"].Password).To(Equal("password123"))
+			Expect(*creds["aa:bb:cc:dd:ee:01"].CertificateVerification).To(Equal("Disabled"))
+
+			Expect(creds).To(HaveKey("aa:bb:cc:dd:ee:02"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/def"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].Username).To(Equal("admin2"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].Password).To(Equal("password456"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].CertificateVerification).To(Equal("Enabled"))
+		})
+	})
+
+	Context("when fencing-credentials.yaml has mixed hostname and MAC entries", func() {
+		It("should key by hostname when present, by MAC when hostname is absent", func() {
+			content := `credentials:
+- hostname: master-0
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+  certificateVerification: Disabled
+- macaddress: aa:bb:cc:dd:ee:02
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/def
+  username: admin2
+  password: password456
+  certificateVerification: Enabled
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			creds, err := loadFencingCredentials(filepath.Join(tempDir, "fencing-credentials.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds).To(HaveLen(2))
+
+			Expect(creds).To(HaveKey("master-0"))
+			Expect(*creds["master-0"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
+
+			Expect(creds).To(HaveKey("aa:bb:cc:dd:ee:02"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/def"))
+		})
+
+		It("should prefer hostname over MAC when both are present on same entry", func() {
+			content := `credentials:
+- hostname: master-0
+  macaddress: aa:bb:cc:dd:ee:01
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			creds, err := loadFencingCredentials(filepath.Join(tempDir, "fencing-credentials.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds).To(HaveLen(1))
+
+			Expect(creds).To(HaveKey("master-0"))
+			Expect(creds).NotTo(HaveKey("aa:bb:cc:dd:ee:01"))
+		})
+	})
+
 	Context("YAML round-trip compatibility with installer output", func() {
 		It("should correctly parse installer-generated YAML format", func() {
 			// This YAML matches the exact format the installer produces
@@ -259,12 +342,126 @@ var _ = Describe("applyFencingCredentials", func() {
 		}
 	})
 
-	Context("when config has no fencing credentials (MAC-based config)", func() {
+	Context("when config has neither hostname nor MAC addresses", func() {
+		It("should return false without attempting to load credentials", func() {
+			testLogger, _ := test.NewNullLogger()
+			host := &models.Host{}
+			config := &hostConfig{
+				configDir: tempDir,
+			}
+			updateParams := &models.HostUpdateParams{}
+
+			applied, err := applyFencingCredentials(testLogger, host, config, updateParams)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeFalse())
+			Expect(updateParams.FencingCredentials).To(BeNil())
+		})
+	})
+
+	Context("when config has no fencing credentials file", func() {
 		It("should return false without modifying updateParams", func() {
 			testLogger, _ := test.NewNullLogger()
 			host := &models.Host{}
 			config := &hostConfig{
-				// MAC-based config - no hostname means FencingCredentials() returns nil
+				configDir:    tempDir,
+				macAddresses: []string{"aa:bb:cc:dd:ee:ff"},
+			}
+			updateParams := &models.HostUpdateParams{}
+
+			applied, err := applyFencingCredentials(testLogger, host, config, updateParams)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeFalse())
+			Expect(updateParams.FencingCredentials).To(BeNil())
+		})
+	})
+
+	Context("when fencing credentials file is corrupt", func() {
+		It("should return error", func() {
+			content := `not valid yaml: [[[`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			testLogger, _ := test.NewNullLogger()
+			host := &models.Host{}
+			config := &hostConfig{
+				configDir: tempDir,
+				hostname:  "master-0",
+			}
+			updateParams := &models.HostUpdateParams{}
+
+			applied, err := applyFencingCredentials(testLogger, host, config, updateParams)
+			Expect(err).To(HaveOccurred())
+			Expect(applied).To(BeFalse())
+		})
+	})
+
+	Context("when MAC-based config has matching fencing credentials", func() {
+		It("should set fencing credentials and return true", func() {
+			content := `credentials:
+- macaddress: aa:bb:cc:dd:ee:ff
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password
+  certificateVerification: Disabled
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			testLogger, _ := test.NewNullLogger()
+			host := &models.Host{}
+			config := &hostConfig{
+				configDir:    tempDir,
+				macAddresses: []string{"aa:bb:cc:dd:ee:ff"},
+			}
+			updateParams := &models.HostUpdateParams{}
+
+			applied, err := applyFencingCredentials(testLogger, host, config, updateParams)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
+			Expect(updateParams.FencingCredentials).NotTo(BeNil())
+			Expect(*updateParams.FencingCredentials.Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
+			Expect(*updateParams.FencingCredentials.Username).To(Equal("admin"))
+			Expect(*updateParams.FencingCredentials.Password).To(Equal("password"))
+			Expect(*updateParams.FencingCredentials.CertificateVerification).To(Equal("Disabled"))
+		})
+
+		It("should match using second MAC address when first does not match", func() {
+			content := `credentials:
+- macaddress: 11:22:33:44:55:66
+  address: redfish+https://192.168.111.2:8000/redfish/v1/Systems/xyz
+  username: admin
+  password: password
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			testLogger, _ := test.NewNullLogger()
+			host := &models.Host{}
+			config := &hostConfig{
+				configDir:    tempDir,
+				macAddresses: []string{"aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"},
+			}
+			updateParams := &models.HostUpdateParams{}
+
+			applied, err := applyFencingCredentials(testLogger, host, config, updateParams)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
+			Expect(*updateParams.FencingCredentials.Address).To(Equal("redfish+https://192.168.111.2:8000/redfish/v1/Systems/xyz"))
+		})
+
+		It("should return false when no MAC address matches", func() {
+			content := `credentials:
+- macaddress: 99:99:99:99:99:99
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password
+`
+			err := os.WriteFile(filepath.Join(tempDir, "fencing-credentials.yaml"), []byte(content), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			testLogger, _ := test.NewNullLogger()
+			host := &models.Host{}
+			config := &hostConfig{
 				configDir:    tempDir,
 				macAddresses: []string{"aa:bb:cc:dd:ee:ff"},
 			}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fencing credentials now support both hostname and MAC-address lookups; hostname entries take precedence, otherwise credentials are matched by MAC. Entries missing both fields are ignored.

* **Tests**
  * Expanded coverage for loading and applying fencing credentials: MAC-only entries, mixed hostname/MAC precedence, missing or corrupt credential data, and multiple-MAC matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->