### PR TITLE
ACM-34415: Copy master providerSpec for Day 2 spoke Machine creation

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1218,14 +1218,13 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 		return reconcileError{err: err}
 	}
 
-	checksum, url, err, stopReconcileLoop := r.getChecksumAndURL(ctx, spokeClient)
+	masterProviderSpec, stopLoop, err := r.getMasterProviderSpec(ctx, spokeClient)
 	if err != nil {
-		log.WithError(err).Errorf("failed to get checksum and url value from master spoke machine")
-		if stopReconcileLoop {
-			log.Debug("Stopping reconcileDay2SpokeBMH")
-			return reconcileComplete{stop: stopReconcileLoop}
+		if stopLoop {
+			log.WithError(err).Errorf("failed to get providerSpec from master spoke machine")
+			return reconcileComplete{stop: true}
 		}
-		return reconcileError{err: err}
+		log.WithError(err).Warnf("could not get providerSpec from existing master machine, using minimal fallback")
 	}
 
 	machineNSName := types.NamespacedName{
@@ -1239,7 +1238,7 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 		return reconcileError{err: err}
 	}
 
-	_, err = r.ensureSpokeMachine(ctx, log, spokeClient, bmh, cd, machineNSName, checksum, url, string(agent.Status.Role))
+	_, err = r.ensureSpokeMachine(ctx, log, spokeClient, bmh, cd, machineNSName, masterProviderSpec, string(agent.Status.Role))
 	if err != nil {
 		log.WithError(err).Errorf("failed to create or update spoke Machine")
 		return reconcileError{err: err}
@@ -1445,47 +1444,25 @@ func (r *BMACReconciler) ensureSpokeBMH(ctx context.Context, log logrus.FieldLog
 	return bmhSpoke, nil
 }
 
-// get spokeMachineMaster and retrieve checksum , url to set into spokeMachineWorker
-func (r *BMACReconciler) getChecksumAndURL(ctx context.Context, spokeClient client.Client) (string, string, error, bool) {
-	var checksum, url string
+// getMasterProviderSpec retrieves the full providerSpec from an existing master
+// Machine on the spoke. This is used as the template for new Day 2 Machines,
+// ensuring the new Machine has the same platform configuration (including
+// customDeploy, image, hostSelector, etc.) as existing masters.
+// The boolean return indicates whether reconciliation should stop (fatal).
+func (r *BMACReconciler) getMasterProviderSpec(ctx context.Context, spokeClient client.Client) (*runtime.RawExtension, bool, error) {
 	machineList := &machinev1beta1.MachineList{}
 	err := spokeClient.List(ctx, machineList, client.MatchingLabels{MACHINE_TYPE: string(models.HostRoleMaster)})
 	if err != nil {
-		return checksum, url, err, false
+		return nil, false, err
 	}
-	//MGMT-10570 check that the master list is not empty before referencing it
-	//Stop the reconciliation in this case because it is a fatal error
 	if len(machineList.Items) == 0 {
-		return checksum, url, errors.New("There are no machines with master label"), true
+		return nil, true, errors.New("no machines with master label found on spoke")
 	}
-
-	providerSpec := machineList.Items[0].Spec.ProviderSpec.Value
-	if providerSpec == nil {
-		return checksum, url, errors.New("master machine has nil ProviderSpec"), false
-	}
-
-	var providerSpecValueObj map[string]interface{}
-	if err = json.Unmarshal(providerSpec.Raw, &providerSpecValueObj); err != nil {
-		return checksum, url, err, false
-	}
-
-	imageRaw, ok := providerSpecValueObj["image"]
-	if !ok || imageRaw == nil {
-		return checksum, url, errors.New("master machine ProviderSpec missing 'image' field"), false
-	}
-	image, ok := imageRaw.(map[string]interface{})
-	if !ok {
-		return checksum, url, errors.New("master machine ProviderSpec 'image' field has unexpected type"), false
-	}
-
-	checksum, _ = image["checksum"].(string)
-	url, _ = image["url"].(string)
-
-	return checksum, url, nil, false
+	return machineList.Items[0].Spec.ProviderSpec.Value, false, nil
 }
 
-func (r *BMACReconciler) ensureSpokeMachine(ctx context.Context, log logrus.FieldLogger, spokeClient client.Client, bmh *bmh_v1alpha1.BareMetalHost, clusterDeployment *hivev1.ClusterDeployment, machineName types.NamespacedName, checksum, URL, role string) (*machinev1beta1.Machine, error) {
-	machineSpoke, mutateFn := r.newSpokeMachine(bmh, clusterDeployment, machineName, checksum, URL, role)
+func (r *BMACReconciler) ensureSpokeMachine(ctx context.Context, log logrus.FieldLogger, spokeClient client.Client, bmh *bmh_v1alpha1.BareMetalHost, clusterDeployment *hivev1.ClusterDeployment, machineName types.NamespacedName, masterProviderSpec *runtime.RawExtension, role string) (*machinev1beta1.Machine, error) {
+	machineSpoke, mutateFn := r.newSpokeMachine(bmh, clusterDeployment, machineName, masterProviderSpec, role)
 	if result, err := controllerutil.CreateOrUpdate(ctx, spokeClient, machineSpoke, mutateFn); err != nil {
 		return nil, err
 	} else if result != controllerutil.OperationResultNone {
@@ -1655,7 +1632,7 @@ func (r *BMACReconciler) newSpokeBMH(log logrus.FieldLogger, bmh *bmh_v1alpha1.B
 	return bmhSpoke, mutateFn
 }
 
-func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, clusterDeployment *hivev1.ClusterDeployment, machineName types.NamespacedName, checksum, URL, role string) (*machinev1beta1.Machine, controllerutil.MutateFn) {
+func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, clusterDeployment *hivev1.ClusterDeployment, machineName types.NamespacedName, masterProviderSpec *runtime.RawExtension, role string) (*machinev1beta1.Machine, controllerutil.MutateFn) {
 	machine := &machinev1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName.Name,
@@ -1665,37 +1642,13 @@ func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, cluste
 	mutateFn := func() error {
 		setAnnotation(&machine.ObjectMeta, BMH_ANNOTATION, fmt.Sprintf("%s/%s", OPENSHIFT_MACHINE_API_NAMESPACE, bmh.Name))
 
-		providerSpecValueFormat := `{
-						"apiVersion": "{{.BMH_API_VERSION}}",
-						"kind": "BareMetalMachineProviderSpec",
-						"image": {
-						"checksum": "{{.CHECKSUM}}",
-						"url": "{{.URL}}"
-						}}`
-
-		tmpl, err := template.New("valueString").Parse(providerSpecValueFormat)
-		if err != nil {
-			return err
-		}
-		buf := &bytes.Buffer{}
-		var providerSpecValue = map[string]interface{}{
-			"BMH_API_VERSION": BMH_API_VERSION,
-			"CHECKSUM":        checksum,
-			"URL":             URL,
-		}
-		if err = tmpl.Execute(buf, providerSpecValue); err != nil {
-			return err
+		if masterProviderSpec != nil {
+			machine.Spec.ProviderSpec.Value = masterProviderSpec
+		} else {
+			fallback := fmt.Sprintf(`{"apiVersion":"%s","kind":"BareMetalMachineProviderSpec","image":{"checksum":"","url":""}}`, BMH_API_VERSION)
+			machine.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: []byte(fallback)}
 		}
 
-		machine.Spec = machinev1beta1.MachineSpec{
-			ProviderSpec: machinev1beta1.ProviderSpec{
-				Value: &runtime.RawExtension{
-					Raw: buf.Bytes(),
-				},
-			},
-		}
-
-		// Setting the same labels as the rest of the machines in the spoke cluster
 		machine.Labels = AddLabel(machine.Labels, machinev1beta1.MachineClusterIDLabel, clusterDeployment.Name)
 		machine.Labels = AddLabel(machine.Labels, MACHINE_ROLE, role)
 		machine.Labels = AddLabel(machine.Labels, MACHINE_TYPE, role)

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -4383,7 +4383,7 @@ var _ = Describe("handleBMHFinalizer", func() {
 	})
 })
 
-var _ = Describe("getChecksumAndURL", func() {
+var _ = Describe("getMasterProviderSpec", func() {
 	var (
 		bmhr        *BMACReconciler
 		spokeClient client.Client
@@ -4410,69 +4410,70 @@ var _ = Describe("getChecksumAndURL", func() {
 		Expect(spokeClient.Create(ctx, m)).To(Succeed())
 	}
 
-	It("returns error when no master machines exist", func() {
-		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+	It("returns error and stops reconciliation when no master machines exist", func() {
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
 		Expect(err).To(HaveOccurred())
-		Expect(stop).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("no machines with master label"))
+		Expect(stopLoop).To(BeTrue())
+		Expect(result).To(BeNil())
 	})
 
-	It("returns error when ProviderSpec.Value is nil", func() {
+	It("returns nil providerSpec (no error) when ProviderSpec.Value is nil", func() {
 		createMasterMachine(nil)
-		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("nil ProviderSpec"))
-		Expect(stop).To(BeFalse())
-	})
-
-	It("returns error when image field is null", func() {
-		createMasterMachine([]byte(`{"image": null}`))
-		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("missing 'image' field"))
-		Expect(stop).To(BeFalse())
-	})
-
-	It("returns error when image field is absent", func() {
-		createMasterMachine([]byte(`{}`))
-		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("missing 'image' field"))
-		Expect(stop).To(BeFalse())
-	})
-
-	It("returns error when image field is not a map", func() {
-		createMasterMachine([]byte(`{"image": "not-a-map"}`))
-		_, _, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("unexpected type"))
-		Expect(stop).To(BeFalse())
-	})
-
-	It("returns empty strings when checksum is missing (valid for customDeploy)", func() {
-		createMasterMachine([]byte(`{"image": {"url": "http://example.com/image"}}`))
-		checksum, url, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stop).To(BeFalse())
-		Expect(checksum).To(Equal(""))
-		Expect(url).To(Equal("http://example.com/image"))
+		Expect(stopLoop).To(BeFalse())
+		Expect(result).To(BeNil())
 	})
 
-	It("returns empty strings when url is missing (valid for customDeploy)", func() {
-		createMasterMachine([]byte(`{"image": {"checksum": "abc123"}}`))
-		checksum, url, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+	It("returns full providerSpec for assisted-install cluster (customDeploy, empty image)", func() {
+		spec := []byte(`{"apiVersion":"baremetal.cluster.k8s.io/v1alpha1","kind":"BareMetalMachineProviderSpec","customDeploy":{"method":"install_coreos"},"image":{"checksum":"","url":""}}`)
+		createMasterMachine(spec)
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stop).To(BeFalse())
-		Expect(checksum).To(Equal("abc123"))
-		Expect(url).To(Equal(""))
+		Expect(stopLoop).To(BeFalse())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Raw).To(Equal(spec))
 	})
 
-	It("returns checksum and url when both are present", func() {
-		createMasterMachine([]byte(`{"image": {"checksum": "abc123", "url": "http://example.com/image"}}`))
-		checksum, url, err, stop := bmhr.getChecksumAndURL(ctx, spokeClient)
+	It("returns full providerSpec for IPI cluster (populated image)", func() {
+		spec := []byte(`{"apiVersion":"baremetal.cluster.k8s.io/v1alpha1","kind":"BareMetalMachineProviderSpec","image":{"checksum":"abc123","url":"http://example.com/image.raw.gz"}}`)
+		createMasterMachine(spec)
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stop).To(BeFalse())
-		Expect(checksum).To(Equal("abc123"))
-		Expect(url).To(Equal("http://example.com/image"))
+		Expect(stopLoop).To(BeFalse())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Raw).To(Equal(spec))
+	})
+
+	It("returns providerSpec even when image field is absent", func() {
+		spec := []byte(`{"apiVersion":"baremetal.cluster.k8s.io/v1alpha1","kind":"BareMetalMachineProviderSpec","customDeploy":{"method":"install_coreos"}}`)
+		createMasterMachine(spec)
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopLoop).To(BeFalse())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Raw).To(Equal(spec))
+	})
+
+	It("returns providerSpec from first master when multiple masters exist", func() {
+		spec1 := []byte(`{"apiVersion":"baremetal.cluster.k8s.io/v1alpha1","kind":"BareMetalMachineProviderSpec","image":{"checksum":"first","url":"http://first"}}`)
+		createMasterMachine(spec1)
+		m2 := &machinev1beta1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "master-1",
+				Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
+				Labels:    map[string]string{MACHINE_TYPE: string(models.HostRoleMaster)},
+			},
+		}
+		spec2 := []byte(`{"apiVersion":"baremetal.cluster.k8s.io/v1alpha1","kind":"BareMetalMachineProviderSpec","image":{"checksum":"second","url":"http://second"}}`)
+		m2.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: spec2}
+		Expect(spokeClient.Create(ctx, m2)).To(Succeed())
+
+		result, stopLoop, err := bmhr.getMasterProviderSpec(ctx, spokeClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopLoop).To(BeFalse())
+		Expect(result).ToNot(BeNil())
 	})
 })
 


### PR DESCRIPTION
## Problem

Day 2 master expansion fails on assisted-installed baremetal clusters. `getChecksumAndURL` returns errors when existing master Machines have nil/missing/empty `providerSpec.image` — the normal state on these clusters where OS is delivered via agent boot (`customDeploy: install_coreos`), not Ironic image provisioning.

Additionally, `newSpokeMachine` used a hardcoded Go template that produced a minimal providerSpec with only `image.checksum` and `image.url`, missing critical fields like `customDeploy` that the machine-controller needs to reconcile the new Machine.

## Root Cause

PR #10164 ([ACM-32996](https://redhat.atlassian.net/browse/ACM-32996)) added strict validation rejecting nil/empty image fields. The deeper issue is that the code extracted only 2 fields from an existing master and re-templated a lossy subset instead of copying the full known-good providerSpec.

## Fix

Replace `getChecksumAndURL` with `getMasterProviderSpec` — returns the full `*runtime.RawExtension` from an existing master Machine. `newSpokeMachine` now assigns this directly instead of templating.

**Why this approach over alternatives:**

| Approach | Problem |
|----------|---------|
| Suppress error, proceed with empty values | Machine created without `customDeploy` → machine-controller can't reconcile → stuck |
| Rewrite extraction with customDeploy detection | Same incomplete providerSpec, just quieter logs |
| **Copy full providerSpec (this PR)** | **New Machine is identical to existing masters → reconciles correctly end-to-end** |

## Behavioral equivalence

| Scenario | Before | After |
|----------|--------|-------|
| No master Machines (fatal) | Stop reconciliation | Stop reconciliation (**preserved**) |
| IPI baremetal (image populated) | Template minimal spec | Copy full spec (superset — better) |
| Assisted-install (empty image + customDeploy) | Error → abort → no Machine | Copy full spec → Machine works |
| Nil providerSpec | Error → infinite retry | Warn → minimal fallback → proceed |

## Changes

- `getChecksumAndURL` → removed
- `getMasterProviderSpec` → new (returns `*runtime.RawExtension, bool, error`)
- `newSpokeMachine` → accepts `*runtime.RawExtension`, assigns directly or uses minimal fallback
- Fatal stop for "no masters" ([MGMT-10570](https://redhat.atlassian.net/browse/MGMT-10570)) preserved via `stopLoop` boolean

**Stats:** 2 files, +73/-119 lines

## Test plan

- [x] Unit tests updated: 6 new test cases for `getMasterProviderSpec`
- [ ] E2E: Deploy baremetal cluster via RHACM assisted-installer, initiate Day 2 master expansion
- [ ] Verify Machine created with full providerSpec including `customDeploy`
- [ ] Verify machine-controller reconciles to Running
- [ ] Verify CSRs auto-approved, etcd member added

Regression-from: #10164 ([ACM-32996](https://redhat.atlassian.net/browse/ACM-32996))

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bare metal host provisioning by retrieving complete machine provider specifications instead of partial data, ensuring more accurate configuration
  * Enhanced error handling with appropriate fallback mechanisms for failed provider specification retrieval

* **Tests**
  * Updated test coverage for provider specification retrieval logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->