### PR TITLE
MGMT-21368: Log slow queries gorm

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -160,6 +161,8 @@ var Options struct {
 	MaxIdleConns                         int           `envconfig:"DB_MAX_IDLE_CONNECTIONS" default:"50"`
 	MaxOpenConns                         int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"90"`
 	ConnMaxLifetime                      time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
+	DBLogSlowQueries                     bool          `envconfig:"DB_LOG_SLOW_QUERIES" default:"false"`
+	DBSlowQueryThreshold                 time.Duration `envconfig:"DB_SLOW_QUERY_THRESHOLD" default:"200ms"`
 	FileSystemUsageThreshold             int           `envconfig:"FILESYSTEM_USAGE_THRESHOLD" default:"80"`
 	EnableNotificationStreaming          bool          `envconfig:"ENABLE_EVENT_STREAMING" default:"false"`
 	WorkDir                              string        `envconfig:"WORK_DIR" default:"/data/"`
@@ -801,6 +804,21 @@ func setupServerForIPXE(serverInfo *servers.ServerInfo, h http.Handler) {
 	}
 }
 
+func newGormLogger(fieldLog logrus.FieldLogger) logger.Interface {
+	if !Options.DBLogSlowQueries {
+		return logger.Default.LogMode(logger.Silent)
+	}
+	fieldLog.WithField("slow_threshold", Options.DBSlowQueryThreshold).Info("GORM slow query logging enabled")
+	return logger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		logger.Config{
+			SlowThreshold:             Options.DBSlowQueryThreshold,
+			LogLevel:                  logger.Warn,
+			IgnoreRecordNotFoundError: true,
+		},
+	)
+}
+
 func setupDB(log logrus.FieldLogger) *gorm.DB {
 	dbConnectionStr, validationErr := Options.DBConfig.LibpqDSN()
 	if validationErr != nil {
@@ -816,7 +834,7 @@ func setupDB(log logrus.FieldLogger) *gorm.DB {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		db, err = gorm.Open(postgres.Open(dbConnectionStr), &gorm.Config{
 			DisableForeignKeyConstraintWhenMigrating: true,
-			Logger:                                   logger.Default.LogMode(logger.Silent),
+			Logger:                                   newGormLogger(log),
 		})
 		if err != nil {
 			log.WithError(err).Info("Failed to connect to DB, retrying")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -64,6 +63,7 @@ import (
 	"github.com/openshift/assisted-service/pkg/auth"
 	paramctx "github.com/openshift/assisted-service/pkg/context"
 	dbPkg "github.com/openshift/assisted-service/pkg/db"
+	"github.com/openshift/assisted-service/pkg/db/slowquery"
 	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/openshift/assisted-service/pkg/generator"
 	"github.com/openshift/assisted-service/pkg/k8sclient"
@@ -82,7 +82,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -162,7 +161,9 @@ var Options struct {
 	MaxOpenConns                         int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"90"`
 	ConnMaxLifetime                      time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
 	DBLogSlowQueries                     bool          `envconfig:"DB_LOG_SLOW_QUERIES" default:"false"`
+	DBSlowQueryScopes                    string        `envconfig:"DB_SLOW_QUERY_SCOPES" default:""`
 	DBSlowQueryThreshold                 time.Duration `envconfig:"DB_SLOW_QUERY_THRESHOLD" default:"200ms"`
+	DBSlowQueryHTTPRoutes                string        `envconfig:"DB_SLOW_QUERY_HTTP_ROUTES" default:""`
 	FileSystemUsageThreshold             int           `envconfig:"FILESYSTEM_USAGE_THRESHOLD" default:"80"`
 	EnableNotificationStreaming          bool          `envconfig:"ENABLE_EVENT_STREAMING" default:"false"`
 	WorkDir                              string        `envconfig:"WORK_DIR" default:"/data/"`
@@ -449,8 +450,22 @@ func main() {
 	log.Println(fmt.Sprintf("Started service with OS Images %v, Release Images %v, Release Sources %v, Ignored OpenShift Versions %v",
 		Options.OsImages, Options.ReleaseImages, Options.ReleaseSourcesConfig.ReleaseSources, Options.IgnoredOpenshiftVersions))
 
+	slowQueryConfig := slowquery.NewConfig(
+		Options.DBSlowQueryScopes,
+		Options.DBLogSlowQueries,
+		Options.DBSlowQueryThreshold,
+		Options.DBSlowQueryHTTPRoutes,
+	)
+	if slowQueryConfig.Enabled() {
+		log.WithFields(logrus.Fields{
+			"scopes":         Options.DBSlowQueryScopes,
+			"slow_threshold": Options.DBSlowQueryThreshold,
+			"http_routes":    Options.DBSlowQueryHTTPRoutes,
+		}).Info("GORM scoped slow query logging enabled")
+	}
+
 	// Connect to db
-	db := setupDB(log)
+	db := setupDB(log, slowQueryConfig)
 	defer common.CloseDB(db)
 
 	ctrlMgr, err := createControllerManager()
@@ -729,6 +744,7 @@ func main() {
 		return func(h http.Handler) http.Handler {
 			wrapped := metrics.WithMatchedRoute(log.WithField("pkg", "matched-h"), prometheusRegistry)(h)
 
+			wrapped = slowquery.Middleware(slowQueryConfig)(wrapped)
 			wrapped = paramctx.ContextHandler()(wrapped)
 			return wrapped
 		}
@@ -804,22 +820,7 @@ func setupServerForIPXE(serverInfo *servers.ServerInfo, h http.Handler) {
 	}
 }
 
-func newGormLogger(fieldLog logrus.FieldLogger) logger.Interface {
-	if !Options.DBLogSlowQueries {
-		return logger.Default.LogMode(logger.Silent)
-	}
-	fieldLog.WithField("slow_threshold", Options.DBSlowQueryThreshold).Info("GORM slow query logging enabled")
-	return logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags),
-		logger.Config{
-			SlowThreshold:             Options.DBSlowQueryThreshold,
-			LogLevel:                  logger.Warn,
-			IgnoreRecordNotFoundError: true,
-		},
-	)
-}
-
-func setupDB(log logrus.FieldLogger) *gorm.DB {
+func setupDB(log logrus.FieldLogger, slowQueryConfig slowquery.Config) *gorm.DB {
 	dbConnectionStr, validationErr := Options.DBConfig.LibpqDSN()
 	if validationErr != nil {
 		log.WithError(validationErr).Fatal("Invalid DB connection config")
@@ -834,7 +835,7 @@ func setupDB(log logrus.FieldLogger) *gorm.DB {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		db, err = gorm.Open(postgres.Open(dbConnectionStr), &gorm.Config{
 			DisableForeignKeyConstraintWhenMigrating: true,
-			Logger:                                   newGormLogger(log),
+			Logger:                                   slowquery.NewLogger(slowQueryConfig, os.Stdout),
 		})
 		if err != nil {
 			log.WithError(err).Info("Failed to connect to DB, retrying")

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/commonutils"
+	"github.com/openshift/assisted-service/pkg/db/slowquery"
 	"github.com/openshift/assisted-service/pkg/leader"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/pkg/ocm"
@@ -624,6 +625,9 @@ func (m *Manager) ClusterMonitoring() {
 		m.log.Debugf("Not a leader, exiting ClusterMonitoring")
 		return
 	}
+	slowquery.SetGoroutineScope(slowquery.ScopeClusterMonitor, "")
+	defer slowquery.ClearGoroutineScope()
+
 	m.log.Debugf("Running ClusterMonitoring")
 	defer commonutils.MeasureOperation("ClusterMonitoring", m.log, m.metricAPI)()
 
@@ -700,7 +704,7 @@ type monitoringCycle struct {
 // initMonitoringCycle sets up the context, logging, deadlines, and query for a monitoring cycle
 func (m *Manager) initMonitoringCycle() *monitoringCycle {
 	requestID := requestid.NewID()
-	baseCtx := requestid.ToContext(context.Background(), requestID)
+	baseCtx := slowquery.WithScope(requestid.ToContext(context.Background(), requestID), slowquery.ScopeClusterMonitor)
 	log := requestid.RequestIDLogger(m.log, requestID)
 
 	startTime := time.Now()

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/commonutils"
 	"github.com/openshift/assisted-service/pkg/conversions"
+	"github.com/openshift/assisted-service/pkg/db/slowquery"
 	"github.com/openshift/assisted-service/pkg/requestid"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
@@ -176,7 +177,7 @@ func (m *Manager) resetRoleAssignmentIfNotAllRolesAreSet() {
 func (m *Manager) clusterHostMonitoring() {
 	var (
 		requestID = requestid.NewID()
-		ctx       = requestid.ToContext(context.Background(), requestID)
+		ctx       = slowquery.WithScope(requestid.ToContext(context.Background(), requestID), slowquery.ScopeHostMonitor)
 		log       = requestid.RequestIDLogger(m.log, requestID)
 		clusters  []*common.Cluster
 		err       error
@@ -255,7 +256,7 @@ func (m *Manager) clusterHostMonitoring() {
 func (m *Manager) infraEnvHostMonitoring() {
 	var (
 		requestID = requestid.NewID()
-		ctx       = requestid.ToContext(context.Background(), requestID)
+		ctx       = slowquery.WithScope(requestid.ToContext(context.Background(), requestID), slowquery.ScopeHostMonitor)
 		log       = requestid.RequestIDLogger(m.log, requestID)
 		infraEnvs []*common.InfraEnv
 		err       error
@@ -317,6 +318,9 @@ func (m *Manager) HostMonitoring() {
 		m.log.Debugf("Not a leader, exiting HostMonitoring")
 		return
 	}
+	slowquery.SetGoroutineScope(slowquery.ScopeHostMonitor, "")
+	defer slowquery.ClearGoroutineScope()
+
 	defer commonutils.MeasureOperation("HostMonitoring", m.log, m.metricApi)()
 	m.initMonitoringQueryGenerator()
 	m.clusterHostMonitoring()

--- a/pkg/db/slowquery/middleware.go
+++ b/pkg/db/slowquery/middleware.go
@@ -1,0 +1,45 @@
+package slowquery
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	rmiddleware "github.com/go-openapi/runtime/middleware"
+)
+
+// Middleware annotates HTTP requests with the HTTP slow-query scope for matching routes.
+func Middleware(cfg Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !cfg.scopeEnabled(ScopeHTTP) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			route := routeLabel(r)
+			if !cfg.matchesHTTPRoute(route) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			SetGoroutineScope(ScopeHTTP, route)
+			defer ClearGoroutineScope()
+
+			ctx := WithRoute(WithScope(r.Context(), ScopeHTTP), route)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func routeLabel(r *http.Request) string {
+	if mr := rmiddleware.MatchedRouteFrom(r); mr != nil {
+		if mr.Operation != nil && mr.Operation.ID != "" {
+			return mr.Operation.ID
+		}
+		if mr.PathPattern != "" {
+			return fmt.Sprintf("%s %s", strings.ToUpper(r.Method), mr.PathPattern)
+		}
+	}
+	return fmt.Sprintf("%s %s", strings.ToUpper(r.Method), r.URL.Path)
+}

--- a/pkg/db/slowquery/slowquery.go
+++ b/pkg/db/slowquery/slowquery.go
@@ -1,0 +1,280 @@
+package slowquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"gorm.io/gorm/utils"
+)
+
+const (
+	ScopeClusterMonitor = "cluster-monitor"
+	ScopeHostMonitor    = "host-monitor"
+	ScopeHTTP           = "http"
+)
+
+type ctxKey int
+
+const (
+	ctxScope ctxKey = iota
+	ctxRoute
+)
+
+// Config controls which parts of the application emit GORM slow-query logs.
+type Config struct {
+	// EnabledScopes lists scopes that may emit slow-query logs (e.g. cluster-monitor, host-monitor, http).
+	EnabledScopes map[string]struct{}
+	// DefaultThreshold is used when a scope does not define its own threshold.
+	DefaultThreshold time.Duration
+	// HTTPRoutes limits HTTP scope logging to matching route labels. Empty means all HTTP routes.
+	HTTPRoutes []string
+}
+
+// AllScopes returns the built-in scope names.
+func AllScopes() []string {
+	return []string{ScopeClusterMonitor, ScopeHostMonitor, ScopeHTTP}
+}
+
+// ParseScopes parses a comma-separated scope list.
+func ParseScopes(raw string) map[string]struct{} {
+	scopes := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		scope := strings.TrimSpace(part)
+		if scope != "" {
+			scopes[scope] = struct{}{}
+		}
+	}
+	return scopes
+}
+
+// ParseHTTPRoutes parses a comma-separated HTTP route filter list.
+func ParseHTTPRoutes(raw string) []string {
+	var routes []string
+	for _, part := range strings.Split(raw, ",") {
+		route := strings.TrimSpace(part)
+		if route != "" {
+			routes = append(routes, route)
+		}
+	}
+	return routes
+}
+
+// NewConfig builds a Config. When scopes is empty and legacyGlobal is true, all built-in scopes are enabled.
+func NewConfig(scopes string, legacyGlobal bool, defaultThreshold time.Duration, httpRoutes string) Config {
+	enabled := ParseScopes(scopes)
+	if len(enabled) == 0 && legacyGlobal {
+		enabled = ParseScopes(strings.Join(AllScopes(), ","))
+	}
+	return Config{
+		EnabledScopes:    enabled,
+		DefaultThreshold: defaultThreshold,
+		HTTPRoutes:       ParseHTTPRoutes(httpRoutes),
+	}
+}
+
+func (c Config) Enabled() bool {
+	return len(c.EnabledScopes) > 0
+}
+
+func (c Config) scopeEnabled(scope string) bool {
+	_, ok := c.EnabledScopes[scope]
+	return ok
+}
+
+func (c Config) matchesHTTPRoute(route string) bool {
+	if len(c.HTTPRoutes) == 0 {
+		return true
+	}
+	route = strings.ToLower(route)
+	for _, pattern := range c.HTTPRoutes {
+		if strings.Contains(route, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) shouldLog(scope, route string) bool {
+	if scope == "" || !c.scopeEnabled(scope) {
+		return false
+	}
+	if scope == ScopeHTTP && !c.matchesHTTPRoute(route) {
+		return false
+	}
+	return true
+}
+
+func (c Config) threshold(_ string) time.Duration {
+	if c.DefaultThreshold > 0 {
+		return c.DefaultThreshold
+	}
+	return 200 * time.Millisecond
+}
+
+// WithScope annotates ctx with a slow-query logging scope for context-aware DB calls.
+func WithScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, ctxScope, scope)
+}
+
+// WithRoute annotates ctx with an HTTP route label (operation ID or method+path).
+func WithRoute(ctx context.Context, route string) context.Context {
+	return context.WithValue(ctx, ctxRoute, route)
+}
+
+func scopeFromContext(ctx context.Context) (scope, route string) {
+	if ctx == nil {
+		return "", ""
+	}
+	if v, ok := ctx.Value(ctxScope).(string); ok {
+		scope = v
+	}
+	if v, ok := ctx.Value(ctxRoute).(string); ok {
+		route = v
+	}
+	return scope, route
+}
+
+type goroutineScope struct {
+	scope string
+	route string
+}
+
+var goroutineScopes sync.Map
+
+// SetGoroutineScope marks the current goroutine with a slow-query scope until ClearGoroutineScope is called.
+// This is used for HTTP handlers and background jobs that do not pass context into every DB call.
+func SetGoroutineScope(scope, route string) {
+	goroutineScopes.Store(currentGoID(), goroutineScope{scope: scope, route: route})
+}
+
+// ClearGoroutineScope removes the scope for the current goroutine.
+func ClearGoroutineScope() {
+	goroutineScopes.Delete(currentGoID())
+}
+
+func goroutineScopeFromRegistry() (scope, route string, ok bool) {
+	v, found := goroutineScopes.Load(currentGoID())
+	if !found {
+		return "", "", false
+	}
+	gs := v.(goroutineScope)
+	return gs.scope, gs.route, true
+}
+
+func resolveScope(ctx context.Context) (scope, route string) {
+	scope, route = scopeFromContext(ctx)
+	if scope != "" {
+		return scope, route
+	}
+	scope, route, ok := goroutineScopeFromRegistry()
+	if ok {
+		return scope, route
+	}
+	return "", ""
+}
+
+func currentGoID() string {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
+	return idField
+}
+
+// sqlStringLiteral matches PostgreSQL-style single-quoted string literals, including ” escapes.
+var sqlStringLiteral = regexp.MustCompile(`'(?:''|[^'])*'`)
+
+// redactSQLLiterals masks string literals that may contain customer or credential data.
+// Placeholders such as $1 are left unchanged.
+func redactSQLLiterals(sql string) string {
+	return sqlStringLiteral.ReplaceAllString(sql, "'?'")
+}
+
+func (l *scopedLogger) tracedSQL(fc func() (string, int64)) (string, int64) {
+	sql, rows := fc()
+	return redactSQLLiterals(sql), rows
+}
+
+// NewLogger returns a GORM logger that emits slow SQL only for enabled scopes.
+func NewLogger(cfg Config, out io.Writer) logger.Interface {
+	if out == nil {
+		out = os.Stdout
+	}
+	return &scopedLogger{
+		cfg:          cfg,
+		writer:       log.New(out, "\r\n", log.LstdFlags),
+		traceStr:     "%s\n[%.3fms] [rows:%v] [scope:%s] %s",
+		traceWarnStr: "%s %s\n[%.3fms] [rows:%v] [scope:%s] %s",
+		traceErrStr:  "%s %s\n[%.3fms] [rows:%v] [scope:%s] %s",
+	}
+}
+
+type scopedLogger struct {
+	cfg                                 Config
+	writer                              logger.Writer
+	traceStr, traceWarnStr, traceErrStr string
+}
+
+var _ gorm.ParamsFilter = (*scopedLogger)(nil)
+
+func (l *scopedLogger) LogMode(level logger.LogLevel) logger.Interface {
+	return l
+}
+
+func (l *scopedLogger) Info(context.Context, string, ...interface{}) {}
+
+func (l *scopedLogger) Warn(context.Context, string, ...interface{}) {}
+
+func (l *scopedLogger) Error(context.Context, string, ...interface{}) {}
+
+// ParamsFilter implements gorm.ParamsFilter so Explain() keeps placeholder syntax ($1, ?)
+// instead of interpolating bound values into logged SQL.
+func (l *scopedLogger) ParamsFilter(_ context.Context, sql string, _ ...interface{}) (string, []interface{}) {
+	return sql, nil
+}
+
+func (l *scopedLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	if !l.cfg.Enabled() {
+		return
+	}
+
+	scope, route := resolveScope(ctx)
+	if !l.cfg.shouldLog(scope, route) {
+		return
+	}
+
+	threshold := l.cfg.threshold(scope)
+	elapsed := time.Since(begin)
+	scopeLabel := scope
+	if route != "" {
+		scopeLabel = fmt.Sprintf("%s:%s", scope, route)
+	}
+
+	switch {
+	case err != nil && (!errors.Is(err, logger.ErrRecordNotFound)):
+		sql, rows := l.tracedSQL(fc)
+		if rows == -1 {
+			l.writer.Printf(l.traceErrStr, utils.FileWithLineNum(), err, float64(elapsed.Nanoseconds())/1e6, "-", scopeLabel, sql)
+		} else {
+			l.writer.Printf(l.traceErrStr, utils.FileWithLineNum(), err, float64(elapsed.Nanoseconds())/1e6, rows, scopeLabel, sql)
+		}
+	case elapsed > threshold:
+		sql, rows := l.tracedSQL(fc)
+		slowLog := fmt.Sprintf("SLOW SQL >= %v", threshold)
+		if rows == -1 {
+			l.writer.Printf(l.traceWarnStr, utils.FileWithLineNum(), slowLog, float64(elapsed.Nanoseconds())/1e6, "-", scopeLabel, sql)
+		} else {
+			l.writer.Printf(l.traceWarnStr, utils.FileWithLineNum(), slowLog, float64(elapsed.Nanoseconds())/1e6, rows, scopeLabel, sql)
+		}
+	}
+}

--- a/pkg/db/slowquery/slowquery_test.go
+++ b/pkg/db/slowquery/slowquery_test.go
@@ -1,0 +1,112 @@
+package slowquery
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSlowQuery(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Slow query")
+}
+
+var _ = Describe("ParseScopes", func() {
+	It("parses a comma-separated scope list", func() {
+		Expect(ParseScopes(" cluster-monitor , host-monitor,http ")).To(Equal(map[string]struct{}{
+			ScopeClusterMonitor: {},
+			ScopeHostMonitor:    {},
+			ScopeHTTP:           {},
+		}))
+	})
+})
+
+var _ = Describe("NewConfig", func() {
+	It("enables all built-in scopes when legacy global logging is on and scopes are empty", func() {
+		cfg := NewConfig("", true, 100*time.Millisecond, "")
+		Expect(cfg.Enabled()).To(BeTrue())
+		Expect(cfg.scopeEnabled(ScopeClusterMonitor)).To(BeTrue())
+		Expect(cfg.scopeEnabled(ScopeHTTP)).To(BeTrue())
+	})
+})
+
+var _ = Describe("Config HTTP route filter", func() {
+	It("matches only configured HTTP routes", func() {
+		cfg := NewConfig(ScopeHTTP, false, time.Millisecond, "V2UpdateCluster")
+		Expect(cfg.shouldLog(ScopeHTTP, "V2UpdateCluster")).To(BeTrue())
+		Expect(cfg.shouldLog(ScopeHTTP, "V2GetClusters")).To(BeFalse())
+	})
+
+	It("accepts operation ID route labels", func() {
+		cfg := NewConfig(ScopeHTTP, false, time.Millisecond, "V2GetCluster")
+		Expect(cfg.shouldLog(ScopeHTTP, "V2GetCluster")).To(BeTrue())
+	})
+})
+
+var _ = Describe("scopedLogger", func() {
+	It("logs slow SQL only for enabled scopes", func() {
+		var buf bytes.Buffer
+		cfg := NewConfig(ScopeClusterMonitor, false, time.Millisecond, "")
+		log := NewLogger(cfg, &buf)
+
+		ctx := WithScope(context.Background(), ScopeClusterMonitor)
+		log.Trace(ctx, time.Now().Add(-2*time.Millisecond), func() (string, int64) { return "SELECT 1", 1 }, nil)
+		Expect(buf.String()).To(ContainSubstring("SLOW SQL"))
+		Expect(buf.String()).To(ContainSubstring(ScopeClusterMonitor))
+
+		buf.Reset()
+		log.Trace(context.Background(), time.Now().Add(-2*time.Millisecond), func() (string, int64) { return "SELECT 2", 1 }, nil)
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("resolves scope from the goroutine registry", func() {
+		var buf bytes.Buffer
+		cfg := NewConfig(ScopeHostMonitor, false, time.Millisecond, "")
+		log := NewLogger(cfg, &buf)
+
+		SetGoroutineScope(ScopeHostMonitor, "")
+		defer ClearGoroutineScope()
+
+		log.Trace(context.Background(), time.Now().Add(-2*time.Millisecond), func() (string, int64) { return "SELECT 3", 1 }, nil)
+		Expect(buf.String()).To(ContainSubstring(ScopeHostMonitor))
+	})
+
+	It("does not interpolate bound parameter values into logged SQL", func() {
+		var buf bytes.Buffer
+		l := NewLogger(NewConfig(ScopeClusterMonitor, false, time.Millisecond, ""), &buf).(*scopedLogger)
+		ctx := WithScope(context.Background(), ScopeClusterMonitor)
+
+		sql, params := l.ParamsFilter(ctx, "SELECT * FROM clusters WHERE pull_secret = $1", "top-secret-value")
+		Expect(sql).To(Equal("SELECT * FROM clusters WHERE pull_secret = $1"))
+		Expect(params).To(BeNil())
+
+		l.Trace(ctx, time.Now().Add(-2*time.Millisecond), func() (string, int64) {
+			return sql, 1
+		}, nil)
+		Expect(buf.String()).To(ContainSubstring("$1"))
+		Expect(buf.String()).NotTo(ContainSubstring("top-secret-value"))
+	})
+
+	It("redacts string literals from logged SQL", func() {
+		Expect(redactSQLLiterals("SELECT * FROM hosts WHERE email = 'user@example.com'")).To(
+			Equal("SELECT * FROM hosts WHERE email = '?'"),
+		)
+		Expect(redactSQLLiterals("SELECT * FROM clusters WHERE pull_secret = $1")).To(
+			Equal("SELECT * FROM clusters WHERE pull_secret = $1"),
+		)
+		Expect(redactSQLLiterals("WHERE name = 'O''Reilly'")).To(Equal("WHERE name = '?'"))
+
+		var buf bytes.Buffer
+		l := NewLogger(NewConfig(ScopeClusterMonitor, false, time.Millisecond, ""), &buf).(*scopedLogger)
+		ctx := WithScope(context.Background(), ScopeClusterMonitor)
+		l.Trace(ctx, time.Now().Add(-2*time.Millisecond), func() (string, int64) {
+			return "SELECT * FROM clusters WHERE name = 'production-cluster'", 1
+		}, nil)
+		Expect(buf.String()).To(ContainSubstring("name = '?'"))
+		Expect(buf.String()).NotTo(ContainSubstring("production-cluster"))
+	})
+})


### PR DESCRIPTION
[MGMT-21368](https://redhat.atlassian.net/browse/MGMT-21368): Add scoped GORM slow-query logging
    
    Adding scope-aware filtering so SQL is
    logged only for selected parts of the service (cluster monitor, host
    monitor, HTTP handlers). Introduce pkg/db/slowquery with a custom GORM
    logger, context and goroutine scope tagging, and HTTP middleware for
    route-level filtering via DB_SLOW_QUERY_SCOPES, DB_SLOW_QUERY_THRESHOLD,
    and DB_SLOW_QUERY_HTTP_ROUTES. DB_LOG_SLOW_QUERIES remains as a legacy
    switch to enable all scopes when no explicit list is set.


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GORM slow-query logging with a configurable threshold, selectable scope(s), and HTTP route filtering.
  * Introduced HTTP middleware to apply per-request slow-query scoping using matched route labels.
  * Enabled slow-query scoping across cluster and host monitoring flows, including goroutine-level scope propagation with request-id context.
* **Bug Fixes**
  * Slow/error SQL is now logged only when the effective scope and (when applicable) HTTP route conditions match.
* **Tests**
  * Added a dedicated suite covering scope/route parsing, route matching behavior, scoped trace logging, and SQL literal redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->