### PR TITLE
MGMT-24457: Add MI350P PCI device IDs to NFD NodeFeatureRule

### DIFF
--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_gpu_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_gpu_rule.yaml
@@ -16,6 +16,7 @@ spec:
           op: In
           value:
           - "75a3" # MI355X
+          - "75a8" # MI350P
           - "75a0" # MI350X
           - "74a5" # MI325X
           - "74a2" # MI308X

--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_vgpu_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_vgpu_rule.yaml
@@ -16,6 +16,7 @@ spec:
           op: In
           value:
           - "75b3" # MI355X VF
+          - "75b8" # MI350P VF
           - "75b0" # MI350X VF
           - "74b9" # MI325X VF
           - "74b6" # MI308X VF


### PR DESCRIPTION
## Summary

- Add AMD Instinct MI350P PCIe GPU PCI device IDs to the NFD NodeFeatureRules so the Assisted Installer correctly detects MI350P GPUs during host discovery
- `75a8` (MI350P PF) added to `amd_gpu_rule.yaml`
- `75b8` (MI350P VF) added to `amd_vgpu_rule.yaml`

Ref: https://www.amd.com/en/blogs/2026/amd-instinct-mi350p-pcie-gpus-run-enterprise-ai-on-your.html

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for AMD MI350P and MI350P VF GPU devices for improved hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->