### PR TITLE
fix lvms-operator catalog resolution in ocp4.22+

### DIFF
--- a/internal/operators/lvm/config.go
+++ b/internal/operators/lvm/config.go
@@ -6,6 +6,13 @@ const (
 	LvmsMinOpenshiftVersion_ForNewResourceRequirements string = "4.13.0"
 	LvmMinMultiNodeSupportVersion                      string = "4.15.0"
 	LvmNewResourcesOpenshiftVersion4_16                string = "4.16.0"
+	// LvmsCatalogFallbackMinVersion is the first OCP version where lvms-operator is not
+	// published to the default redhat-operators catalog. A fallback CatalogSource pointing
+	// to the previous catalog index is injected so the Subscription can resolve.
+	// TODO: Remove once lvms-operator is published to the 4.22 redhat-operators catalog.
+	LvmsCatalogFallbackMinVersion string = "4.22.0"
+	LvmsCatalogFallbackName       string = "redhat-operators-v4-21"
+	LvmsCatalogFallbackImage      string = "registry.redhat.io/redhat/redhat-operator-index:v4.21"
 
 	LvmoSubscriptionName string = "odf-lvm-operator"
 	LvmsSubscriptionName string = "lvms-operator"

--- a/internal/operators/lvm/manifest.go
+++ b/internal/operators/lvm/manifest.go
@@ -30,6 +30,18 @@ func Manifests(cluster *common.Cluster) (map[string][]byte, []byte, error) {
 
 	openshiftManifests := make(map[string][]byte)
 
+	needsFallbackCatalog, err := common.BaseVersionGreaterOrEqual(LvmsCatalogFallbackMinVersion, cluster.OpenshiftVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	if needsFallbackCatalog {
+		lvmCatalogSource, err := getCatalogSource()
+		if err != nil {
+			return nil, nil, err
+		}
+		openshiftManifests["50_openshift-lvm_catalog_source.yaml"] = lvmCatalogSource
+	}
+
 	openshiftManifests["50_openshift-lvm_ns.yaml"] = lvmNamespace
 	openshiftManifests["50_openshift-lvm_operator_group.yaml"] = lvmOperatorGroup
 	openshiftManifests["50_openshift-lvm_subscription.yaml"] = lvmSubscription
@@ -42,11 +54,22 @@ func getSubscriptionInfo(openshiftVersion string) (map[string]string, error) {
 		return map[string]string{}, err
 	}
 
+	needsFallbackCatalog, err := common.BaseVersionGreaterOrEqual(LvmsCatalogFallbackMinVersion, openshiftVersion)
+	if err != nil {
+		return map[string]string{}, err
+	}
+
+	catalogSource := "redhat-operators"
+	if needsFallbackCatalog {
+		catalogSource = LvmsCatalogFallbackName
+	}
+
 	if !isGreaterOrEqual {
 		return map[string]string{
 			"OPERATOR_NAMESPACE":              Operator.Namespace,
 			"OPERATOR_SUBSCRIPTION_NAME":      LvmoSubscriptionName,
 			"OPERATOR_SUBSCRIPTION_SPEC_NAME": LvmoSubscriptionName,
+			"OPERATOR_CATALOG_SOURCE":         catalogSource,
 		}, nil
 	}
 
@@ -54,7 +77,16 @@ func getSubscriptionInfo(openshiftVersion string) (map[string]string, error) {
 		"OPERATOR_NAMESPACE":              Operator.Namespace,
 		"OPERATOR_SUBSCRIPTION_NAME":      LvmsSubscriptionName,
 		"OPERATOR_SUBSCRIPTION_SPEC_NAME": LvmsSubscriptionName,
+		"OPERATOR_CATALOG_SOURCE":         catalogSource,
 	}, nil
+}
+
+func getCatalogSource() ([]byte, error) {
+	data := map[string]string{
+		"CATALOG_SOURCE_NAME":  LvmsCatalogFallbackName,
+		"CATALOG_SOURCE_IMAGE": LvmsCatalogFallbackImage,
+	}
+	return executeTemplate(data, "LvmCatalogSource", LvmCatalogSource)
 }
 
 func getSubscription(cluster *common.Cluster) ([]byte, error) {
@@ -109,8 +141,26 @@ metadata:
 spec:
   installPlanApproval: Automatic
   name: "{{.OPERATOR_SUBSCRIPTION_SPEC_NAME}}"
-  source: redhat-operators
+  source: "{{.OPERATOR_CATALOG_SOURCE}}"
   sourceNamespace: openshift-marketplace`
+
+// LvmCatalogSource is injected when the default redhat-operators catalog does not publish
+// lvms-operator for the target OCP version. The Subscription is pointed at this source instead.
+// TODO: Remove once lvms-operator is published to the redhat-operators catalog for the target version.
+const LvmCatalogSource = `apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{.CATALOG_SOURCE_NAME}}"
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat Operators v4.21
+  image: "{{.CATALOG_SOURCE_IMAGE}}"
+  priority: -100
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 10m0s`
 
 const LvmNamespace = `apiVersion: v1
 kind: Namespace


### PR DESCRIPTION

**Description:**

## Problem

When deploying a cluster with the LVM operator enabled on OCP 4.22+, the installation gets stuck at the *"Waiting for olm operators csv initialization"* stage and eventually times out. The root cause is that `lvms-operator` is no longer published in the `redhat-operator-index:v4.22` catalog in the gRPC format required by the legacy OLM v1alpha1 `Subscription` API.

The OLM Subscription enters `ResolutionFailed` state with:
```
no operators found in package lvms-operator in the catalog referenced by subscription lvms-operator
```

Because OLM can never resolve the Subscription to an InstallPlan, no CSV is ever created in `openshift-storage`, and the install times out.

## Fix

For OCP ≥ 4.22, assisted-service now injects an additional `CatalogSource` manifest pointing to `redhat-operator-index:v4.21` (where `lvms-operator` is still available). The LVMS Subscription is then directed at this fallback catalog source instead of the default `redhat-operators`.

For OCP < 4.22 the behavior is **completely unchanged** — the Subscription continues to use `redhat-operators` as before.

## Files Changed

- `internal/operators/lvm/config.go` — added 3 constants: `LvmsCatalogFallbackMinVersion` (`4.22.0`), `LvmsCatalogFallbackName`, `LvmsCatalogFallbackImage`
- `internal/operators/lvm/manifest.go`:
  - `Manifests()` — injects `50_openshift-lvm_catalog_source.yaml` for OCP ≥ 4.22
  - `getSubscriptionInfo()` — sets catalog source dynamically based on OCP version
  - `LvmSubscription` template — `source` field is now dynamic instead of hardcoded `redhat-operators`
  - Added `LvmCatalogSource` template and `getCatalogSource()` function

## Precedent

This is the same workaround pattern already used for LSO (`deploy/operator/setup_lso.sh`), which went through the identical issue on 4.22 and then again on 5.0. The TODO comment is intentional — the workaround should be removed once `lvms-operator` is published to the 4.22 catalog.

## Testing

- [ ] Deploy cluster with LVM enabled on OCP 4.22 — verify `lvms-operator` CSV is created and operator reaches `Succeeded`
- [ ] Verify `50_openshift-lvm_catalog_source.yaml` manifest is generated for OCP 4.22+
- [ ] Verify no catalog source manifest is generated for OCP 4.21 and below
- [ ] Existing LVM unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback catalog support for the LVM operator to improve compatibility across different OpenShift versions.
  * The operator subscription now dynamically selects the appropriate catalog source based on your OpenShift version, ensuring optimal compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->