### PR TITLE
AGENT-1529: Add ovnKubernetesConfig to install-config definition

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -198,6 +198,14 @@ type MachineNetwork struct {
 	Cidr string `json:"cidr"`
 }
 
+type IPv4OVNKConfig struct {
+	InternalJoinSubnet string `json:"internalJoinSubnet,omitempty"`
+}
+
+type OVNKConfig struct {
+	IPv4 *IPv4OVNKConfig `json:"ipv4,omitempty"`
+}
+
 type Capabilities struct {
 	BaselineCapabilitySet         configv1.ClusterVersionCapabilitySet `json:"baselineCapabilitySet,omitempty"`
 	AdditionalEnabledCapabilities []configv1.ClusterVersionCapability  `json:"additionalEnabledCapabilities,omitempty"`
@@ -244,10 +252,11 @@ type InstallerConfigBaremetal struct {
 	BaseDomain string `json:"baseDomain"`
 	Proxy      *Proxy `json:"proxy,omitempty"`
 	Networking struct {
-		NetworkType    string           `json:"networkType"`
-		ClusterNetwork []ClusterNetwork `json:"clusterNetwork"`
-		MachineNetwork []MachineNetwork `json:"machineNetwork,omitempty"`
-		ServiceNetwork []string         `json:"serviceNetwork"`
+		NetworkType         string           `json:"networkType"`
+		ClusterNetwork      []ClusterNetwork `json:"clusterNetwork"`
+		MachineNetwork      []MachineNetwork `json:"machineNetwork,omitempty"`
+		ServiceNetwork      []string         `json:"serviceNetwork"`
+		OVNKubernetesConfig *OVNKConfig      `json:"ovnKubernetesConfig,omitempty"`
 	} `json:"networking"`
 	Metadata struct {
 		Name string `json:"name"`

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -677,10 +677,11 @@ func getInstallerConfigBaremetal() installcfg.InstallerConfigBaremetal {
 		APIVersion: "v1",
 		BaseDomain: "test.base.domain",
 		Networking: struct {
-			NetworkType    string                      `json:"networkType"`
-			ClusterNetwork []installcfg.ClusterNetwork `json:"clusterNetwork"`
-			MachineNetwork []installcfg.MachineNetwork `json:"machineNetwork,omitempty"`
-			ServiceNetwork []string                    `json:"serviceNetwork"`
+			NetworkType         string                      `json:"networkType"`
+			ClusterNetwork      []installcfg.ClusterNetwork `json:"clusterNetwork"`
+			MachineNetwork      []installcfg.MachineNetwork `json:"machineNetwork,omitempty"`
+			ServiceNetwork      []string                    `json:"serviceNetwork"`
+			OVNKubernetesConfig *installcfg.OVNKConfig      `json:"ovnKubernetesConfig,omitempty"`
 		}{
 			NetworkType:    "OpenShiftSDN",
 			ClusterNetwork: []installcfg.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}},


### PR DESCRIPTION
This allows this field to be specified in install config overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OVN Kubernetes networking in baremetal installer settings.
  * Users can now specify OVN Kubernetes parameters, including an IPv4 configuration block.
  * The baremetal networking configuration accepts an optional OVN Kubernetes configuration field for flexible setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->