### PR TITLE
MGMT-24336: Bump LSO catalog fallback to v4.22 for OCP 5.0

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -24,22 +24,22 @@ function install_lso() {
 
 
     OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
-    if [[ ${OC_VERSION_MAJOR_MINOR} == "4.22" && "${DISCONNECTED}" != true ]]; then
-        # LSO has not been published to the 4.22 redhat-operators catalog, so
-        # it cannot be installed on OpenShift 4.22. Until this is resolved,
-        # we explicitly install the 4.21 catalog as redhat-operators-v4-21
-        # and then subscribe to the LSO version from the 4.21 rather than the 4.22 catalog.
-        # TODO: Bump the versions once LSO is published to the 4.22 catalog.
-        catalog_source_name="redhat-operators-v4-21"
+    if [[ ${OC_VERSION_MAJOR_MINOR} == "5.0" && "${DISCONNECTED}" != true ]]; then
+        # LSO has not been published to the 5.0 redhat-operators catalog, so
+        # it cannot be installed on OpenShift 5.0. Until this is resolved,
+        # we explicitly install the 4.22 catalog as redhat-operators-v4-22
+        # and then subscribe to the LSO version from the 4.22 rather than the 5.0 catalog.
+        # TODO: Bump the versions once LSO is published to the 5.0 catalog.
+        catalog_source_name="redhat-operators-v4-22"
         oc create -f - <<EOCR
         kind: CatalogSource
         apiVersion: operators.coreos.com/v1alpha1
         metadata:
-          name: redhat-operators-v4-21
+          name: redhat-operators-v4-22
           namespace: openshift-marketplace
         spec:
-          displayName: Red Hat Operators v4.21
-          image: registry.redhat.io/redhat/redhat-operator-index:v4.21
+          displayName: Red Hat Operators v4.22
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.22
           priority: -100
           publisher: Red Hat
           sourceType: grpc


### PR DESCRIPTION
LSO is not available in the redhat-operators catalog for pre-GA OCP versions. Bump the fallback so OCP 5.0 clusters install LSO from the v4.22 catalog.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for OpenShift 5.0 by creating a dedicated operator catalog source so the correct operator index is selected during installation on that platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
