### PR TITLE
MGMT-24453: upgrade to golang 1.26 for assisted-service

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.21
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.assisted-service.ocp
+++ b/Dockerfile.assisted-service.ocp
@@ -1,5 +1,5 @@
 # Build binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /src
 COPY . .
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-service/api
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/openshift/assisted-service/models v0.0.0

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -86,7 +86,7 @@ github.com/openshift/api/machine/v1
 github.com/openshift/api/machine/v1beta1
 github.com/openshift/api/operator/v1
 # github.com/openshift/assisted-service/models v0.0.0 => ../models
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/assisted-service/models
 github.com/openshift/assisted-service/models/validations
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-service/client
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/go-openapi/errors v0.20.4

--- a/client/vendor/modules.txt
+++ b/client/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/mitchellh/mapstructure
 ## explicit
 github.com/oklog/ulid
 # github.com/openshift/assisted-service/models v0.0.0 => ../models
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/assisted-service/models
 github.com/openshift/assisted-service/models/validations
 # go.mongodb.org/mongo-driver v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-service
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/IBM/netaddr v1.5.0

--- a/models/go.mod
+++ b/models/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-service/models
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/go-openapi/errors v0.20.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -816,12 +816,12 @@ github.com/openshift/assisted-image-service/pkg/isoeditor
 github.com/openshift/assisted-image-service/pkg/overlay
 github.com/openshift/assisted-image-service/pkg/servers
 # github.com/openshift/assisted-service/api v0.0.0 => ./api
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/assisted-service/api/common
 github.com/openshift/assisted-service/api/hiveextension/v1beta1
 github.com/openshift/assisted-service/api/v1beta1
 # github.com/openshift/assisted-service/client v0.0.0 => ./client
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/assisted-service/client
 github.com/openshift/assisted-service/client/events
 github.com/openshift/assisted-service/client/installer
@@ -830,7 +830,7 @@ github.com/openshift/assisted-service/client/manifests
 github.com/openshift/assisted-service/client/operators
 github.com/openshift/assisted-service/client/versions
 # github.com/openshift/assisted-service/models v0.0.0 => ./models
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/assisted-service/models
 github.com/openshift/assisted-service/models/validations
 # github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2
- Run go mod tidy and update vendor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go toolchain across modules from 1.25 to 1.26.
  * Updated builder and CI build root images to align with Go 1.26 and the newer OpenShift build image.
  * Runtime/base image for releases remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->