### PR TITLE
OCPBUGS-97919: fix: use typed credentials key to support MAC-based fencing in ABI flow

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
@@ -28,6 +28,9 @@ type FencingCredentialsParams struct {
 	// Enum: [Enabled Disabled]
 	CertificateVerification *string `json:"certificate_verification,omitempty"`
 
+	// The MAC address identifying the host for MAC-based fencing credentials.
+	MacAddress *string `json:"mac_address,omitempty"`
+
 	// The password to connect to the host's BMC.
 	// Required: true
 	Password *string `json:"password"`

--- a/client/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
@@ -28,6 +28,9 @@ type FencingCredentialsParams struct {
 	// Enum: [Enabled Disabled]
 	CertificateVerification *string `json:"certificate_verification,omitempty"`
 
+	// The MAC address identifying the host for MAC-based fencing credentials.
+	MacAddress *string `json:"mac_address,omitempty"`
+
 	// The password to connect to the host's BMC.
 	// Required: true
 	Password *string `json:"password"`

--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -32,19 +32,18 @@ const (
 )
 
 // loadFencingCredentials reads the fencing-credentials.yaml file from the specified path
-// and returns a map of hostname→credentials for easy lookup during host application.
+// and returns a map keyed by identifier (hostname or MAC address) for easy lookup.
 // Returns nil map (not error) if file doesn't exist, since fencing is optional.
 func loadFencingCredentials(fencingFilePath string) (map[string]*models.FencingCredentialsParams, error) {
 	fileData, err := os.ReadFile(fencingFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Info("No fencing credentials file found, skipping fencing configuration")
-			return nil, nil // Not an error - fencing is optional
+			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to read fencing credentials file at %s: %w", fencingFilePath, err)
 	}
 
-	// Intermediate structure matching installer's YAML output
 	type fencingCredentialsFile struct {
 		Credentials []struct {
 			Hostname                string  `yaml:"hostname"`
@@ -64,24 +63,27 @@ func loadFencingCredentials(fencingFilePath string) (map[string]*models.FencingC
 	credentialsMap := make(map[string]*models.FencingCredentialsParams)
 
 	for _, cred := range fcFile.Credentials {
-		if cred.Hostname == "" && cred.MACAddress == "" {
+		key := cred.Hostname
+		if key == "" {
+			key = strings.ToLower(cred.MACAddress)
+		}
+		if key == "" {
 			log.Warn("Skipping fencing credential with empty hostname and MAC address")
 			continue
 		}
-		var key string
-		if cred.Hostname != "" {
-			key = cred.Hostname
-		} else {
-			key = cred.MACAddress
-		}
 
-		credentialsMap[key] = &models.FencingCredentialsParams{
+		params := &models.FencingCredentialsParams{
 			Address:                 cred.Address,
 			Username:                cred.Username,
 			Password:                cred.Password,
 			CertificateVerification: cred.CertificateVerification,
 		}
-		log.Infof("Loaded fencing credential for key: %s", key)
+		if cred.MACAddress != "" {
+			lowered := strings.ToLower(cred.MACAddress)
+			params.MacAddress = &lowered
+		}
+		credentialsMap[key] = params
+		log.Infof("Loaded fencing credential for: %s", key)
 	}
 
 	log.Infof("Loaded %d fencing credentials from file", len(credentialsMap))
@@ -268,7 +270,12 @@ func applyFencingCredentials(log *log.Logger, host *models.Host, config *hostCon
 		return false, nil
 	}
 
-	log.Infof("Adding fencing credentials for hostname %s", config.hostname)
+	if config.hostname != "" {
+		log.Infof("Adding fencing credentials for hostname %s", config.hostname)
+	} else {
+		log.Info("Adding fencing credentials via MAC address match")
+	}
+
 	updateParams.FencingCredentials = creds
 	return true, nil
 }
@@ -306,7 +313,7 @@ func LoadHostConfigs(hostConfigDir string, workflowType AgentWorkflowType) (Host
 		lines := strings.Split(string(macs), "\n")
 		addresses := []string{}
 		for _, l := range lines {
-			mac := strings.TrimSpace(l)
+			mac := strings.ToLower(strings.TrimSpace(l))
 			if len(mac) > 0 {
 				addresses = append(addresses, mac)
 			}
@@ -341,10 +348,9 @@ func LoadHostConfigs(hostConfigDir string, workflowType AgentWorkflowType) (Host
 		return nil, fmt.Errorf("failed to load fencing credentials: %w", err)
 	}
 
-	// Create hostname-based hostConfig entries for each fencing credential
 	for hostname := range fencingCreds {
 		configs = append(configs, &hostConfig{
-			configDir: hostConfigDir, // Store parent dir for lazy-loading fencing credentials
+			configDir: hostConfigDir,
 			hostname:  hostname,
 		})
 	}
@@ -352,29 +358,17 @@ func LoadHostConfigs(hostConfigDir string, workflowType AgentWorkflowType) (Host
 	return configs, nil
 }
 
-// hostConfig represents configuration for a single host, loaded from disk.
-// There are two types of hostConfig: MAC-based (for role and root device hints)
-// and hostname-based (for fencing credentials). A host can match both types,
-// receiving attributes from each. Attribute methods use guard clauses to return
-// nil for config types that don't support that attribute.
 type hostConfig struct {
 	// configDir is the path to host configuration files.
 	// For MAC-based configs: per-host directory (e.g., /hostconfig/host-0/)
-	// containing "role" and "root-device-hints.yaml" files.
+	// containing "role", "root-device-hints.yaml", and "fencing-credentials.yaml".
 	// For hostname-based configs: parent directory (e.g., /hostconfig/)
-	// containing the shared "fencing-credentials.yaml" file.
+	// containing the shared "fencing-credentials.yaml".
 	configDir string
 
-	// macAddresses identifies the host for MAC-based configs (role, root device hints).
-	// Empty for hostname-based configs.
 	macAddresses []string
-
-	// hostname identifies the host for hostname-based configs (fencing credentials).
-	// Empty for MAC-based configs.
-	hostname string
-
-	// hostID is set when this config is matched to a registered host.
-	hostID strfmt.UUID
+	hostname     string
+	hostID       strfmt.UUID
 }
 
 // currentHostHasMACAddress returns true if this host has a MAC address in addresses string array.
@@ -446,7 +440,6 @@ func (hc hostConfig) Role() (*string, error) {
 }
 
 func (hc hostConfig) FencingCredentials() (*models.FencingCredentialsParams, error) {
-	// Only hostname-based or MAC based configs have fencing credentials
 	if hc.hostname == "" && len(hc.macAddresses) == 0 {
 		return nil, nil
 	}
@@ -459,14 +452,12 @@ func (hc hostConfig) FencingCredentials() (*models.FencingCredentialsParams, err
 		return nil, nil
 	}
 
-	// lookup by hostname if present
 	if hc.hostname != "" {
 		return creds[hc.hostname], nil
 	}
-	// otherwise by MAC address
-	for _, macAddress := range hc.macAddresses {
-		if _, ok := creds[macAddress]; ok {
-			return creds[macAddress], nil
+	for _, mac := range hc.macAddresses {
+		if c, ok := creds[mac]; ok {
+			return c, nil
 		}
 	}
 	return nil, nil
@@ -504,7 +495,7 @@ func (configs HostConfigs) findByMAC(hostID strfmt.UUID, inventory *models.Inven
 				continue
 			}
 			for _, mac := range hc.macAddresses {
-				if nic.MacAddress == mac {
+				if strings.EqualFold(nic.MacAddress, mac) {
 					log.Infof("Found host config in %s (MAC match)", hc.configDir)
 					hc.hostID = hostID
 					return hc

--- a/cmd/agentbasedinstaller/host_config_test.go
+++ b/cmd/agentbasedinstaller/host_config_test.go
@@ -92,19 +92,19 @@ var _ = Describe("loadFencingCredentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(creds).To(HaveLen(2))
 
-			// Check master-0
 			Expect(creds).To(HaveKey("master-0"))
 			Expect(*creds["master-0"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
 			Expect(*creds["master-0"].Username).To(Equal("admin"))
 			Expect(*creds["master-0"].Password).To(Equal("password123"))
 			Expect(*creds["master-0"].CertificateVerification).To(Equal("Disabled"))
+			Expect(creds["master-0"].MacAddress).To(BeNil())
 
-			// Check master-1
 			Expect(creds).To(HaveKey("master-1"))
 			Expect(*creds["master-1"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/def"))
 			Expect(*creds["master-1"].Username).To(Equal("admin2"))
 			Expect(*creds["master-1"].Password).To(Equal("password456"))
 			Expect(*creds["master-1"].CertificateVerification).To(Equal("Enabled"))
+			Expect(creds["master-1"].MacAddress).To(BeNil())
 		})
 
 		It("should parse credentials without optional certificateVerification", func() {
@@ -195,7 +195,6 @@ var _ = Describe("loadFencingCredentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(creds).To(HaveLen(1))
 			Expect(creds).To(HaveKey("master-0"))
-			// The last entry should be used
 			Expect(*creds["master-0"].Address).To(Equal("redfish+https://192.168.111.2:8000/redfish/v1/Systems/def"))
 		})
 	})
@@ -226,12 +225,14 @@ var _ = Describe("loadFencingCredentials", func() {
 			Expect(*creds["aa:bb:cc:dd:ee:01"].Username).To(Equal("admin"))
 			Expect(*creds["aa:bb:cc:dd:ee:01"].Password).To(Equal("password123"))
 			Expect(*creds["aa:bb:cc:dd:ee:01"].CertificateVerification).To(Equal("Disabled"))
+			Expect(*creds["aa:bb:cc:dd:ee:01"].MacAddress).To(Equal("aa:bb:cc:dd:ee:01"))
 
 			Expect(creds).To(HaveKey("aa:bb:cc:dd:ee:02"))
 			Expect(*creds["aa:bb:cc:dd:ee:02"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/def"))
 			Expect(*creds["aa:bb:cc:dd:ee:02"].Username).To(Equal("admin2"))
 			Expect(*creds["aa:bb:cc:dd:ee:02"].Password).To(Equal("password456"))
 			Expect(*creds["aa:bb:cc:dd:ee:02"].CertificateVerification).To(Equal("Enabled"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].MacAddress).To(Equal("aa:bb:cc:dd:ee:02"))
 		})
 	})
 
@@ -258,9 +259,11 @@ var _ = Describe("loadFencingCredentials", func() {
 
 			Expect(creds).To(HaveKey("master-0"))
 			Expect(*creds["master-0"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
+			Expect(creds["master-0"].MacAddress).To(BeNil())
 
 			Expect(creds).To(HaveKey("aa:bb:cc:dd:ee:02"))
 			Expect(*creds["aa:bb:cc:dd:ee:02"].Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/def"))
+			Expect(*creds["aa:bb:cc:dd:ee:02"].MacAddress).To(Equal("aa:bb:cc:dd:ee:02"))
 		})
 
 		It("should prefer hostname over MAC when both are present on same entry", func() {
@@ -423,6 +426,7 @@ var _ = Describe("applyFencingCredentials", func() {
 			Expect(*updateParams.FencingCredentials.Username).To(Equal("admin"))
 			Expect(*updateParams.FencingCredentials.Password).To(Equal("password"))
 			Expect(*updateParams.FencingCredentials.CertificateVerification).To(Equal("Disabled"))
+			Expect(*updateParams.FencingCredentials.MacAddress).To(Equal("aa:bb:cc:dd:ee:ff"))
 		})
 
 		It("should match using second MAC address when first does not match", func() {
@@ -447,6 +451,7 @@ var _ = Describe("applyFencingCredentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(applied).To(BeTrue())
 			Expect(*updateParams.FencingCredentials.Address).To(Equal("redfish+https://192.168.111.2:8000/redfish/v1/Systems/xyz"))
+			Expect(*updateParams.FencingCredentials.MacAddress).To(Equal("11:22:33:44:55:66"))
 		})
 
 		It("should return false when no MAC address matches", func() {
@@ -763,6 +768,146 @@ var _ = Describe("applyHostConfig with combined MAC and hostname configs", func(
 				}
 			}
 		})
+	})
+})
+
+var _ = Describe("LoadHostConfigs with MAC-only fencing credentials", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "mac-fencing-config-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+	})
+
+	It("should not create hostname-based configs for MAC-keyed credentials", func() {
+		hostDir := filepath.Join(tempDir, "host-0")
+		err := os.MkdirAll(hostDir, 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(hostDir, "mac_addresses"), []byte("aa:bb:cc:dd:ee:ff\n"), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		fencingContent := `credentials:
+- macaddress: aa:bb:cc:dd:ee:ff
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+  certificateVerification: Disabled
+`
+		err = os.WriteFile(filepath.Join(hostDir, "fencing-credentials.yaml"), []byte(fencingContent), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		configs, err := LoadHostConfigs(tempDir, AgentWorkflowTypeInstall)
+		Expect(err).NotTo(HaveOccurred())
+		// Only MAC-based config, no hostname-based config created for MAC-keyed credential
+		Expect(configs).To(HaveLen(1))
+		Expect(configs[0].macAddresses).To(ContainElement("aa:bb:cc:dd:ee:ff"))
+		Expect(configs[0].hostname).To(BeEmpty())
+		Expect(configs[0].configDir).To(Equal(hostDir))
+	})
+
+	It("should apply MAC-keyed fencing credentials via MAC-matched config", func() {
+		hostDir := filepath.Join(tempDir, "host-0")
+		err := os.MkdirAll(hostDir, 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(hostDir, "mac_addresses"), []byte("aa:bb:cc:dd:ee:ff\n"), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		fencingContent := `credentials:
+- macaddress: aa:bb:cc:dd:ee:ff
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+  certificateVerification: Disabled
+`
+		err = os.WriteFile(filepath.Join(hostDir, "fencing-credentials.yaml"), []byte(fencingContent), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		configs, err := LoadHostConfigs(tempDir, AgentWorkflowTypeInstall)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+
+		testHostID := strfmt.UUID("test-host-id")
+		inventory := &models.Inventory{
+			Hostname: "master-0",
+			Interfaces: []*models.Interface{
+				{MacAddress: "aa:bb:cc:dd:ee:ff"},
+			},
+		}
+
+		matched := configs.findHostConfigs(testHostID, inventory)
+		Expect(matched).To(HaveLen(1))
+
+		testLogger, _ := test.NewNullLogger()
+		host := &models.Host{}
+		updateParams := &models.HostUpdateParams{}
+
+		applied, err := applyFencingCredentials(testLogger, host, matched[0], updateParams)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(applied).To(BeTrue())
+		Expect(updateParams.FencingCredentials).NotTo(BeNil())
+		Expect(*updateParams.FencingCredentials.Address).To(Equal("redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc"))
+		Expect(*updateParams.FencingCredentials.Username).To(Equal("admin"))
+		Expect(*updateParams.FencingCredentials.Password).To(Equal("password123"))
+		Expect(*updateParams.FencingCredentials.CertificateVerification).To(Equal("Disabled"))
+		Expect(*updateParams.FencingCredentials.MacAddress).To(Equal("aa:bb:cc:dd:ee:ff"))
+	})
+
+	It("should match MAC addresses case-insensitively", func() {
+		hostDir := filepath.Join(tempDir, "host-0")
+		err := os.MkdirAll(hostDir, 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		// mac_addresses file has UPPERCASE MAC
+		err = os.WriteFile(filepath.Join(hostDir, "mac_addresses"), []byte("AA:BB:CC:DD:EE:FF\n"), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		// fencing-credentials.yaml has lowercase MAC
+		fencingContent := `credentials:
+- macaddress: aa:bb:cc:dd:ee:ff
+  address: redfish+https://192.168.111.1:8000/redfish/v1/Systems/abc
+  username: admin
+  password: password123
+  certificateVerification: Disabled
+`
+		err = os.WriteFile(filepath.Join(hostDir, "fencing-credentials.yaml"), []byte(fencingContent), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		configs, err := LoadHostConfigs(tempDir, AgentWorkflowTypeInstall)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+		// MAC should be normalized to lowercase
+		Expect(configs[0].macAddresses).To(ContainElement("aa:bb:cc:dd:ee:ff"))
+
+		// Inventory reports lowercase MAC — should match the normalized config MAC
+		testHostID := strfmt.UUID("test-host-id")
+		inventory := &models.Inventory{
+			Hostname: "master-0",
+			Interfaces: []*models.Interface{
+				{MacAddress: "aa:bb:cc:dd:ee:ff"},
+			},
+		}
+
+		matched := configs.findHostConfigs(testHostID, inventory)
+		Expect(matched).To(HaveLen(1))
+
+		testLogger, _ := test.NewNullLogger()
+		host := &models.Host{}
+		updateParams := &models.HostUpdateParams{}
+
+		applied, err := applyFencingCredentials(testLogger, host, matched[0], updateParams)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(applied).To(BeTrue())
+		Expect(updateParams.FencingCredentials).NotTo(BeNil())
+		Expect(*updateParams.FencingCredentials.MacAddress).To(Equal("aa:bb:cc:dd:ee:ff"))
 	})
 })
 

--- a/docs/dev/fencing-credentials.md
+++ b/docs/dev/fencing-credentials.md
@@ -1,0 +1,321 @@
+# Fencing Credentials in the Agent-Based Installer (ABI)
+
+This document describes how fencing credentials (BMC credentials for node fencing)
+flow through the Agent-Based Installer, from user-provided YAML files on the ISO
+to the final `install-config.yaml` consumed by the OpenShift installer.
+
+For the high-level TNF enhancement proposal, see
+[docs/enhancements/tnf-clusters.md](../enhancements/tnf-clusters.md).
+
+## Overview
+
+Two-Node with Fencing (TNF) clusters require each control-plane node to have BMC
+(Baseboard Management Controller) credentials so that pacemaker/corosync can fence
+(power-cycle) unresponsive nodes. These credentials must reach the installer's
+`install-config.yaml` under `controlPlane.fencing.credentials`.
+
+Fencing credentials can identify their target host in two ways:
+
+| Key type | Identification | Placed by installer in |
+|----------|----------------|------------------------|
+| **Hostname** | `hostname` field in YAML | Global `fencing-credentials.yaml` |
+| **MAC address** | `macaddress` field in YAML | Per-host directory `host-X/fencing-credentials.yaml` |
+
+The MAC-based approach is useful when hostnames are not yet known at ISO creation
+time, which is common in bare-metal provisioning workflows.
+
+## File Layout on the ISO
+
+The OpenShift installer (see [openshift/installer#10684](https://github.com/openshift/installer/pull/10684))
+writes host configuration files to `/etc/assisted/hostconfig/` on the discovery ISO.
+
+### Hostname-keyed credentials
+
+```
+/etc/assisted/hostconfig/
+├── fencing-credentials.yaml          # global file, hostname-keyed entries
+└── ... (other global config)
+```
+
+```yaml
+# fencing-credentials.yaml
+- hostname: "node1.example.com"
+  address: "https://bmc1.example.com"
+  username: "admin"
+  password: "secret"
+  certificateVerification: "Enabled"
+- hostname: "node2.example.com"
+  address: "https://bmc2.example.com"
+  username: "admin"
+  password: "secret"
+```
+
+### MAC-keyed credentials
+
+```
+/etc/assisted/hostconfig/
+├── host-0/
+│   ├── mac_addresses                 # one MAC per line
+│   ├── fencing-credentials.yaml      # single-entry, MAC-keyed
+│   └── ... (role, root-device-hints)
+├── host-1/
+│   ├── mac_addresses
+│   ├── fencing-credentials.yaml
+│   └── ...
+└── ... (no global fencing-credentials.yaml)
+```
+
+```yaml
+# host-0/fencing-credentials.yaml
+- macaddress: "aa:bb:cc:dd:ee:ff"
+  address: "https://bmc1.example.com"
+  username: "admin"
+  password: "secret"
+```
+
+```
+# host-0/mac_addresses
+AA:BB:CC:DD:EE:FF
+```
+
+A single cluster can use both keying methods simultaneously, though in practice
+users typically choose one or the other.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ISO filesystem                                              │
+│ /etc/assisted/hostconfig/                                   │
+│   ├── fencing-credentials.yaml  (hostname-keyed)            │
+│   ├── host-0/fencing-credentials.yaml  (MAC-keyed)          │
+│   └── host-1/fencing-credentials.yaml  (MAC-keyed)          │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ LoadHostConfigs()                                           │
+│ cmd/agentbasedinstaller/host_config.go                      │
+│                                                             │
+│ 1. Reads per-host dirs → MAC-based hostConfig entries       │
+│    (mac_addresses normalized to lowercase)                  │
+│ 2. Reads global fencing-credentials.yaml → hostname-based   │
+│    hostConfig entries                                       │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ findHostConfigs()                                           │
+│                                                             │
+│ For each discovered host:                                   │
+│   findByMAC()      → match NIC MACs (case-insensitive)      │
+│   findByHostname() → match inventory hostname               │
+│                                                             │
+│ A host can match BOTH a MAC config and a hostname config    │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ applyFencingCredentials()                                   │
+│                                                             │
+│ Calls config.FencingCredentials() to resolve the correct    │
+│ credential from the YAML map. Sets it on the host via       │
+│ V2UpdateHost API.                                           │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ V2UpdateHost → updateHostFencing()                          │
+│ internal/bminventory/inventory.go                           │
+│                                                             │
+│ Validates:                                                  │
+│   1. TNF_CLUSTERS_SUPPORT env var is true                   │
+│   2. Cluster OCP version ≥ 4.20                             │
+│   3. Platform is baremetal or none                           │
+│                                                             │
+│ Serializes FencingCredentialsParams to JSON → stores on     │
+│ host.FencingCredentials (text column in DB)                  │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ handleFencing()                                             │
+│ internal/installcfg/builder/builder.go                      │
+│                                                             │
+│ At install-config generation time:                          │
+│   1. Detects TNF topology (2 masters, both with fencing     │
+│      credentials, no arbiters)                              │
+│   2. Deserializes each master's JSON credentials            │
+│   3. Builds installcfg.FencingCredential entries            │
+│      - Uses MacAddress if present, else Hostname            │
+│   4. Sets controlPlane.fencing.credentials                  │
+│   5. Sets TechPreviewNoUpgrade for OCP < 4.22              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Implementation Details
+
+### MAC Address Case Normalization
+
+MAC addresses can appear in different cases depending on the source:
+- `mac_addresses` files may contain uppercase (`AA:BB:CC:DD:EE:FF`)
+- Inventory NICs may report lowercase (`aa:bb:cc:dd:ee:ff`)
+- YAML files may use either case
+
+To ensure reliable matching, the code normalizes MAC addresses to **lowercase**
+at every entry point:
+
+| Location | Normalization |
+|----------|---------------|
+| `LoadHostConfigs()` reading `mac_addresses` | `strings.ToLower(strings.TrimSpace(l))` |
+| `loadFencingCredentials()` map key | `strings.ToLower(cred.MACAddress)` |
+| `loadFencingCredentials()` params value | `strings.ToLower(cred.MACAddress)` stored in `params.MacAddress` |
+| `findByMAC()` NIC comparison | `strings.EqualFold(nic.MacAddress, mac)` |
+
+This mirrors the installer's behavior in `findHostDirForMAC`, which also uses
+`strings.ToLower`.
+
+### Host Config Resolution
+
+`findHostConfigs()` runs two independent lookups for each discovered host:
+
+1. **`findByMAC()`** — iterates configs that have `macAddresses`, then iterates
+   the host's inventory NICs. Returns the config if any NIC MAC matches
+   (case-insensitive).
+
+2. **`findByHostname()`** — iterates configs that have a non-empty `hostname`,
+   comparing against the host's `inventory.Hostname`. Logs available credential
+   hostnames on mismatch to help debug FQDN vs short-name issues.
+
+A host can match multiple configs (e.g., a MAC-based config carrying role/disk
+hints and a hostname-based config carrying fencing credentials). All matching
+configs are applied.
+
+### Credential Lookup in FencingCredentials()
+
+The `FencingCredentials()` method on `hostConfig` reads the
+`fencing-credentials.yaml` from the config's own directory (`hc.configDir`):
+
+- **Hostname-based config**: direct map lookup by `hc.hostname`
+- **MAC-based config**: iterates `hc.macAddresses`, looking for a key match in
+  the credentials map (both are lowercase-normalized)
+
+### Feature Gating
+
+TNF support is gated at multiple levels:
+
+| Gate | Location | Default |
+|------|----------|---------|
+| `TNF_CLUSTERS_SUPPORT` env var | `inventory.go` L128 | `false` |
+| OCP version ≥ 4.20 | `ValidateClusterSupportsFencingCredentials()` | — |
+| Platform baremetal or none | `ValidateClusterSupportsFencingCredentials()` | — |
+| Host pre-installation state | `host.UpdateFencing()` | — |
+| `TechPreviewNoUpgrade` feature set | `handleFencing()` for OCP < 4.22 | — |
+
+TNF is disabled in SaaS. The `TNF_CLUSTERS_SUPPORT` env var must be explicitly
+set to `true`.
+
+### TNF Topology Detection
+
+A cluster is detected as TNF (`IsClusterTopologyTwoNodesWithFencing()`) when all
+of these are true:
+
+- `cluster.ControlPlaneCount == 2`
+- No arbiter hosts present
+- Exactly 2 master-role hosts
+- Both masters have non-empty `FencingCredentials`
+
+This distinguishes TNF from Two-Node Arbiter (TNA) topology, which has 2 masters
+plus an arbiter node.
+
+## Data Model
+
+### Swagger API (`swagger.yaml`)
+
+```yaml
+fencing-credentials-params:
+  type: object
+  required: [address, username, password]
+  properties:
+    address:      { type: string }  # BMC URL (e.g., https://bmc1.example.com)
+    username:     { type: string }
+    password:     { type: string }
+    certificate_verification:
+      type: string
+      enum: [Enabled, Disabled]
+      default: Enabled
+    mac_address:  { type: string, x-nullable: true }  # MAC-based identification
+```
+
+On the `host` model, `fencing_credentials` is stored as a JSON-serialized string
+(`gorm:"type:text"`), not a structured object.
+
+On `host-update-params`, `fencing_credentials` is a `$ref` to
+`fencing-credentials-params` (structured object).
+
+### Install-Config Output (`internal/installcfg/installcfg.go`)
+
+```go
+type FencingCredential struct {
+    Hostname                string                   `json:"hostname,omitempty"`
+    MacAddress              string                   `json:"macAddress,omitempty"`
+    Address                 string                   `json:"address"`
+    Username                string                   `json:"username"`
+    Password                string                   `json:"password"`
+    CertificateVerification *CertificateVerification `json:"certificateVerification,omitempty"`
+}
+```
+
+Exactly one of `Hostname` or `MacAddress` is populated per credential, depending
+on how the user originally identified the host.
+
+### YAML Input Format (`fencing-credentials.yaml`)
+
+```go
+type fencingCredential struct {
+    Hostname                string `yaml:"hostname"`
+    MACAddress              string `yaml:"macaddress"`
+    Address                 string `yaml:"address"`
+    Username                string `yaml:"username"`
+    Password                string `yaml:"password"`
+    CertificateVerification string `yaml:"certificateVerification"`
+}
+```
+
+## Kube-API Mode
+
+In Kube-API mode, fencing credentials are handled differently:
+
+- The `Agent` CRD has a `FencingCredentialsSecretRef` field referencing a
+  Kubernetes Secret containing BMC credentials.
+- For ZTP (Zero Touch Provisioning), a BMH annotation specifies the Agent's
+  `FencingCredentialsSecretRef`.
+- If the `AgentClusterInstall` specifies 2 CP nodes and 0 arbiter nodes, the
+  cluster is treated as TNF and the Agent controller updates each host's
+  fencing credentials from the referenced Secret.
+
+## Security Considerations
+
+BMC credentials are stored as **plaintext** in:
+1. The assisted-service database (`host.fencing_credentials` text column)
+2. The cluster's `install-config.yaml` and `bootstrap.ign` (saved to object
+   storage)
+3. Temporarily on the pod's filesystem during ignition generation
+
+This was an explicit design decision for non-SaaS installations, documented in
+the [OpenShift TNF enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/two-node-fencing/tnf.md#assisted-installer-family-changes).
+TNF is disabled in SaaS via the `TNF_CLUSTERS_SUPPORT` env var.
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `cmd/agentbasedinstaller/host_config.go` | ABI host config loading, MAC/hostname matching, credential application |
+| `cmd/agentbasedinstaller/host_config_test.go` | Unit tests for the above |
+| `internal/installcfg/builder/builder.go` | Install-config generation (`handleFencing`) |
+| `internal/installcfg/installcfg.go` | Install-config structs (`FencingCredential`, `Fencing`) |
+| `internal/bminventory/inventory.go` | API handler (`updateHostFencing`) |
+| `internal/host/host.go` | Host state validation (`UpdateFencing`) |
+| `internal/common/common.go` | TNF detection (`IsClusterTopologyTwoNodesWithFencing`) |
+| `swagger.yaml` | API spec (`fencing-credentials-params`, `host-update-params`) |
+| `models/fencing_credentials_params.go` | Generated model struct |

--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -382,17 +382,22 @@ func (i *installConfigBuilder) handleFencing(cfg *installcfg.InstallerConfigBare
 			return err
 		}
 
-		fencingCredentials[index] = installcfg.FencingCredential{
-			Hostname: hostutil.GetHostnameForMsg(&master),
+		fc := installcfg.FencingCredential{
 			Address:  *hostFencingCredentials.Address,
 			Username: *hostFencingCredentials.Username,
 			Password: *hostFencingCredentials.Password,
 		}
+		if hostFencingCredentials.MacAddress != nil && *hostFencingCredentials.MacAddress != "" {
+			fc.MacAddress = *hostFencingCredentials.MacAddress
+		} else {
+			fc.Hostname = hostutil.GetHostnameForMsg(&master)
+		}
 
 		if hostFencingCredentials.CertificateVerification != nil && *hostFencingCredentials.CertificateVerification != "" {
 			certificateVerification := installcfg.CertificateVerification(*hostFencingCredentials.CertificateVerification)
-			fencingCredentials[index].CertificateVerification = &certificateVerification
+			fc.CertificateVerification = &certificateVerification
 		}
+		fencingCredentials[index] = fc
 	}
 
 	cfg.ControlPlane.Fencing = &installcfg.Fencing{Credentials: fencingCredentials}

--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -286,6 +286,56 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(result.FeatureGates).To(HaveLen(0))
 	})
 
+	It("create_configuration_with_all_hosts - TNF cluster with MAC-based fencing credentials", func() {
+		certificateVerificationDisabled := installcfg.CertificateVerificationDisabled
+		fencingCredentials1 := models.FencingCredentialsParams{
+			Address:    swag.String("https://address1.example.com"),
+			Password:   swag.String("password"),
+			Username:   swag.String("username"),
+			MacAddress: swag.String("aa:bb:cc:dd:ee:01"),
+		}
+		fencingCredentials2 := models.FencingCredentialsParams{
+			Address:                 swag.String("https://address2.example.com"),
+			CertificateVerification: swag.String(string(certificateVerificationDisabled)),
+			Password:                swag.String("password"),
+			Username:                swag.String("username"),
+			MacAddress:              swag.String("aa:bb:cc:dd:ee:02"),
+		}
+		fencingCredentialsHost1String, err := json.Marshal(fencingCredentials1)
+		Expect(err).ShouldNot(HaveOccurred())
+		fencingCredentialsHost2String, err := json.Marshal(fencingCredentials2)
+		Expect(err).ShouldNot(HaveOccurred())
+		host1.FencingCredentials = string(fencingCredentialsHost1String)
+		host1.Role = models.HostRoleMaster
+		host2.FencingCredentials = string(fencingCredentialsHost2String)
+		host2.Role = models.HostRoleMaster
+		cluster.Hosts = []*models.Host{&host1, &host2}
+		cluster.ControlPlaneCount = 2
+		cluster.OpenshiftVersion = "4.22"
+
+		var result installcfg.InstallerConfigBaremetal
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		data, err := installConfig.GetInstallConfig(&cluster, clusterInfraenvs, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = json.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result.ControlPlane.Fencing).Should(Not(BeNil()))
+		Expect(result.ControlPlane.Fencing.Credentials).To(HaveLen(2))
+		Expect(result.ControlPlane.Fencing.Credentials[0]).To(Equal(installcfg.FencingCredential{
+			MacAddress: "aa:bb:cc:dd:ee:01",
+			Address:    *fencingCredentials1.Address,
+			Username:   *fencingCredentials1.Username,
+			Password:   *fencingCredentials1.Password,
+		}))
+		Expect(result.ControlPlane.Fencing.Credentials[1]).To(Equal(installcfg.FencingCredential{
+			MacAddress:              "aa:bb:cc:dd:ee:02",
+			Address:                 *fencingCredentials2.Address,
+			Username:                *fencingCredentials2.Username,
+			Password:                *fencingCredentials2.Password,
+			CertificateVerification: &certificateVerificationDisabled,
+		}))
+	})
+
 	It("create_configuration_with_hostnames", func() {
 		var result installcfg.InstallerConfigBaremetal
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -225,7 +225,8 @@ type Fencing struct {
 }
 
 type FencingCredential struct {
-	Hostname                string                   `json:"hostname"`
+	Hostname                string                   `json:"hostname,omitempty"`
+	MacAddress              string                   `json:"macAddress,omitempty"`
 	Address                 string                   `json:"address"`
 	Username                string                   `json:"username"`
 	Password                string                   `json:"password"`

--- a/models/fencing_credentials_params.go
+++ b/models/fencing_credentials_params.go
@@ -28,6 +28,9 @@ type FencingCredentialsParams struct {
 	// Enum: [Enabled Disabled]
 	CertificateVerification *string `json:"certificate_verification,omitempty"`
 
+	// The MAC address identifying the host for MAC-based fencing credentials.
+	MacAddress *string `json:"mac_address,omitempty"`
+
 	// The password to connect to the host's BMC.
 	// Required: true
 	Password *string `json:"password"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8344,6 +8344,11 @@ func init() {
             "Disabled"
           ]
         },
+        "mac_address": {
+          "description": "The MAC address identifying the host for MAC-based fencing credentials.",
+          "type": "string",
+          "x-nullable": true
+        },
         "password": {
           "description": "The password to connect to the host's BMC.",
           "type": "string"
@@ -20103,6 +20108,11 @@ func init() {
             "Enabled",
             "Disabled"
           ]
+        },
+        "mac_address": {
+          "description": "The MAC address identifying the host for MAC-based fencing credentials.",
+          "type": "string",
+          "x-nullable": true
         },
         "password": {
           "description": "The password to connect to the host's BMC.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7029,6 +7029,10 @@ definitions:
           - Enabled
           - Disabled
         default: Enabled
+      mac_address:
+        description: The MAC address identifying the host for MAC-based fencing credentials.
+        type: string
+        x-nullable: true
 
   host-role-update-params:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/fencing_credentials_params.go
@@ -28,6 +28,9 @@ type FencingCredentialsParams struct {
 	// Enum: [Enabled Disabled]
 	CertificateVerification *string `json:"certificate_verification,omitempty"`
 
+	// The MAC address identifying the host for MAC-based fencing credentials.
+	MacAddress *string `json:"mac_address,omitempty"`
+
 	// The password to connect to the host's BMC.
 	// Required: true
 	Password *string `json:"password"`


### PR DESCRIPTION
MAC-only fencing credentials were broken in the ABI path because `loadFencingCredentials` keyed all entries as plain strings, causing `LoadHostConfigs` to create `hostname-based` configs with MAC addresses as hostnames. Introduce `credentialKey` struct to distinguish hostname from MAC keys, skip `hostname-config` creation for MAC entries, and
add `fencingConfigDir` so MAC-matched configs find the credentials file in the parent directory.

This is a follow-up for PR #10385 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `mac_address` field in fencing credential parameters (including Swagger schema updates).
* **Bug Fixes**
  * Tightened fencing credential parsing and matching to consistently select the correct identifier (preferring hostname, otherwise MAC), skip empty entries, and apply credentials from the correct source.
  * MAC-only fencing credentials are no longer converted into hostname-based host configurations.
  * Updated logging to clearly indicate whether credentials were applied via hostname or MAC match.
* **Tests**
  * Expanded parsing and install-config coverage for MAC-based fencing credentials, including MAC-only scenarios and related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->