### PR TITLE
MGMT-24551: Add vNIC NFD rule and refine NIC subsystem matchers

### DIFF
--- a/internal/operators/nodefeaturediscovery/templates/custom/amd_vnic_rule.yaml
+++ b/internal/operators/nodefeaturediscovery/templates/custom/amd_vnic_rule.yaml
@@ -1,13 +1,13 @@
-apiVersion: nfd.openshift.io/v1alpha1
+apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
-  name: amd-nic
+  name: amd-vnic
   namespace: {{ .Operator.Namespace }}
 spec:
   rules:
-  - name: amd-nic
+  - name: amd-vnic
     labels:
-      feature.node.kubernetes.io/amd-nic: "true"
+      feature.node.kubernetes.io/amd-vnic: "true"
     matchFeatures:
     - feature: pci.device
       matchExpressions:
@@ -15,7 +15,7 @@ spec:
         device:
           op: In
           value:
-          - "1002" # DSC Ethernet Controller (PF)
+          - "1003" # DSC Ethernet Controller (VF)
         subsystem_vendor: {op: In, value: ["1dd8"]}
         subsystem_device:
           op: In


### PR DESCRIPTION
## Summary
- Add `amd_vnic_rule.yaml` NodeFeatureRule for AMD Pensando VF detection (device `1003`, subsystem `1dd8:5201` Pollara-1Q400)
- Update `amd_nic_rule.yaml` with `subsystem_vendor`/`subsystem_device` matchers to tighten PCI matching, aligning with upstream AMD network-operator templates

## Context

The existing NIC rule only matched on vendor+device, which could match unintended PCI functions. Adding subsystem matchers narrows detection to Pollara-1Q400 hardware specifically. The vNIC rule (VF counterpart) was missing entirely.

AMD Pensando Pollara 400G AI NIC has been officially introduced since 2025.

→ https://www.amd.com/en/blogs/2025/pollara400ainicreadyserverplatforms.html

Both rules align with the reference templates in the AMD network-operator.

Jira: https://redhat.atlassian.net/browse/MGMT-24551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded AMD NIC device detection with enhanced PCI matching criteria for better hardware identification
  * Added automatic node labeling for AMD virtual NIC devices, enabling improved workload scheduling and resource optimization in Kubernetes environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->