### PR TITLE
MGMT-24410: Fixes for installer cache

### DIFF
--- a/docs/dev/installercache.md
+++ b/docs/dev/installercache.md
@@ -25,6 +25,8 @@ This setting is used by the installercache to decide if there is enough space to
 This will accept a capacity, followed by either "GiB", "MiB", "KiB" or "B" 
 For example "1GiB"
 
+Any existing content will be deleted when the service starts.
+
 ### INSTALLER_CACHE_RELEASE_FETCH_RETRY_INTERVAL
 
 If the cache finds itself unable to write a release (as indicated by `INSTALLER_CACHE_MAX_RELEASE_SIZE`) to the cache without breaking the cache limit

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -23,10 +23,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
-	linkPruningGracePeriod time.Duration = 5 * time.Minute
-)
-
 // Installers implements a thread safe LRU cache for ocp install binaries
 // on the pod's ephermal file system. The number of binaries stored is
 // limited by the storageCapacity parameter.
@@ -97,6 +93,8 @@ type Release struct {
 	cached bool
 	// extractDuration is the amount of time taken to perform extraction, zero if no extraction took place.
 	extractDuration float64
+	// cleanup is called to clean up the release when it is no longer needed
+	cleanup func() error
 }
 
 // Cleanup is called to signal that the caller has finished using the release and that resources may be released.
@@ -112,49 +110,31 @@ func (rl *Release) Cleanup(ctx context.Context) error {
 		"extract_duration", rl.extractDuration,
 	)
 
-	var ret error
-
-	// Ensure page cache is removed for the file
-	if err := rl.cleanPageCache(); err != nil {
-		ret = errors.Join(ret, fmt.Errorf("failed to clean page cache: %w", err))
-	}
-
-	if err := os.Remove(rl.Path); err != nil && !os.IsNotExist(err) {
-		ret = errors.Join(ret, fmt.Errorf("failed to remove binary: %w", err))
-	}
-
-	return ret
-}
-
-func (r *Release) cleanPageCache() error {
-	f, err := os.Open(r.Path)
-	if err != nil {
-		switch {
-		case os.IsNotExist(err):
-			return nil
-		default:
-			return fmt.Errorf("failed to open binary file %s: %w", r.Path, err)
-		}
-	}
-
-	defer f.Close()
-
-	err = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED)
-	if err != nil {
-		return fmt.Errorf("fadvise failed: %w", err)
-	}
-
-	return nil
+	return rl.cleanup()
 }
 
 // New constructs an installer cache with a given storage capacity
+// If the cache directory already exists, it will be removed and a new one will be created.
 func New(config Config, eventsHandler eventsapi.Handler, metricsAPI metrics.API, diskStatsHelper metrics.DiskStatsHelper, log logrus.FieldLogger) (*Installers, error) {
+	log.Infof("Creating installer cache with config: %+v", config)
+
 	if config.MaxCapacity > 0 && config.MaxReleaseSize == 0 {
 		return nil, fmt.Errorf("config.MaxReleaseSize (%d bytes) must not be zero", config.MaxReleaseSize)
 	}
 	if config.MaxCapacity > 0 && config.MaxReleaseSize > config.MaxCapacity {
 		return nil, fmt.Errorf("config.MaxReleaseSize (%d bytes) must not be greater than config.MaxCapacity (%d bytes)", config.MaxReleaseSize, config.MaxCapacity)
 	}
+
+	err := os.RemoveAll(config.CacheDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove cache directory %s: %w", config.CacheDir, err)
+	}
+
+	err = os.MkdirAll(config.CacheDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache directory %s: %w", config.CacheDir, err)
+	}
+
 	return &Installers{
 		log:             log,
 		eventsHandler:   eventsHandler,
@@ -257,6 +237,13 @@ func (i *Installers) get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 		return nil, err
 	}
 
+	release.cleanup = func() error {
+		i.Lock()
+		defer i.Unlock()
+
+		return cleanHardLink(release.Path)
+	}
+
 	return release, nil
 }
 
