### PR TITLE
MGMT-24407: do not reset stage timeout on progress info changes

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -586,8 +586,7 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 			return nil
 		}
 		updates := map[string]interface{}{
-			"progress_progress_info":    progress.ProgressInfo,
-			"progress_stage_updated_at": strfmt.DateTime(time.Now()),
+			"progress_progress_info": progress.ProgressInfo,
 		}
 		return m.updateHostAndNotify(ctx, m.db, h, updates).Error
 	}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -439,6 +439,27 @@ var _ = Describe("update_progress", func() {
 				Expect(hostFromDB.StageUpdatedAt.String()).Should(Equal(updatedAt))
 			})
 
+			It("same_stage_different_info_preserves_stage_updated_at", func() {
+				progress.CurrentStage = models.HostStageWritingImageToDisk
+				progress.ProgressInfo = "20%"
+				mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
+					eventstest.WithHostIdMatcher(host.ID.String()),
+					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
+					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
+				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
+				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
+				updatedAt := hostFromDB.StageUpdatedAt.String()
+
+				progress.ProgressInfo = "50%"
+				Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &progress)).ShouldNot(HaveOccurred())
+				hostFromDB = hostutil.GetHostFromDB(*hostFromDB.ID, host.InfraEnvID, db)
+				Expect(hostFromDB.Progress.ProgressInfo).Should(Equal("50%"))
+				Expect(hostFromDB.StageUpdatedAt.String()).Should(Equal(updatedAt))
+			})
+
 			It("writing to disk", func() {
 				progress.CurrentStage = models.HostStageWritingImageToDisk
 				progress.ProgressInfo = "20%"


### PR DESCRIPTION
## Problem

`UpdateInstallProgress` resets `progress_stage_updated_at` whenever `ProgressInfo` changes within the same stage. A host stuck in a stage (e.g. Joined) can avoid the configured timeout indefinitely as long as the installer keeps sending updates with varying info text.

## Fix

Remove `progress_stage_updated_at` from the same-stage update path so the timeout is anchored to when the stage was first entered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp accuracy for installation stage transitions. The stage change timestamp is now preserved when updating progress information without advancing to a new stage, providing clearer visibility into when installation stages actually changed during the provisioning process.

* **Tests**
  * Added test coverage for progress updates with unchanged stages to verify timestamp preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->