### PR TITLE
MGMT-19732: Add ntp_sources field for exclusive NTP configuration

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -208,6 +208,9 @@ type Cluster struct {
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -106,6 +106,9 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env.go
@@ -85,6 +85,9 @@ type InfraEnv struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -57,6 +57,9 @@ type InfraEnvCreateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -41,6 +41,9 @@ type InfraEnvUpdateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OS image
 	OpenshiftVersion *string `json:"openshift_version,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -102,6 +102,9 @@ type V2ClusterUpdateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// List of OLM operators to be installed.
 	// For the full list of supported operators, check the endpoint `/v2/supported-operators`:
 	//

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -208,6 +208,9 @@ type Cluster struct {
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -106,6 +106,9 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/infra_env.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/infra_env.go
@@ -85,6 +85,9 @@ type InfraEnv struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -57,6 +57,9 @@ type InfraEnvCreateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -41,6 +41,9 @@ type InfraEnvUpdateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OS image
 	OpenshiftVersion *string `json:"openshift_version,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -102,6 +102,9 @@ type V2ClusterUpdateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// List of OLM operators to be installed.
 	// For the full list of supported operators, check the endpoint `/v2/supported-operators`:
 	//

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -439,7 +439,7 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(ctx context.Context
 	params.NewClusterParams.Platform = platform
 	params.NewClusterParams.UserManagedNetworking = userManagedNetworking
 
-	if params.NewClusterParams.AdditionalNtpSource == nil {
+	if params.NewClusterParams.AdditionalNtpSource == nil && params.NewClusterParams.NtpSources == nil {
 		params.NewClusterParams.AdditionalNtpSource = &b.Config.DefaultNTPSource
 	}
 	if params.NewClusterParams.DiskEncryption == nil {
@@ -519,6 +519,18 @@ func (b *bareMetalInventory) validateRegisterClusterInternalParams(params *insta
 		if ntpSource != "" && !pkgvalidations.ValidateAdditionalNTPSource(ntpSource) {
 			err = errors.Errorf("Invalid NTP source: %s", ntpSource)
 			return common.NewApiError(http.StatusBadRequest, err)
+		}
+	}
+
+	if params.NewClusterParams.NtpSources != nil {
+		ntpSources := swag.StringValue(params.NewClusterParams.NtpSources)
+		if ntpSources != "" {
+			if swag.StringValue(params.NewClusterParams.AdditionalNtpSource) != "" {
+				return common.NewApiError(http.StatusBadRequest, errors.New("ntp_sources and additional_ntp_source are mutually exclusive"))
+			}
+			if !pkgvalidations.ValidateAdditionalNTPSource(ntpSources) {
+				return common.NewApiError(http.StatusBadRequest, errors.Errorf("Invalid NTP source: %s", ntpSources))
+			}
 		}
 	}
 
@@ -773,6 +785,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(ctx context.Context, kubeKe
 			NetworkType:                  params.NewClusterParams.NetworkType,
 			UserManagedNetworking:        params.NewClusterParams.UserManagedNetworking,
 			AdditionalNtpSource:          swag.StringValue(params.NewClusterParams.AdditionalNtpSource),
+			NtpSources:                   swag.StringValue(params.NewClusterParams.NtpSources),
 			MonitoredOperators:           monitoredOperators,
 			HighAvailabilityMode:         params.NewClusterParams.HighAvailabilityMode,
 			Hyperthreading:               swag.StringValue(params.NewClusterParams.Hyperthreading),
@@ -2676,7 +2689,7 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 		return err
 	}
 
-	if err = b.updateNtpSources(params, updates, usages, log); err != nil {
+	if err = b.updateNtpSources(params, cluster, updates, usages, log); err != nil {
 		return err
 	}
 
@@ -3109,7 +3122,21 @@ func setCommonUserNetworkManagedParams(db *gorm.DB, id *strfmt.UUID, params *mod
 	return nil, false
 }
 
-func (b *bareMetalInventory) updateNtpSources(params installer.V2UpdateClusterParams, updates map[string]interface{}, usages map[string]models.Usage, log logrus.FieldLogger) error {
+func (b *bareMetalInventory) updateNtpSources(params installer.V2UpdateClusterParams, cluster *common.Cluster, updates map[string]interface{}, usages map[string]models.Usage, log logrus.FieldLogger) error {
+	additionalNtpSource := cluster.AdditionalNtpSource
+	ntpSources := cluster.NtpSources
+
+	if params.ClusterUpdateParams.AdditionalNtpSource != nil {
+		additionalNtpSource = swag.StringValue(params.ClusterUpdateParams.AdditionalNtpSource)
+	}
+	if params.ClusterUpdateParams.NtpSources != nil {
+		ntpSources = swag.StringValue(params.ClusterUpdateParams.NtpSources)
+	}
+
+	if additionalNtpSource != "" && ntpSources != "" {
+		return common.NewApiError(http.StatusBadRequest, errors.New("ntp_sources and additional_ntp_source are mutually exclusive"))
+	}
+
 	if params.ClusterUpdateParams.AdditionalNtpSource != nil {
 		ntpSource := swag.StringValue(params.ClusterUpdateParams.AdditionalNtpSource)
 		additionalNtpSourcesDefined := ntpSource != ""
@@ -3125,6 +3152,18 @@ func (b *bareMetalInventory) updateNtpSources(params installer.V2UpdateClusterPa
 		b.setUsage(additionalNtpSourcesDefined, usage.AdditionalNtpSourceUsage, &map[string]interface{}{
 			"source_count": len(strings.Split(ntpSource, ","))}, usages)
 	}
+
+	if params.ClusterUpdateParams.NtpSources != nil {
+		ntpSources := swag.StringValue(params.ClusterUpdateParams.NtpSources)
+
+		if ntpSources != "" && !pkgvalidations.ValidateAdditionalNTPSource(ntpSources) {
+			err := errors.Errorf("Invalid NTP source: %s", ntpSources)
+			log.WithError(err).Error("Failed to validate NTP sources")
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
+		updates["ntp_sources"] = ntpSources
+	}
+
 	return nil
 }
 
@@ -5118,6 +5157,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(ctx context.Context, kubeK
 				StaticNetworkConfig:          staticNetworkConfig,
 				Type:                         common.ImageTypePtr(params.InfraenvCreateParams.ImageType),
 				AdditionalNtpSources:         swag.StringValue(params.InfraenvCreateParams.AdditionalNtpSources),
+				NtpSources:                   swag.StringValue(params.InfraenvCreateParams.NtpSources),
 				SSHAuthorizedKey:             swag.StringValue(params.InfraenvCreateParams.SSHAuthorizedKey),
 				RendezvousIP:                 params.InfraenvCreateParams.RendezvousIP,
 				CPUArchitecture:              params.InfraenvCreateParams.CPUArchitecture,
@@ -5241,6 +5281,16 @@ func (b *bareMetalInventory) validateInfraEnvCreateParams(ctx context.Context, p
 		return err
 	}
 
+	infraEnvNtpSources := swag.StringValue(params.InfraenvCreateParams.NtpSources)
+	if infraEnvNtpSources != "" {
+		if ntpSource != "" {
+			return common.NewApiError(http.StatusBadRequest, errors.New("ntp_sources and additional_ntp_sources are mutually exclusive"))
+		}
+		if !pkgvalidations.ValidateAdditionalNTPSource(infraEnvNtpSources) {
+			return common.NewApiError(http.StatusBadRequest, errors.Errorf("Invalid NTP source: %s", infraEnvNtpSources))
+		}
+	}
+
 	if params.InfraenvCreateParams.SSHAuthorizedKey != nil && *params.InfraenvCreateParams.SSHAuthorizedKey != "" {
 		if err = validations.ValidateSSHPublicKey(*params.InfraenvCreateParams.SSHAuthorizedKey); err != nil {
 			err = errors.Errorf("SSH key is not valid")
@@ -5275,7 +5325,7 @@ func (b *bareMetalInventory) validateInfraEnvCreateParams(ctx context.Context, p
 }
 
 func (b *bareMetalInventory) setDefaultRegisterInfraEnvParams(_ context.Context, params installer.RegisterInfraEnvParams) installer.RegisterInfraEnvParams {
-	if params.InfraenvCreateParams.AdditionalNtpSources == nil {
+	if params.InfraenvCreateParams.AdditionalNtpSources == nil && params.InfraenvCreateParams.NtpSources == nil {
 		params.InfraenvCreateParams.AdditionalNtpSources = &b.Config.DefaultNTPSource
 	}
 
@@ -5286,7 +5336,7 @@ func (b *bareMetalInventory) setDefaultRegisterInfraEnvParams(_ context.Context,
 		params.InfraenvCreateParams.CPUArchitecture = common.DefaultCPUArchitecture
 	}
 
-	if params.InfraenvCreateParams.AdditionalNtpSources == nil {
+	if params.InfraenvCreateParams.AdditionalNtpSources == nil && params.InfraenvCreateParams.NtpSources == nil {
 		params.InfraenvCreateParams.AdditionalNtpSources = swag.String(b.Config.DefaultNTPSource)
 	}
 
@@ -5766,6 +5816,20 @@ func (b *bareMetalInventory) applyRendezvousIPUpdates(infraEnv *common.InfraEnv,
 }
 
 func (b *bareMetalInventory) updateInfraEnvNtpSources(params installer.UpdateInfraEnvParams, infraEnv *common.InfraEnv, updates map[string]interface{}, log logrus.FieldLogger) error {
+	additionalNtpSources := infraEnv.AdditionalNtpSources
+	ntpSources := infraEnv.NtpSources
+
+	if params.InfraEnvUpdateParams.AdditionalNtpSources != nil {
+		additionalNtpSources = swag.StringValue(params.InfraEnvUpdateParams.AdditionalNtpSources)
+	}
+	if params.InfraEnvUpdateParams.NtpSources != nil {
+		ntpSources = swag.StringValue(params.InfraEnvUpdateParams.NtpSources)
+	}
+
+	if additionalNtpSources != "" && ntpSources != "" {
+		return common.NewApiError(http.StatusBadRequest, errors.New("ntp_sources and additional_ntp_sources are mutually exclusive"))
+	}
+
 	if params.InfraEnvUpdateParams.AdditionalNtpSources != nil {
 		ntpSource := swag.StringValue(params.InfraEnvUpdateParams.AdditionalNtpSources)
 		additionalNtpSourcesDefined := ntpSource != ""
@@ -5779,6 +5843,20 @@ func (b *bareMetalInventory) updateInfraEnvNtpSources(params installer.UpdateInf
 			updates["additional_ntp_sources"] = ntpSource
 		}
 	}
+
+	if params.InfraEnvUpdateParams.NtpSources != nil {
+		ntpSources := swag.StringValue(params.InfraEnvUpdateParams.NtpSources)
+
+		if ntpSources != "" && !pkgvalidations.ValidateAdditionalNTPSource(ntpSources) {
+			err := errors.Errorf("Invalid NTP source: %s", ntpSources)
+			log.WithError(err).Error("Failed to validate NTP sources")
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
+		if ntpSources != infraEnv.NtpSources {
+			updates["ntp_sources"] = ntpSources
+		}
+	}
+
 	return nil
 }
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -334,11 +334,13 @@ func GetClusterNTPSources(db *gorm.DB, clusterID strfmt.UUID) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if cluster.NtpSources != "" {
+		return cluster.NtpSources, nil
+	}
 	if cluster.AdditionalNtpSource != "" {
 		return cluster.AdditionalNtpSource, nil
-	} else {
-		return getUnifiedNTPSources(db, clusterID)
 	}
+	return getUnifiedNTPSources(db, clusterID)
 }
 
 func GetHostNTPSources(db *gorm.DB, host *models.Host) (string, error) {
@@ -352,6 +354,9 @@ func GetHostNTPSources(db *gorm.DB, host *models.Host) (string, error) {
 	infraEnv, err = GetInfraEnvFromDB(db, host.InfraEnvID)
 	if err != nil {
 		return "", err
+	}
+	if infraEnv.NtpSources != "" {
+		return infraEnv.NtpSources, nil
 	}
 	return infraEnv.AdditionalNtpSources, nil
 }

--- a/internal/ignition/disconnected.go
+++ b/internal/ignition/disconnected.go
@@ -155,14 +155,18 @@ func createInfraEnvManifest(infraEnv *common.InfraEnv, manifestsDir string) erro
 		}
 	}
 
-	var additionalNtpSources []string
-	for _, source := range strings.Split(infraEnv.AdditionalNtpSources, ",") {
+	ntpSourcesRaw := infraEnv.AdditionalNtpSources
+	if infraEnv.NtpSources != "" {
+		ntpSourcesRaw = infraEnv.NtpSources
+	}
+	var desiredNtpSources []string
+	for _, source := range strings.Split(ntpSourcesRaw, ",") {
 		source = strings.TrimSpace(source)
 		if source != "" {
-			additionalNtpSources = append(additionalNtpSources, source)
+			desiredNtpSources = append(desiredNtpSources, source)
 		}
 	}
-	spec.AdditionalNTPSources = additionalNtpSources
+	spec.AdditionalNTPSources = desiredNtpSources
 
 	if strings.TrimSpace(infraEnv.StaticNetworkConfig) != "" {
 		if infraEnv.ID == nil {

--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -290,9 +290,14 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 
 	// If the list of additional NTP sources is empty then we want to pass an empty list to the
 	// template, but the Split method returns a slice with one empty element in that case.
-	additionalNtpSources := strings.Split(infraEnv.AdditionalNtpSources, ",")
-	if len(additionalNtpSources) == 1 && additionalNtpSources[0] == "" {
-		additionalNtpSources = []string{}
+	// When ntp_sources is set, use it for discovery so the user's servers are available from the start.
+	ntpSourcesRaw := infraEnv.AdditionalNtpSources
+	if infraEnv.NtpSources != "" {
+		ntpSourcesRaw = infraEnv.NtpSources
+	}
+	desiredNtpSources := strings.Split(ntpSourcesRaw, ",")
+	if len(desiredNtpSources) == 1 && desiredNtpSources[0] == "" {
+		desiredNtpSources = []string{}
 	}
 
 	var ignitionParams = map[string]interface{}{
@@ -317,7 +322,8 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"SELINUX_POLICY":       base64.StdEncoding.EncodeToString([]byte(selinuxPolicy)),
 		"EnableAgentService":   infraEnv.InternalIgnitionConfigOverride == "",
 		"ProfileProxyExports":  dataurl.EncodeBytes([]byte(GetProfileProxyEntries(httpProxy, httpsProxy, noProxy))),
-		"AdditionalNtpSources": additionalNtpSources,
+		"DesiredNtpSources":    desiredNtpSources,
+		"OverwriteNtpConfig":   infraEnv.NtpSources != "",
 	}
 	if safeForLogs {
 		for _, key := range []string{"userSshKey", "PullSecretToken", "PULL_SECRET", "RH_ROOT_CA"} {

--- a/internal/ignition/templates/add-ntp-sources.sh
+++ b/internal/ignition/templates/add-ntp-sources.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+{{ if .OverwriteNtpConfig }}
+# Replace mode: use only the specified NTP sources, no default pool
+cat > /etc/chrony.conf <<.
+{{ range .DesiredNtpSources }}server {{ . }} iburst
+{{ end }}driftfile /var/lib/chrony/drift
+makestep 1.0 -1
+rtcsync
+logdir /var/log/chrony
+.
+{{ else }}
+# Append mode: add sources to existing chrony.conf
 # Allow chrony to step the clock at any time if the offset is larger than 1 second.
 # The default "makestep 1.0 3" only allows stepping during the first 3 clock updates,
 # which may have been exhausted before valid NTP sources were available.
@@ -7,7 +18,8 @@
 sed -i 's/^makestep .*/makestep 1.0 -1/' /etc/chrony.conf
 
 cat >> /etc/chrony.conf <<.
-{{ range .AdditionalNtpSources }}
+{{ range .DesiredNtpSources }}
 server {{ . }} iburst
 {{ end }}
 .
+{{ end }}

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -54,7 +54,7 @@
         "enabled": true,
         "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toString | toJson }}
     }
-    {{end}}{{if .AdditionalNtpSources}},
+    {{end}}{{if .DesiredNtpSources}},
     {
         "name": "add-ntp-sources.service",
         "enabled": true,
@@ -269,7 +269,7 @@
         "name": "root"
       },
       "contents": { "source": "{{.ProfileProxyExports}}" }
-    }{{end}}{{if .AdditionalNtpSources}},
+    }{{end}}{{if .DesiredNtpSources}},
     {
       "path": "/usr/local/bin/add-ntp-sources.sh",
       "mode": 493,

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -201,6 +201,12 @@ const schedulableMastersManifestPatch = `---
   value: true
 `
 
+const exclusiveChronyConf = `
+driftfile /var/lib/chrony/drift
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony`
+
 func (m *ManifestsGenerator) createChronyManifestContent(c *common.Cluster, role models.HostRole, log logrus.FieldLogger) ([]byte, error) {
 	sources := make([]string, 0)
 
@@ -234,7 +240,12 @@ func (m *ManifestsGenerator) createChronyManifestContent(c *common.Cluster, role
 		}
 	}
 
-	content := defaultChronyConf[:]
+	var content string
+	if c.NtpSources != "" {
+		content = exclusiveChronyConf[:]
+	} else {
+		content = defaultChronyConf[:]
+	}
 
 	for _, source := range sources {
 		content += fmt.Sprintf("\nserver %s iburst", source)

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -264,6 +264,72 @@ var _ = Describe("chrony manifest", func() {
 			Expect(chronyConfServers).To(ConsistOf("from.cluster"))
 		})
 
+		It("Uses ntp_sources without default pool, includes discovered sources", func() {
+			cluster.NtpSources = "my-ntp.corp.com"
+			db.Save(cluster)
+			Expect(db.Error).ToNot(HaveOccurred())
+
+			cluster.Hosts = []*models.Host{
+				createHost([]*models.NtpSource{
+					common.TestNTPSourceSynced,
+					common.TestNTPSourceUnsynced,
+				}),
+			}
+
+			response, err := ntpUtils.createChronyManifestContent(cluster, models.HostRoleMaster, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			chronyConf := extractChronyConf(response)
+			Expect(chronyConf).ToNot(ContainSubstring("pool"))
+
+			chronyConfServers := extractChronyConfServers(response)
+			Expect(chronyConfServers).To(ConsistOf(
+				common.TestNTPSourceSynced.SourceName,
+				common.TestNTPSourceUnsynced.SourceName,
+				"my-ntp.corp.com",
+			))
+		})
+
+		It("Uses multiple ntp_sources when set", func() {
+			cluster.NtpSources = "ntp1.corp.com,ntp2.corp.com"
+			db.Save(cluster)
+			Expect(db.Error).ToNot(HaveOccurred())
+
+			cluster.Hosts = []*models.Host{
+				createHost(nil),
+			}
+
+			response, err := ntpUtils.createChronyManifestContent(cluster, models.HostRoleMaster, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			chronyConf := extractChronyConf(response)
+			Expect(chronyConf).ToNot(ContainSubstring("pool"))
+
+			chronyConfServers := extractChronyConfServers(response)
+			Expect(chronyConfServers).To(ConsistOf("ntp1.corp.com", "ntp2.corp.com"))
+		})
+
+		It("Falls back to default behavior when ntp_sources is empty", func() {
+			cluster.AdditionalNtpSource = "from.cluster"
+			db.Save(cluster)
+			Expect(db.Error).ToNot(HaveOccurred())
+
+			cluster.Hosts = []*models.Host{
+				createHost([]*models.NtpSource{
+					common.TestNTPSourceSynced,
+				}),
+			}
+
+			response, err := ntpUtils.createChronyManifestContent(cluster, models.HostRoleMaster, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			chronyConf := extractChronyConf(response)
+			Expect(chronyConf).To(ContainSubstring("pool"))
+
+			chronyConfServers := extractChronyConfServers(response)
+			Expect(chronyConfServers).To(ConsistOf(common.TestNTPSourceSynced.SourceName, "from.cluster"))
+		})
+
 		It("Adds sources from infra-env if hosts don't have reference to cluster", func() {
 			host := createHost(nil)
 			host.ClusterID = nil

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -208,6 +208,9 @@ type Cluster struct {
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -106,6 +106,9 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/models/infra_env.go
+++ b/models/infra_env.go
@@ -85,6 +85,9 @@ type InfraEnv struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -57,6 +57,9 @@ type InfraEnvCreateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/models/infra_env_update_params.go
+++ b/models/infra_env_update_params.go
@@ -41,6 +41,9 @@ type InfraEnvUpdateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OS image
 	OpenshiftVersion *string `json:"openshift_version,omitempty"`
 

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -102,6 +102,9 @@ type V2ClusterUpdateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// List of OLM operators to be installed.
 	// For the full list of supported operators, check the endpoint `/v2/supported-operators`:
 	//

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6832,6 +6832,10 @@ func init() {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string"
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
+          "type": "string"
+        },
         "ocp_release_image": {
           "description": "OpenShift release image URI.",
           "type": "string"
@@ -7117,6 +7121,11 @@ func init() {
         },
         "no_proxy": {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
           "type": "string",
           "x-nullable": true
         },
@@ -9280,6 +9289,10 @@ func init() {
           "format": "int64",
           "x-nullable": true
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string"
+        },
         "openshift_version": {
           "description": "Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).",
           "type": "string"
@@ -9391,6 +9404,11 @@ func init() {
           "format": "int64",
           "x-nullable": true
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string",
+          "x-nullable": true
+        },
         "openshift_version": {
           "description": "Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).",
           "type": "string"
@@ -9455,6 +9473,11 @@ func init() {
           "description": "The number of seconds to wait before mapping host MACs to interfaces when applying static network config on minimal ISO.\nThis can be used on hosts that need time to discover their NICs.",
           "type": "integer",
           "format": "int64",
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string",
           "x-nullable": true
         },
         "openshift_version": {
@@ -11266,6 +11289,11 @@ func init() {
         },
         "no_proxy": {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
           "type": "string",
           "x-nullable": true
         },
@@ -18484,6 +18512,10 @@ func init() {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string"
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
+          "type": "string"
+        },
         "ocp_release_image": {
           "description": "OpenShift release image URI.",
           "type": "string"
@@ -18769,6 +18801,11 @@ func init() {
         },
         "no_proxy": {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
           "type": "string",
           "x-nullable": true
         },
@@ -20901,6 +20938,10 @@ func init() {
           "minimum": 0,
           "x-nullable": true
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string"
+        },
         "openshift_version": {
           "description": "Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).",
           "type": "string"
@@ -21014,6 +21055,11 @@ func init() {
           "minimum": 0,
           "x-nullable": true
         },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string",
+          "x-nullable": true
+        },
         "openshift_version": {
           "description": "Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).",
           "type": "string"
@@ -21079,6 +21125,11 @@ func init() {
           "type": "integer",
           "format": "int64",
           "minimum": 0,
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.",
+          "type": "string",
           "x-nullable": true
         },
         "openshift_version": {
@@ -22849,6 +22900,11 @@ func init() {
         },
         "no_proxy": {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "ntp_sources": {
+          "description": "A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.",
           "type": "string",
           "x-nullable": true
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5236,6 +5236,10 @@ definitions:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
         x-nullable: true
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+        x-nullable: true
       olm_operators:
         type: array
         description: |
@@ -5458,6 +5462,10 @@ definitions:
       additional_ntp_source:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
+        x-nullable: true
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
         x-nullable: true
       olm_operators:
         type: array
@@ -5829,6 +5837,9 @@ definitions:
       additional_ntp_source:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
       monitored_operators:
         x-go-custom-tag: gorm:"foreignkey:ClusterID;references:ID"
         type: array
@@ -7794,6 +7805,9 @@ definitions:
       additional_ntp_sources:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
       ssh_authorized_key:
         type: string
         description: SSH public key for debugging the installation.
@@ -7924,6 +7938,10 @@ definitions:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
         x-nullable: true
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+        x-nullable: true
       ssh_authorized_key:
         type: string
         description: SSH public key for debugging the installation.
@@ -7990,6 +8008,10 @@ definitions:
       additional_ntp_sources:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
+        x-nullable: true
+      ntp_sources:
+        type: string
+        description: A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
         x-nullable: true
       ssh_authorized_key:
         type: string

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -208,6 +208,9 @@ type Cluster struct {
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -106,6 +106,9 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// OpenShift release image URI.
 	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/infra_env.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env.go
@@ -85,6 +85,9 @@ type InfraEnv struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -57,6 +57,9 @@ type InfraEnvCreateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -41,6 +41,9 @@ type InfraEnvUpdateParams struct {
 	// Minimum: 0
 	NetworkDiscoveryDelaySeconds *int64 `json:"network_discovery_delay_seconds,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for hosts in this infra-env.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// Version of the OS image
 	OpenshiftVersion *string `json:"openshift_version,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -102,6 +102,9 @@ type V2ClusterUpdateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+	NtpSources *string `json:"ntp_sources,omitempty"`
+
 	// List of OLM operators to be installed.
 	// For the full list of supported operators, check the endpoint `/v2/supported-operators`:
 	//


### PR DESCRIPTION
Add a new ntp_sources field to cluster and infra-env models that allows users to specify the complete NTP configuration. When set, only the user-specified sources are included — the default NTP pool is not added.

This field is mutually exclusive with additional_ntp_source — the API rejects requests that set both, checking the resulting DB state on updates to prevent conflicts.

- Discovery: when ntp_sources is set, add-ntp-sources.sh overwrites the ISO chrony.conf with only the user's servers instead of appending to the default configuration
- Installation: the default NTP pool is excluded from the generated chrony MachineConfig, while agent-discovered sources from the user's specified servers are preserved
- NTP resolution: GetClusterNTPSources() and GetHostNTPSources() return ntp_sources when set, preserving backward compatibility with additional_ntp_source when ntp_sources is not set

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ntp_sources parameter for cluster and infra-env create/update to specify exclusive NTP sources for hosts.

* **Improvements**
  * Enforced mutual exclusivity between ntp_sources and legacy additional_ntp_source(s); tightened validation and refined defaulting.
  * Ignition/chrony generation and manifests updated to honor ntp_sources and optionally overwrite chrony config.

* **Tests**
  * Added tests validating chrony manifest behavior with ntp_sources set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->