### PR TITLE
NO-ISSUE: make the isDiskEncryptionSetWithTpm function more robust

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -917,14 +917,7 @@ func setDiskEncryptionWithDefaultValues(c *models.Cluster, config *models.DiskEn
 	}
 
 	c.DiskEncryption = config
-
-	if c.DiskEncryption.EnableOn == nil {
-		c.DiskEncryption.EnableOn = swag.String(models.DiskEncryptionEnableOnNone)
-	}
-
-	if config.Mode == nil {
-		c.DiskEncryption.Mode = swag.String(models.DiskEncryptionModeTpmv2)
-	}
+	common.ApplyDiskEncryptionDefaults(c.DiskEncryption)
 }
 
 func updateSSHPublicKey(cluster *common.Cluster) error {
@@ -2712,9 +2705,13 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 			return common.NewApiError(http.StatusBadRequest, errors.New(msg))
 		}
 		if params.ClusterUpdateParams.DiskEncryption.EnableOn != nil {
+			enableOn, _ := common.DiskEncryptionFieldDefaults(params.ClusterUpdateParams.DiskEncryption.EnableOn, nil)
+			params.ClusterUpdateParams.DiskEncryption.EnableOn = swag.String(enableOn)
 			updates["disk_encryption_enable_on"] = params.ClusterUpdateParams.DiskEncryption.EnableOn
 		}
 		if params.ClusterUpdateParams.DiskEncryption.Mode != nil {
+			_, mode := common.DiskEncryptionFieldDefaults(nil, params.ClusterUpdateParams.DiskEncryption.Mode)
+			params.ClusterUpdateParams.DiskEncryption.Mode = swag.String(mode)
 			updates["disk_encryption_mode"] = params.ClusterUpdateParams.DiskEncryption.Mode
 		}
 		if params.ClusterUpdateParams.DiskEncryption.TangServers != "" {

--- a/internal/common/disk_encryption.go
+++ b/internal/common/disk_encryption.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+)
+
+// DiskEncryptionFieldDefaults returns enable_on and mode with defaults for nil or empty values.
+func DiskEncryptionFieldDefaults(enableOn, mode *string) (string, string) {
+	enableOnValue := swag.StringValue(enableOn)
+	if enableOnValue == "" {
+		enableOnValue = models.DiskEncryptionEnableOnNone
+	}
+	modeValue := swag.StringValue(mode)
+	if modeValue == "" {
+		modeValue = models.DiskEncryptionModeTpmv2
+	}
+	return enableOnValue, modeValue
+}
+
+// ApplyDiskEncryptionDefaults normalizes nil or empty disk encryption fields to their defaults.
+func ApplyDiskEncryptionDefaults(diskEncryption *models.DiskEncryption) {
+	if diskEncryption == nil {
+		return
+	}
+	enableOn, mode := DiskEncryptionFieldDefaults(diskEncryption.EnableOn, diskEncryption.Mode)
+	diskEncryption.EnableOn = swag.String(enableOn)
+	diskEncryption.Mode = swag.String(mode)
+}

