### PR TITLE
ACM-33842: update Go toolchain to 1.25.9 (CVE-2026-32280)

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/api
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.9
 
 require (
 	github.com/itchyny/gojq v0.12.8

--- a/client/go.mod
+++ b/client/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/client
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.9
 
 require (
 	github.com/go-openapi/errors v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.9
 
 require (
 	github.com/IBM/netaddr v1.5.0

--- a/models/go.mod
+++ b/models/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/models
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.9
 
 require (
 	github.com/go-openapi/errors v0.22.0


### PR DESCRIPTION
## Summary
- Update toolchain directive from go1.25.5 to go1.25.9 across all go.mod files
- Go 1.25.9 includes the fix for CVE-2026-32280 (crypto/x509 DoS in certificate chain building)
- No source code changes — only go.mod toolchain version bump

https://redhat.atlassian.net/browse/ACM-33842