### PR TITLE
MGMT-24496: Allow spaces between the value and unit for installcache

### DIFF
--- a/docs/dev/installercache.md
+++ b/docs/dev/installercache.md
@@ -13,7 +13,7 @@ The installer cache has a number of settings, which can be overridden by providi
 This defaults to `0`, which means that there is no limit to the size of the installer cache.
 This should be kept at zero if the storage directory is not ephemeral.
 
-Otherwise, it will accept a capacity, followed by either "GiB", "MiB", "KiB" or "B" 
+Otherwise, it will accept a capacity, followed by either "GiB", "MiB", "KiB", "GB", "MB", "KB" or "B"
 
 For example "32GiB"
 
@@ -22,7 +22,7 @@ For example "32GiB"
 This is the estimated maximum size that we believe any Openshift release could ever be. The default at the time of writing is 2GiB.
 This setting is used by the installercache to decide if there is enough space to write a release to the cache or if some things will need to be evicted first.
 
-This will accept a capacity, followed by either "GiB", "MiB", "KiB" or "B" 
+This will accept a capacity, followed by either "GiB", "MiB", "KiB", "GB", "MB", "KB" or "B"
 For example "1GiB"
 
 ### INSTALLER_CACHE_RELEASE_FETCH_RETRY_INTERVAL

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -53,11 +53,15 @@ type Config struct {
 }
 
 func (s *Size) Decode(value string) error {
-	bytes, err := units.ParseBase2Bytes(value)
+	toParse := strings.ReplaceAll(strings.TrimSpace(value), " ", "")
+
+	bytes, err := units.ParseStrictBytes(toParse)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse size %q (from %q): %w", toParse, value, err)
 	}
+
 	*s = Size(bytes)
+
 	return nil
 }
 

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/internal/metrics"
@@ -449,6 +450,56 @@ var _ = Describe("installer cache", func() {
 		Expect(linkCount).To(Equal(numberOfLinks - numberOfExpiredLinks))
 	})
 
+})
+
+var _ = Describe("Size.Decode", func() {
+	const (
+		oneGiB int64 = 1024 * 1024 * 1024
+		oneGB  int64 = 1000 * 1000 * 1000
+	)
+
+	DescribeTable("accepts unambiguous strings",
+		func(input string, expected Size) {
+			var s Size
+			Expect(s.Decode(input)).To(Succeed())
+			Expect(s).To(Equal(expected))
+		},
+
+		Entry("gibibytes", "20GiB", Size(20*oneGiB)),
+		Entry("mebibytes", "512MiB", Size(512*1024*1024)),
+		Entry("gigabyte", "20GB", Size(20*oneGB)),
+		Entry("megabytes", "512MB", Size(512*1000*1000)),
+		Entry("zero", "0", Size(0)),
+		Entry("zero with unit", "0GiB", Size(0)),
+		Entry("space between magnitude and unit", "20 GiB", Size(20*oneGiB)),
+	)
+
+	It("does not equate decimal GB with binary GiB", func() {
+		var gb, gib Size
+		Expect(gb.Decode("20GB")).To(Succeed())
+		Expect(gib.Decode("20GiB")).To(Succeed())
+		Expect(gb).NotTo(Equal(gib))
+	})
+
+	DescribeTable("rejects non-canonical unit casing",
+		func(input string) {
+			var s Size
+			Expect(s.Decode(input)).NotTo(Succeed())
+		},
+		Entry("lowercase gb", "20gb"),
+		Entry("all-caps iB suffix", "20GIB"),
+		Entry("mixed Gib looks like giga-bit not gibibyte", "20Gib"),
+		Entry("bare G without B", "20G"),
+	)
+
+	DescribeTable("rejects invalid spellings",
+		func(input string) {
+			var s Size
+			Expect(s.Decode(input)).NotTo(Succeed())
+		},
+		Entry("unit only", "GiB"),
+		Entry("unknown suffix", "20XB"),
+	)
 })
 
 func TestInstallerCache(t *testing.T) {


### PR DESCRIPTION
- installercache config values with a space (e.g. "20 GiB") raised a parsing error
- Also stop considering decimal prefixes as binary prefixes. Indeed `units.ParseBase2Bytes` was considering `10GB` as `10GiB`

So strictly speaking this introduces a change of behavior for users using the decimal prefixes. But those weren't documented and the change _lower_ the size, so it shouldn't be a big issue if someone used GB as GiB. On the other hand, if an user was doing 20 GB hoping it will behave as 20*1000*1000*1000, this will fix the case where more space were used

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installer cache docs to list additional accepted size unit suffixes and whitespace-tolerant formats.

* **Bug Fixes**
  * Improved size-parsing behavior: accepts more canonical unit formats, distinguishes decimal vs binary units (e.g., GB vs GiB), tolerates surrounding/embedded whitespace, and returns clearer error messages for invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->