--- a/internal/common/disk_encryption_test.go
+++ b/internal/common/disk_encryption_test.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiskEncryptionFieldDefaults(t *testing.T) {
+	enableOn, mode := DiskEncryptionFieldDefaults(nil, nil)
+	assert.Equal(t, models.DiskEncryptionEnableOnNone, enableOn)
+	assert.Equal(t, models.DiskEncryptionModeTpmv2, mode)
+
+	enableOn, mode = DiskEncryptionFieldDefaults(swag.String(""), swag.String(""))
+	assert.Equal(t, models.DiskEncryptionEnableOnNone, enableOn)
+	assert.Equal(t, models.DiskEncryptionModeTpmv2, mode)
+
+	enableOn, mode = DiskEncryptionFieldDefaults(swag.String(models.DiskEncryptionEnableOnMasters), swag.String(models.DiskEncryptionModeTang))
+	assert.Equal(t, models.DiskEncryptionEnableOnMasters, enableOn)
+	assert.Equal(t, models.DiskEncryptionModeTang, mode)
+}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1151,8 +1151,12 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(
 		if cluster.DiskEncryption == nil { // true when current cluster configuration does not include disk encryption
 			cluster.DiskEncryption = &models.DiskEncryption{}
 		}
-		updateString(swag.StringValue(clusterInstall.Spec.DiskEncryption.EnableOn), swag.StringValue(cluster.DiskEncryption.EnableOn), &params.DiskEncryption.EnableOn)
-		updateString(swag.StringValue(clusterInstall.Spec.DiskEncryption.Mode), swag.StringValue(cluster.DiskEncryption.Mode), &params.DiskEncryption.Mode)
+		enableOn, mode := common.DiskEncryptionFieldDefaults(
+			clusterInstall.Spec.DiskEncryption.EnableOn,
+			clusterInstall.Spec.DiskEncryption.Mode,
+		)
+		updateString(enableOn, swag.StringValue(cluster.DiskEncryption.EnableOn), &params.DiskEncryption.EnableOn)
+		updateString(mode, swag.StringValue(cluster.DiskEncryption.Mode), &params.DiskEncryption.Mode)
 		if clusterInstall.Spec.DiskEncryption.TangServers != cluster.DiskEncryption.TangServers {
 			params.DiskEncryption.TangServers = clusterInstall.Spec.DiskEncryption.TangServers
 			update = true
@@ -1440,9 +1444,13 @@ func CreateClusterParams(clusterDeployment *hivev1.ClusterDeployment, clusterIns
 	}
 
 	if isDiskEncryptionEnabled(clusterInstall) {
+		enableOn, mode := common.DiskEncryptionFieldDefaults(
+			clusterInstall.Spec.DiskEncryption.EnableOn,
+			clusterInstall.Spec.DiskEncryption.Mode,
+		)
 		clusterParams.DiskEncryption = &models.DiskEncryption{
-			EnableOn:    clusterInstall.Spec.DiskEncryption.EnableOn,
-			Mode:        clusterInstall.Spec.DiskEncryption.Mode,
+			EnableOn:    swag.String(enableOn),
+			Mode:        swag.String(mode),
 			TangServers: clusterInstall.Spec.DiskEncryption.TangServers,
 		}
 	}

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -366,9 +366,14 @@ func (v *validator) GetInfraEnvHostRequirements(ctx context.Context, infraEnv *c
 }
 
 func isDiskEncryptionSetWithTpm(c *common.Cluster) bool {
-	return c.DiskEncryption != nil &&
-		swag.StringValue(c.DiskEncryption.EnableOn) != models.DiskEncryptionEnableOnNone &&
-		swag.StringValue(c.DiskEncryption.Mode) == models.DiskEncryptionModeTpmv2
+	if c.DiskEncryption == nil {
+		return false
+	}
+	enableOn := swag.StringValue(c.DiskEncryption.EnableOn)
+	if enableOn == "" || enableOn == models.DiskEncryptionEnableOnNone {
+		return false
+	}
+	return swag.StringValue(c.DiskEncryption.Mode) == models.DiskEncryptionModeTpmv2
 }
 
 func (v *validator) GetPreflightHardwareRequirements(ctx context.Context, cluster *common.Cluster) (*models.PreflightHardwareRequirements, error) {

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -1862,6 +1862,25 @@ var _ = Describe("Preflight host requirements", func() {
 			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeFalse())
 		})
 
+		It("TPM - unset enable_on with tpmv2 mode is treated as disabled", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					Mode: swag.String(models.DiskEncryptionModeTpmv2),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeFalse())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeFalse())
+		})
+
 		It("Tang - all roles", func() {
 
 			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
In OCPBUGS-86731 the issue was likelly caused by DiskEncryptionEnabledOn was an empty string and the validation threated empty string as enabled. A new test is also added to test the robustness.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
