### PR TITLE
MGMT-24495: Fix S3 additional_name and file_name

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -4155,6 +4156,10 @@ func (b *bareMetalInventory) V2GetPresignedForClusterFiles(ctx context.Context, 
 	if params.FileName == constants.ManifestFolder {
 		if params.AdditionalName != nil {
 			additionalName := *params.AdditionalName
+			if !filepath.IsLocal(additionalName) {
+				return common.NewApiError(http.StatusBadRequest,
+					errors.New("additional_name must be local to the manifest directory"))
+			}
 			fullFileName = manifests.GetManifestObjectName(params.ClusterID, additionalName)
 			downloadFilename = additionalName[strings.LastIndex(additionalName, "/")+1:]
 		} else {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11615,6 +11615,28 @@ var _ = Describe("KubeConfig download", func() {
 		Expect(*replyPayload.URL).Should(Equal("url"))
 	})
 
+	It("V2 presigned rejects path traversal in additional_name", func() {
+		mockS3Client.EXPECT().IsAwsS3().Return(true)
+		traversalName := "../../other-cluster-uuid/kubeconfig"
+		generateReply := bm.V2GetPresignedForClusterFiles(ctx, installer.V2GetPresignedForClusterFilesParams{
+			ClusterID:      clusterID,
+			FileName:       constants.ManifestFolder,
+			AdditionalName: &traversalName,
+		})
+		verifyApiError(generateReply, http.StatusBadRequest)
+	})
+
+	It("V2 presigned rejects absolute path in additional_name", func() {
+		mockS3Client.EXPECT().IsAwsS3().Return(true)
+		absoluteName := "/etc/passwd"
+		generateReply := bm.V2GetPresignedForClusterFiles(ctx, installer.V2GetPresignedForClusterFilesParams{
+			ClusterID:      clusterID,
+			FileName:       constants.ManifestFolder,
+			AdditionalName: &absoluteName,
+		})
+		verifyApiError(generateReply, http.StatusBadRequest)
+	})
+
 })
 
 var _ = Describe("DownloadMinimalInitrd", func() {

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -207,6 +207,10 @@ func (m *Manifests) DeleteClusterManifestInternal(ctx context.Context, params op
 
 	_, _, path := m.getManifestPathsFromParameters(ctx, params.Folder, &params.FileName)
 
+	if err = m.validateManifestFileNames(ctx, params.ClusterID, []string{params.FileName}); err != nil {
+		return err
+	}
+
 	err = m.deleteManifest(ctx, params.ClusterID, path)
 	if err != nil {
 		return err
@@ -296,6 +300,10 @@ func (m *Manifests) V2DownloadClusterManifest(ctx context.Context, params operat
 	// at the application level.
 	if _, err := common.GetClusterFromDB(m.db, params.ClusterID, false); err != nil {
 		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+	}
+
+	if err := m.validateManifestFileNames(ctx, params.ClusterID, []string{params.FileName}); err != nil {
+		return common.GenerateErrorResponder(err)
 	}
 
 	objectName := GetManifestObjectName(params.ClusterID, path)

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -949,6 +949,15 @@ invalid YAML content: {
 			Expect(err.StatusCode()).To(Equal(int32(http.StatusNotFound)))
 		})
 
+		It("rejects path traversal in file_name", func() {
+			clusterID := registerCluster().ID
+			response := manifestsAPI.V2DeleteClusterManifest(ctx, operations.V2DeleteClusterManifestParams{
+				ClusterID: *clusterID,
+				FileName:  "../../other-cluster/kubeconfig",
+			})
+			Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusUnprocessableEntity, errors.New(""))))
+		})
+
 		It("deletes after installation has been started", func() {
 			clusterID := strfmt.UUID(uuid.New().String())
 			cluster := common.Cluster{
@@ -1003,6 +1012,15 @@ invalid YAML content: {
 			Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusNotFound, errors.New(""))))
 			err := response.(*common.ApiErrorResponse)
 			Expect(err.StatusCode()).To(Equal(int32(http.StatusNotFound)))
+		})
+
+		It("rejects path traversal in file_name", func() {
+			clusterID := registerCluster().ID
+			response := manifestsAPI.V2DownloadClusterManifest(ctx, operations.V2DownloadClusterManifestParams{
+				ClusterID: *clusterID,
+				FileName:  "../../other-cluster/kubeconfig",
+			})
+			Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusUnprocessableEntity, errors.New(""))))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Reject `..` in the `additional_name` query parameter on the presigned file download endpoint (`V2GetPresignedForClusterFiles`)
- Add missing `validateManifestFileNames` call to the manifest download (`V2DownloadClusterManifest`) and delete (`DeleteClusterManifestInternal`) paths, matching the validation already present on create and update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of manifest and related file path inputs to block path-traversal and non-local additional names, preventing unauthorized file access.

* **Tests**
  * Added tests confirming the API rejects malicious or non-local file path attempts (including relative and absolute path patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->