### PR TITLE
MGMT-24550: Migrate NFD NodeFeatureRule apiVersion to nfd.k8s-sigs.io

### DIFF
--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_gpu_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_gpu_rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nfd.openshift.io/v1alpha1
+apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: amd-gpu

--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_nic_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_nic_rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nfd.openshift.io/v1alpha1
+apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: amd-nic

--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_vgpu_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_vgpu_rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nfd.openshift.io/v1alpha1
+apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: amd-vgpu


### PR DESCRIPTION
## Summary
- Migrate AMD GPU, vGPU, and NIC `NodeFeatureRule` manifests from `nfd.openshift.io/v1alpha1` to the recommended `nfd.k8s-sigs.io/v1alpha1` API group

## Context

The OpenShift `cluster-nfd-operator` is migrating `NodeFeatureRule` from the downstream `nfd.openshift.io` API group to the upstream `nfd.k8s-sigs.io`. Both CRDs are currently served, but the downstream version is [marked as a temp fix](https://github.com/openshift/cluster-nfd-operator/blob/master/Makefile) and will eventually be removed. The NFD team has confirmed `nfd.k8s-sigs.io/v1alpha1` is the recommended API group going forward.

Both AMD operators (gpu-operator and network-operator) have already adopted `nfd.k8s-sigs.io/v1alpha1` in their templates.

Jira: https://redhat.atlassian.net/browse/MGMT-24550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node Feature Discovery rule templates for AMD hardware detection to use the standard Kubernetes API group specification, improving cross-platform compatibility and enabling the operator to function on standard Kubernetes clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->