### PR TITLE
[release-ocm-2.16] ACM-35142: CVE-2025-58058 Bump github.com/ulikunitz/xz to v0.5.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/testcontainers/testcontainers-go v0.29.1
-	github.com/ulikunitz/xz v0.5.11 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.11 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.11 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,7 +336,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gormigrate/gormigrate/v2 v2.1.2 h1:F/d1hpHbRAvKezziV2CC5KUE82cVe9zTgHSBoOOZ4CY=
 github.com/go-gormigrate/gormigrate/v2 v2.1.2/go.mod h1:9nHVX6z3FCMCQPA7PThGcA55t22yKQfK/Dnsf5i7hUo=
-github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -1284,8 +1283,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
-github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ultraware/funlen v0.0.1/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/vendor/github.com/ulikunitz/xz/README.md
+++ b/vendor/github.com/ulikunitz/xz/README.md
@@ -75,3 +75,14 @@ To decompress it use the following command.
 
     $ gxz -d bigfile.xz
 
+## Security & Vulnerabilities
+
+The security policy is documented in [SECURITY.md](SECURITY.md). 
+
+The software is not affected by the supply chain attack on the original xz
+implementation, [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094).
+This implementation doesn't share any files with the original xz implementation
+and no patches or pull requests are accepted without a review.
+
+All security advisories for this project are published under
+[github.com/ulikunitz/xz/security/advisories](https://github.com/ulikunitz/xz/security/advisories?state=published).

--- a/vendor/github.com/ulikunitz/xz/SECURITY.md
+++ b/vendor/github.com/ulikunitz/xz/SECURITY.md
@@ -6,5 +6,14 @@ Currently the last minor version v0.5.x is supported.
 
 ## Reporting a Vulnerability
 
-Report a vulnerability by creating a Github issue at
-<https://github.com/ulikunitz/xz/issues>. Expect a response in a week.
+You can privately report a vulnerability following this
+[procedure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+Alternatively you can create a Github issue at
+<https://github.com/ulikunitz/xz/issues>.
+
+In both cases expect a response in at least 7 days.
+
+## Security Advisories
+
+All security advisories for this project are published under
+[github.com/ulikunitz/xz/security/advisories](https://github.com/ulikunitz/xz/security/advisories?state=published).

--- a/vendor/github.com/ulikunitz/xz/TODO.md
+++ b/vendor/github.com/ulikunitz/xz/TODO.md
@@ -1,9 +1,5 @@
 # TODO list
 
-## Release v0.5.x
-
-1. Support check flag in gxz command.
-
 ## Release v0.6
 
 1. Review encoder and check for lzma improvements under xz.
@@ -86,6 +82,24 @@
 
 ## Log
 
+## 2025-08-28
+
+Release v0.5.14 addresses the security vulnerability CVE-2025-58058. If you put
+bytes in from of a LZMA stream, the header might not be read correctly and
+memory for the dictionary buffer allocated. I have implemented mitigations for
+the problem.
+
+### 2025-08-20
+
+Release v0.5.13 addressed issue #61 regarding handling of multiple WriteClosers
+together. So I added a new package xio with a WriteCloserStack to address the
+issue.
+
+### 2024-04-03
+
+Release v0.5.12 updates README.md and SECURITY.md to address the supply chain
+attack on the original xz implementation.
+
 ### 2022-12-12
 
 Matt Dantay (@bodgit) reported an issue with the LZMA reader. The implementation
@@ -99,7 +113,7 @@ it.
 
 Mituo Heijo has fuzzed xz and found a bug in the function readIndexBody. The
 function allocated a slice of records immediately after reading the value
-without further checks. Sincex the number has been too large the make function
+without further checks. Since the number has been too large the make function
 did panic. The fix is to check the number against the expected number of records
 before allocating the records.
 

--- a/vendor/github.com/ulikunitz/xz/lzma/reader.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/reader.go
@@ -6,25 +6,32 @@
 // Reader and Writer support the classic LZMA format. Reader2 and
 // Writer2 support the decoding and encoding of LZMA2 streams.
 //
-// The package is written completely in Go and doesn't rely on any external
+// The package is written completely in Go and does not rely on any external
 // library.
 package lzma
 
 import (
 	"errors"
+	"fmt"
 	"io"
 )
 
 // ReaderConfig stores the parameters for the reader of the classic LZMA
 // format.
 type ReaderConfig struct {
+	// Since v0.5.14 this parameter sets an upper limit for a .lzma file's
+	// dictionary size. This helps to mitigate problems with mangled
+	// headers.
 	DictCap int
 }
 
 // fill converts the zero values of the configuration to the default values.
 func (c *ReaderConfig) fill() {
 	if c.DictCap == 0 {
-		c.DictCap = 8 * 1024 * 1024
+		// set an upper limit of 2 GiB-1 for dictionary capacity
+		// to address the zero prefix security issue.
+		c.DictCap = (1 << 31) - 1
+		// original: c.DictCap = 8 * 1024 * 1024
 	}
 }
 
@@ -39,10 +46,33 @@ func (c *ReaderConfig) Verify() error {
 }
 
 // Reader provides a reader for LZMA files or streams.
+//
+// # Security concerns
+//
+// Note that LZMA format doesn't support a magic marker in the header. So
+// [NewReader] cannot determine whether it reads the actual header. For instance
+// the LZMA stream might have a zero byte in front of the reader, leading to
+// larger dictionary sizes and file sizes. The code will detect later that there
+// are problems with the stream, but the dictionary has already been allocated
+// and this might consume a lot of memory.
+//
+// Version 0.5.14 introduces built-in mitigations:
+//
+//   - The [ReaderConfig] DictCap field is now interpreted as a limit for the
+//     dictionary size.
+//   - The default is 2 Gigabytes minus 1 byte (2^31-1 bytes).
+//   - Users can check with the [Reader.Header] method what the actual values are in
+//     their LZMA files and set a smaller limit using [ReaderConfig].
+//   - The dictionary size doesn't exceed the larger of the file size and
+//     the minimum dictionary size. This is another measure to prevent huge
+//     memory allocations for the dictionary.
+//   - The code supports stream sizes only up to a pebibyte (1024^5).
 type Reader struct {
-	lzma io.Reader
-	h    header
-	d    *decoder
+	lzma   io.Reader
+	header Header
+	// headerOrig stores the original header read from the stream.
+	headerOrig Header
+	d          *decoder
 }
 
 // NewReader creates a new reader for an LZMA stream using the classic
@@ -51,8 +81,37 @@ func NewReader(lzma io.Reader) (r *Reader, err error) {
 	return ReaderConfig{}.NewReader(lzma)
 }
 
+// ErrDictSize reports about an error of the dictionary size.
+type ErrDictSize struct {
+	ConfigDictCap  int
+	HeaderDictSize uint32
+	Message        string
+}
+
+// Error returns the error message.
+func (e *ErrDictSize) Error() string {
+	return e.Message
+}
+
+func newErrDictSize(messageformat string,
+	configDictCap int, headerDictSize uint32,
+	args ...interface{}) *ErrDictSize {
+	newArgs := make([]interface{}, len(args)+2)
+	newArgs[0] = configDictCap
+	newArgs[1] = headerDictSize
+	copy(newArgs[2:], args)
+	return &ErrDictSize{
+		ConfigDictCap:  configDictCap,
+		HeaderDictSize: headerDictSize,
+		Message:        fmt.Sprintf(messageformat, newArgs...),
+	}
+}
+
+// We support only files not larger than 1 << 50 bytes (a pebibyte, 1024^5).
+const maxStreamSize = 1 << 50
+
 // NewReader creates a new reader for an LZMA stream in the classic
-// format. The function reads and verifies the the header of the LZMA
+// format. The function reads and verifies the header of the LZMA
 // stream.
 func (c ReaderConfig) NewReader(lzma io.Reader) (r *Reader, err error) {
 	if err = c.Verify(); err != nil {
@@ -66,27 +125,61 @@ func (c ReaderConfig) NewReader(lzma io.Reader) (r *Reader, err error) {
 		return nil, err
 	}
 	r = &Reader{lzma: lzma}
-	if err = r.h.unmarshalBinary(data); err != nil {
+	if err = r.header.unmarshalBinary(data); err != nil {
 		return nil, err
 	}
-	if r.h.dictCap < MinDictCap {
-		r.h.dictCap = MinDictCap
+	r.headerOrig = r.header
+	dictSize := int64(r.header.DictSize)
+	if int64(c.DictCap) < dictSize {
+		return nil, newErrDictSize(
+			"lzma: header dictionary size %[2]d exceeds configured dictionary capacity %[1]d",
+			c.DictCap, uint32(dictSize),
+		)
 	}
-	dictCap := r.h.dictCap
-	if c.DictCap > dictCap {
-		dictCap = c.DictCap
+	if dictSize < MinDictCap {
+		dictSize = MinDictCap
+	}
+	// original code: disabled this because there is no point in increasing
+	// the dictionary above what is stated in the file.
+	/*
+		if int64(c.DictCap) > int64(dictSize) {
+			dictSize = int64(c.DictCap)
+		}
+	*/
+	size := r.header.Size
+	if size >= 0 && size < dictSize {
+		dictSize = size
+	}
+	// Protect against modified or malicious headers.
+	if size > maxStreamSize {
+		return nil, fmt.Errorf(
+			"lzma: stream size %d exceeds a pebibyte (1024^5)",
+			size)
+	}
+	if dictSize < MinDictCap {
+		dictSize = MinDictCap
 	}
 
-	state := newState(r.h.properties)
-	dict, err := newDecoderDict(dictCap)
+	r.header.DictSize = uint32(dictSize)
+
+	state := newState(r.header.Properties)
+	dict, err := newDecoderDict(int(dictSize))
 	if err != nil {
 		return nil, err
 	}
-	r.d, err = newDecoder(ByteReader(lzma), state, dict, r.h.size)
+	r.d, err = newDecoder(ByteReader(lzma), state, dict, r.header.Size)
 	if err != nil {
 		return nil, err
 	}
 	return r, nil
+}
+
+// Header returns the header as read from the LZMA stream. It is intended to
+// allow the user to understand what parameters are typically provided in the
+// headers of the LZMA files and set the DictCap field in [ReaderConfig]
+// accordingly.
+func (r *Reader) Header() (h Header, ok bool) {
+	return r.headerOrig, r.d != nil
 }
 
 // EOSMarker indicates that an EOS marker has been encountered.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1021,7 +1021,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/ulikunitz/xz v0.5.11
+# github.com/ulikunitz/xz v0.5.15
 ## explicit; go 1.12
 github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash


### PR DESCRIPTION
Bump `github.com/ulikunitz/xz` from v0.5.11 to v0.5.15 to fix CVE-2025-58058.

## Changes
- `github.com/ulikunitz/xz` v0.5.11 → v0.5.15
- Vendor updated

https://redhat.atlassian.net/browse/ACM-35142