@@ -289,7 +276,6 @@ func (i *Installers) shouldEvict(totalUsed int64) (shouldEvict bool) {
 func (i *Installers) evict() bool {
 	// store the file paths
 	files := NewPriorityQueue(&fileInfo{})
-	links := make([]*fileInfo, 0)
 	var totalSize int64
 
 	// visit process the file/dir pointed by path and store relevant
@@ -302,9 +288,8 @@ func (i *Installers) evict() bool {
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		//find hard links
+		//skip hard links
 		if strings.HasPrefix(info.Name(), "ln_") {
-			links = append(links, &fileInfo{path, info})
 			return nil
 		}
 
@@ -322,25 +307,23 @@ func (i *Installers) evict() bool {
 
 	err := filepath.Walk(i.config.CacheDir, visit)
 	if err != nil {
-		if !os.IsNotExist(err) { //ignore first invocation where the cacheDir does not exist
-			i.log.WithError(err).Errorf("release binary eviction failed to inspect directory %s", i.config.CacheDir)
-		}
+		i.log.WithError(err).Errorf("release binary eviction failed to inspect directory %s", i.config.CacheDir)
+
 		return false
 	}
-
-	// TODO: We might want to consider if we need to do this longer term, in theory every hardlink should be automatically freed.
-	i.pruneExpiredHardLinks(links, linkPruningGracePeriod)
 
 	// delete the oldest file if necessary
 	evicted := false
 	for i.shouldEvict(totalSize) && files.Len() > 0 {
 		finfo, _ := files.Pop()
-		totalSize -= finfo.info.Size()
+
 		//remove the file
 		if err := i.evictFile(finfo.path); err != nil {
 			i.log.WithError(err).Errorf("failed to evict file %s", finfo.path)
 			continue
 		}
+
+		totalSize -= finfo.info.Size()
 		evicted = true
 	}
 	i.metricsAPI.InstallerCacheReleaseEvicted(evicted)
@@ -349,7 +332,13 @@ func (i *Installers) evict() bool {
 
 func (i *Installers) evictFile(filePath string) error {
 	i.log.Infof("evicting binary file %s due to storage pressure", filePath)
-	err := os.Remove(filePath)
+
+	err := cleanPageCache(filePath)
+	if err != nil {
+		i.log.WithError(err).Warnf("failed to clean page cache for %s", filePath)
+	}
+
+	err = os.Remove(filePath)
 	if err != nil {
 		return err
 	}
@@ -366,18 +355,71 @@ func (i *Installers) evictFile(filePath string) error {
 	return nil
 }
 
-// pruneExpiredHardLinks removes any hardlinks that have been around for too long
-// the grace period is used to determine which links should be removed.
-func (i *Installers) pruneExpiredHardLinks(links []*fileInfo, gracePeriod time.Duration) {
-	for idx := 0; idx < len(links); idx++ {
-		finfo := links[idx]
-		graceTime := time.Now().Add(-1 * gracePeriod)
-		grace := graceTime.Unix()
-		if finfo.info.ModTime().Unix() < grace {
-			i.log.Infof("attempting to prune hard link %s", finfo.path)
-			if err := os.Remove(finfo.path); err != nil {
-				i.log.WithError(err).Errorf("failed to prune hard link %s", finfo.path)
-			}
+func cleanHardLink(path string) error {
+	var ret error
+
+	// Ensure page cache is removed for the file
+	if err := cleanPageCacheForHardLink(path); err != nil {
+		ret = errors.Join(ret, fmt.Errorf("failed to clean page cache: %w", err))
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		ret = errors.Join(ret, fmt.Errorf("failed to remove binary: %w", err))
+	}
+
+	return ret
+}
+
+func cleanPageCacheForHardLink(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		switch {
+		case os.IsNotExist(err):
+			return nil
+		default:
+			return fmt.Errorf("failed to open file %s: %w", path, err)
 		}
 	}
+
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file %s: %w", path, err)
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	// If we can't determine the hardlink status, run fadvise to be safe
+	// If there are more than 2 links, we don't need to run fadvise, as the file is still in use
+	if ok && stat != nil && stat.Nlink > 2 {
+		return nil
+	}
+
+	err = cleanPageCache(path)
+	if err != nil {
+		return fmt.Errorf("failed to clean page cache: %w", err)
+	}
+
+	return nil
+}
+
+func cleanPageCache(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		switch {
+		case os.IsNotExist(err):
+			return nil
+		default:
+			return fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+	}
+
+	defer f.Close()
+
+	err = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED)
+	if err != nil {
+		return fmt.Errorf("fadvise failed: %w", err)
+	}
+
+	return nil
 }

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -2,12 +2,9 @@ package installercache
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -51,6 +48,9 @@ var _ = Describe("release event", func() {
 			releaseID:       releaseID,
 			cached:          false,
 			extractDuration: 19.5,
+			cleanup: func() error {
+				return nil
+			},
 		}
 		eventsHandler.EXPECT().V2AddMetricsEvent(
 			ctx, &clusterID, nil, nil, "", models.EventSeverityInfo, metricEventInstallerCacheRelease, gomock.Any(),
@@ -98,8 +98,6 @@ var _ = Describe("installer cache", func() {
 		var err error
 		cacheDir, err = os.MkdirTemp("/tmp", "cacheDir")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(os.Mkdir(filepath.Join(cacheDir, "quay.io"), 0755)).To(Succeed())
-		Expect(os.Mkdir(filepath.Join(filepath.Join(cacheDir, "quay.io"), "release-dev"), 0755)).To(Succeed())
 		manager, err = New(getInstallerCacheConfig(12, 5), eventsHandler, metricsAPI, diskStatsHelper, logrus.New())
 		Expect(err).NotTo(HaveOccurred())
 		ctx = context.TODO()
@@ -404,51 +402,18 @@ var _ = Describe("installer cache", func() {
 		Expect(getUsedBytesForDirectory(manager.config.CacheDir)).To(BeNumerically("<=", manager.config.MaxCapacity))
 	})
 
-	It("should remove expired links while leaving non expired links intact", func() {
+	It("should reset the cache directory contents on construction", func() {
+		cacheConfig := getInstallerCacheConfig(10, 5)
 
-		numberOfLinks := 10
-		numberOfExpiredLinks := 5
-		directory, err := os.MkdirTemp("", "testPruneExpiredHardLinks")
+		Expect(os.MkdirAll(cacheConfig.CacheDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(cacheConfig.CacheDir, "test.txt"), []byte("test"), 0600)).To(Succeed())
+
+		_, err := New(cacheConfig, eventsHandler, metricsAPI, diskStatsHelper, logrus.New())
 		Expect(err).ToNot(HaveOccurred())
 
-		defer os.RemoveAll(directory)
-
-		for i := 0; i < numberOfLinks; i++ {
-			var someFile *os.File
-			someFile, err = os.CreateTemp(directory, "somefile")
-			Expect(err).ToNot(HaveOccurred())
-			linkPath := filepath.Join(directory, fmt.Sprintf("ln_%s", uuid.NewString()))
-			err = os.Link(someFile.Name(), linkPath)
-			Expect(err).ToNot(HaveOccurred())
-			if i > numberOfExpiredLinks-1 {
-				err = os.Chtimes(linkPath, time.Now().Add(-10*time.Minute), time.Now().Add(-10*time.Minute))
-				Expect(err).ToNot(HaveOccurred())
-			}
-		}
-
-		links := make([]*fileInfo, 0)
-		err = filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
-			if strings.HasPrefix(info.Name(), "ln_") {
-				links = append(links, &fileInfo{path, info})
-			}
-			return nil
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(links)).To(Equal(10))
-
-		manager.pruneExpiredHardLinks(links, linkPruningGracePeriod)
-
-		linkCount := 0
-		err = filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
-			if strings.HasPrefix(info.Name(), "ln_") {
-				linkCount++
-			}
-			return nil
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(linkCount).To(Equal(numberOfLinks - numberOfExpiredLinks))
+		_, err = os.Stat(filepath.Join(cacheConfig.CacheDir, "test.txt"))
+		Expect(os.IsNotExist(err)).To(BeTrue())
 	})
-
 })
 
 func TestInstallerCache(t *testing.T) {

--- a/internal/installercache/interface.go
+++ b/internal/installercache/interface.go
@@ -21,5 +21,8 @@ func NewMockRelease(path string, eventsHandler eventsapi.Handler) *Release {
 	return &Release{
 		Path:          path,
 		eventsHandler: eventsHandler,
+		cleanup: func() error {
+			return nil
+		},
 	}
 }


### PR DESCRIPTION
  * Remove from page cache when it's the last hard link
  * Remove from page cache before deleting the binary
  * Remove pruneExpiredHardLinks, cache dir is cleaned upon creation
  * Decrement total size only when a file is evicted

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-release cleanup is now delegated to instance-specific handlers; cache eviction skips special linked entries, performs preparatory page-cache cleanup before file removal, and corrects size accounting.
* **Tests**
  * Tests updated to cover delegated cleanup; removed old hard-link pruning test and added a startup cache-reset test.
* **Documentation**
  * Documents that installer cache contents are cleared when the service starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->