### PR TITLE
MGMT-24463: Add candidate channel to OCP 4.21 release sources

### DIFF
--- a/data/default_release_sources.json
+++ b/data/default_release_sources.json
@@ -303,31 +303,36 @@
       {
         "cpu_architecture": "x86_64",
         "channels": [
-          "stable"
+          "stable",
+          "candidate"
         ]
       },
       {
         "cpu_architecture": "arm64",
         "channels": [
-          "stable"
+          "stable",
+          "candidate"
         ]
       },
       {
         "cpu_architecture": "ppc64le",
         "channels": [
-          "stable"
+          "stable",
+          "candidate"
         ]
       },
       {
         "cpu_architecture": "s390x",
         "channels": [
-          "stable"
+          "stable",
+          "candidate"
         ]
       },
       {
         "cpu_architecture": "multi",
         "channels": [
-          "stable"
+          "stable",
+          "candidate"
         ]
       }
     ]


### PR DESCRIPTION
When 4.21 became GA (commit 2404be6b2), candidate channel was removed from 4.20 but was not added to 4.21. This follows the established pattern where the current GA version exposes both stable and candidate channels (as was done for 4.20 and 4.16 before it).

57 candidate versions exist for 4.21 in the upstream OCM upgrade graph (latest: 4.21.9) but were not accessible via Assisted Installer.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenShift 4.21 upgrade channels now include both stable and candidate release options for all supported CPU architectures (x86_64, arm64, ppc64le, s390x, and multi).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->