### PR TITLE
MGMT-24610: Get OCP lifecycle data via api/v2 and update the product's name

### DIFF
--- a/internal/releasesources/clients.go
+++ b/internal/releasesources/clients.go
@@ -30,7 +30,7 @@ type openShiftReleasesAPIClientInterface interface {
 //
 //go:generate mockgen -source=clients.go -destination=mock_clients.go -package=releasesources
 type openShiftSupportLevelAPIClientInterface interface {
-	getSupportLevels(majorVersion string) (ocpVersionSupportLevels, error)
+	getSupportLevels() (ocpVersionSupportLevels, error)
 }
 
 type ReleaseGraph struct {
@@ -55,14 +55,14 @@ type version struct {
 }
 
 const (
-	OpenshiftUpdateServiceAPIURLPath                    string = "api/upgrades_info/v1/graph"
-	OpenshiftUpdateServiceAPIURLQueryChannel            string = "channel"
-	OpenshiftUpdateServiceAPIURLQueryArch               string = "arch"
-	redHatProductLifeCycleDataAPIQueryName              string = "name"
-	redHatProductLifeCycleDataAPIQueryNameValueTemplate string = "Openshift Container Platform %s"
-	redHatProductLifeCycleDataAPIEndOfLife              string = "End of life"
-	redHatProductLifeCycleDataAPIMaintenanceSupport     string = "Maintenance Support"
-	redHatProductLifeCycleDataAPIFullSupport            string = "Full Support"
+	OpenshiftUpdateServiceAPIURLPath                string = "api/upgrades_info/v1/graph"
+	OpenshiftUpdateServiceAPIURLQueryChannel        string = "channel"
+	OpenshiftUpdateServiceAPIURLQueryArch           string = "arch"
+	redHatProductLifeCycleDataAPIQueryName          string = "name"
+	redHatProductLifeCycleDataAPIQueryNameValue     string = "Red Hat OpenShift Container Platform"
+	redHatProductLifeCycleDataAPIEndOfLife          string = "End of life"
+	redHatProductLifeCycleDataAPIMaintenanceSupport string = "Maintenance Support"
+	redHatProductLifeCycleDataAPIFullSupport        string = "Full Support"
 )
 
 type openShiftReleasesAPIClient struct {
@@ -120,13 +120,11 @@ func (o openShiftReleasesAPIClient) getReleases(
 	return &releaseGraphInstance, nil
 }
 
-func (o openShiftSupportLevelAPIClient) getSupportLevels(openshiftMajorVersion string) (ocpVersionSupportLevels, error) {
+func (o openShiftSupportLevelAPIClient) getSupportLevels() (ocpVersionSupportLevels, error) {
 	url := appendURLQueryParams(
 		o.baseURL,
 		map[string]string{
-			redHatProductLifeCycleDataAPIQueryName: fmt.Sprintf(
-				redHatProductLifeCycleDataAPIQueryNameValueTemplate, openshiftMajorVersion,
-			),
+			redHatProductLifeCycleDataAPIQueryName: redHatProductLifeCycleDataAPIQueryNameValue,
 		},
 	)
 

--- a/internal/releasesources/clients_test.go
+++ b/internal/releasesources/clients_test.go
@@ -25,11 +25,11 @@ type QueryParameters struct {
 	Arch    string
 }
 
-var supportLevelsResponseVersion4 = `{
+var supportLevelsResponse = `{
 			"data": [
 			  {
 				"uuid": "0964595a-151e-4240-8a62-31e6c3730226",
-				"name": "OpenShift Container Platform 4",
+				"name": "Red Hat OpenShift Container Platform",
 				"former_names": [],
 				"show_last_minor_release": false,
 				"show_final_minor_release": false,
@@ -72,6 +72,291 @@ var supportLevelsResponseVersion4 = `{
 				  }
 				],
 				"versions": [
+                  {
+					"name": "5.7",
+					"type": "Full Support",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2023-10-31T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "4.15 GA + 3 months",
+						"date_format": "string",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2025-05-01T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "2025-10-31T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "",
+						"date_format": "string",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.6",
+					"type": "Full Support",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2023-05-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2024-01-31T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2024-11-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "N/A",
+						"date_format": "string"
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "N/A",
+						"date_format": "string"
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.5",
+					"type": "Maintenance Support",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2023-01-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2023-08-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2024-07-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "2025-01-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "",
+						"date_format": "string",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.4",
+					"type": "Maintenance Support",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2022-08-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2023-04-17T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2024-02-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.3",
+					"type": "End of life",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2022-03-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2022-11-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2023-09-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.2",
+					"type": "End of life",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2021-10-18T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2022-06-10T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2023-04-18T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
+				  {
+					"name": "5.1",
+					"type": "End of life",
+					"last_minor_release": null,
+					"final_minor_release": null,
+					"extra_header_value": null,
+					"additional_text": "",
+					"phases": [
+					  {
+						"name": "General availability",
+						"date": "2021-07-27T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Full support",
+						"date": "2022-01-27T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Maintenance support",
+						"date": "2023-01-27T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended update support",
+						"date": "N/A",
+						"date_format": "string",
+						"additional_text": ""
+					  },
+					  {
+						"name": "Extended life phase",
+						"date": "2023-04-27T00:00:00.000Z",
+						"date_format": "date",
+						"additional_text": ""
+					  }
+					],
+					"extra_dependences": []
+				  },
 				  {
 					"name": "4.14",
 					"type": "Full Support",
@@ -365,32 +650,23 @@ var supportLevelsResponseVersion4 = `{
 			]
 		  }`
 
-func getExpectedSupportLevels(openshiftMajorVersion string) (ocpVersionSupportLevels, error) {
-	if openshiftMajorVersion == "4" {
-		return ocpVersionSupportLevels{
-			"4.14": "production",
-			"4.13": "production",
-			"4.12": "maintenance",
-			"4.11": "maintenance",
-			"4.10": "end-of-life",
-			"4.9":  "end-of-life",
-			"4.8":  "end-of-life",
-		}, nil
+func getExpectedSupportLevels() ocpVersionSupportLevels {
+	return ocpVersionSupportLevels{
+		"5.7":  "production",
+		"5.6":  "production",
+		"5.5":  "maintenance",
+		"5.4":  "maintenance",
+		"5.3":  "end-of-life",
+		"5.2":  "end-of-life",
+		"5.1":  "end-of-life",
+		"4.14": "production",
+		"4.13": "production",
+		"4.12": "maintenance",
+		"4.11": "maintenance",
+		"4.10": "end-of-life",
+		"4.9":  "end-of-life",
+		"4.8":  "end-of-life",
 	}
-
-	if openshiftMajorVersion == "5" {
-		return ocpVersionSupportLevels{
-			"5.7": "production",
-			"5.6": "production",
-			"5.5": "maintenance",
-			"5.4": "maintenance",
-			"5.3": "end-of-life",
-			"5.2": "end-of-life",
-			"5.1": "end-of-life",
-		}, nil
-	}
-
-	return nil, errors.New("")
 }
 
 var requestResponseParams = []RequestResponseParameters{
@@ -915,9 +1191,9 @@ var _ = Describe("Test getSupportLevels", func() {
 		supportLevelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			queryParameters := r.URL.Query()
 
-			if queryParameters["name"][0] == "Openshift Container Platform 4" {
+			if queryParameters["name"][0] == "Red Hat OpenShift Container Platform" {
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(supportLevelsResponseVersion4))
+				_, _ = w.Write([]byte(supportLevelsResponse))
 				return
 			}
 
@@ -929,12 +1205,9 @@ var _ = Describe("Test getSupportLevels", func() {
 		Expect(err).ToNot(HaveOccurred())
 		client := openShiftSupportLevelAPIClient{baseURL: *u}
 
-		supportLevels, err := client.getSupportLevels("4")
+		supportLevels, err := client.getSupportLevels()
 		Expect(err).ToNot(HaveOccurred())
-
-		expectedSupportLevels, err := getExpectedSupportLevels("4")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(supportLevels).To(Equal(expectedSupportLevels))
+		Expect(supportLevels).To(Equal(getExpectedSupportLevels()))
 	})
 
 	It("Should cause an error with invalid response from server", func() {
@@ -947,7 +1220,7 @@ var _ = Describe("Test getSupportLevels", func() {
 		Expect(err).ToNot(HaveOccurred())
 		client := openShiftSupportLevelAPIClient{baseURL: *u}
 
-		supportLevels, err := client.getSupportLevels("4")
+		supportLevels, err := client.getSupportLevels()
 		Expect(err).To(HaveOccurred())
 		Expect(supportLevels).To(BeNil())
 	})
@@ -963,7 +1236,7 @@ var _ = Describe("Test getSupportLevels", func() {
 		Expect(err).ToNot(HaveOccurred())
 		client := openShiftSupportLevelAPIClient{baseURL: *u}
 
-		supportLevels, err := client.getSupportLevels("4")
+		supportLevels, err := client.getSupportLevels()
 		Expect(err).To(HaveOccurred())
 		Expect(supportLevels).To(BeNil())
 	})

--- a/internal/releasesources/config.go
+++ b/internal/releasesources/config.go
@@ -6,5 +6,5 @@ type Config struct {
 	OCMBaseURL                           string        `envconfig:"OCM_BASE_URL" default:""`
 	ReleaseSources                       string        `envconfig:"RELEASE_SOURCES" default:""`
 	OpenShiftReleaseSyncerInterval       time.Duration `envconfig:"OPENSHIFT_RELEASE_SYNCER_INTERVAL" default:"30m"`
-	RedHatProductLifeCycleDataAPIBaseURL string        `envconfig:"RED_HAT_PRODUCT_LIFE_CYCLE_DATA_API_BASE_URL" default:"https://access.redhat.com/product-life-cycles/api/v1/products"`
+	RedHatProductLifeCycleDataAPIBaseURL string        `envconfig:"RED_HAT_PRODUCT_LIFE_CYCLE_DATA_API_BASE_URL" default:"https://access.redhat.com/product-life-cycles/api/v2/products"`
 }

--- a/internal/releasesources/mock_clients.go
+++ b/internal/releasesources/mock_clients.go
@@ -80,16 +80,16 @@ func (m *MockopenShiftSupportLevelAPIClientInterface) EXPECT() *MockopenShiftSup
 }
 
 // getSupportLevels mocks base method.
-func (m *MockopenShiftSupportLevelAPIClientInterface) getSupportLevels(majorVersion string) (ocpVersionSupportLevels, error) {
+func (m *MockopenShiftSupportLevelAPIClientInterface) getSupportLevels() (ocpVersionSupportLevels, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getSupportLevels", majorVersion)
+	ret := m.ctrl.Call(m, "getSupportLevels")
 	ret0, _ := ret[0].(ocpVersionSupportLevels)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // getSupportLevels indicates an expected call of getSupportLevels.
-func (mr *MockopenShiftSupportLevelAPIClientInterfaceMockRecorder) getSupportLevels(majorVersion any) *gomock.Call {
+func (mr *MockopenShiftSupportLevelAPIClientInterfaceMockRecorder) getSupportLevels() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getSupportLevels", reflect.TypeOf((*MockopenShiftSupportLevelAPIClientInterface)(nil).getSupportLevels), majorVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getSupportLevels", reflect.TypeOf((*MockopenShiftSupportLevelAPIClientInterface)(nil).getSupportLevels))
 }

--- a/internal/releasesources/release_sources.go
+++ b/internal/releasesources/release_sources.go
@@ -273,7 +273,7 @@ func (h *releaseSourcesHandler) SyncReleaseImages() error {
 		return err
 	}
 	h.log.Debugf("Found %d dynamic release Images", len(enrichedDynamicReleaseImages))
-	supportLevels, err := h.getSupportLevels()
+	supportLevels, err := h.supportLevelClient.getSupportLevels()
 	if err != nil {
 		return err
 	}
@@ -316,55 +316,6 @@ func (h *releaseSourcesHandler) SyncReleaseImages() error {
 
 	h.log.Debug("Commiting changes")
 	return tx.Commit().Error
-}
-
-// getReleaseImagesMajorOCPVersions retrieves the major OCP versions for both static and dynamic release images discovered.
-func (h *releaseSourcesHandler) getReleaseImagesMajorOCPVersions() (ocpMajorVersionSet, error) {
-	majorVersions := ocpMajorVersionSet{}
-
-	// First from static release images
-	for _, releaseImage := range h.enrichedStaticReleaseImages {
-		majorVersion, err := common.GetMajorVersion(*releaseImage.OpenshiftVersion)
-		if err != nil {
-			return nil, errors.Errorf("error occurred while trying to get the major version of %s", *releaseImage.OpenshiftVersion)
-		}
-		majorVersions[*majorVersion] = true
-	}
-
-	// Then from dynamic release images
-	for _, releaseSource := range h.releaseSources {
-		majorVersion, err := common.GetMajorVersion(*releaseSource.OpenshiftVersion)
-		if err != nil {
-			return nil, errors.Errorf("error occurred while trying to get the major version of %s", *releaseSource.OpenshiftVersion)
-		}
-		majorVersions[*majorVersion] = true
-	}
-
-	return majorVersions, nil
-}
-
-// getSupportLevels retrieves a mapping from OCP major.minor versions
-// to their corresponding support levels for both static and dynamic release images.
-func (h *releaseSourcesHandler) getSupportLevels() (ocpVersionSupportLevels, error) {
-	ocpMajorVersionSet, err := h.getReleaseImagesMajorOCPVersions()
-	if err != nil {
-		return nil, err
-	}
-
-	supportLevels := ocpVersionSupportLevels{}
-
-	for majorVersion := range ocpMajorVersionSet {
-		supportLevelsForMajor, err := h.supportLevelClient.getSupportLevels(majorVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		for majorMinorVersion, supportLevel := range supportLevelsForMajor {
-			supportLevels[majorMinorVersion] = supportLevel
-		}
-	}
-
-	return supportLevels, nil
 }
 
 // setSupportLevels sets support level for given release images as follows:

--- a/internal/releasesources/release_sources_test.go
+++ b/internal/releasesources/release_sources_test.go
@@ -36,13 +36,10 @@ func setGetReleasesMock(releasesMock *MockopenShiftReleasesAPIClientInterface, t
 	}
 }
 
-func setGetSupportLevelsMock(supportLevelMock *MockopenShiftSupportLevelAPIClientInterface, majorVersion string) {
-	supportLevels, err := getExpectedSupportLevels(majorVersion)
-	Expect(err).ToNot(HaveOccurred())
-
+func setGetSupportLevelsMock(supportLevelMock *MockopenShiftSupportLevelAPIClientInterface) {
 	supportLevelMock.EXPECT().
-		getSupportLevels(majorVersion).
-		Return(supportLevels, nil).
+		getSupportLevels().
+		Return(getExpectedSupportLevels(), nil).
 		AnyTimes()
 }
 
@@ -203,7 +200,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -337,7 +334,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -366,7 +363,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -502,7 +499,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -523,7 +520,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -553,7 +550,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -656,7 +653,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		err = handler.SyncReleaseImages()
 		Expect(err).ToNot(HaveOccurred())
@@ -711,7 +708,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.releasesClient = releasesClientMock
 		handler.supportLevelClient = supportLevelsClientMock
 
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 		releasesClientMock.EXPECT().
 			getReleases(models.ReleaseChannelStable, "4.16", common.AMD64CPUArchitecture).
 			Return(&ReleaseGraph{}, nil).
@@ -777,7 +774,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "4.14", common.AMD64CPUArchitecture).
 				Return(
@@ -875,7 +872,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "4.14", common.AMD64CPUArchitecture).
 				Return(
@@ -973,7 +970,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "4.14", common.S390xCPUArchitecture).
 				Return(
@@ -1083,8 +1080,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
-			setGetSupportLevelsMock(supportLevelsClientMock, "5")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 
 			err = handler.SyncReleaseImages()
 			Expect(err).ToNot(HaveOccurred())
@@ -1200,8 +1196,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
-			setGetSupportLevelsMock(supportLevelsClientMock, "5")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "5.3", common.AMD64CPUArchitecture).
 				Return(
@@ -1330,7 +1325,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.releasesClient = releasesClientMock
 		handler.supportLevelClient = supportLevelsClientMock
 
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 		releasesClientMock.EXPECT().
 			getReleases(models.ReleaseChannelCandidate, "4.14", common.AMD64CPUArchitecture).
 			Return(
@@ -1482,7 +1477,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "4.14", common.AMD64CPUArchitecture).
 				Return(&ReleaseGraph{
@@ -1561,7 +1556,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			handler.releasesClient = releasesClientMock
 			handler.supportLevelClient = supportLevelsClientMock
 
-			setGetSupportLevelsMock(supportLevelsClientMock, "4")
+			setGetSupportLevelsMock(supportLevelsClientMock)
 			releasesClientMock.EXPECT().
 				getReleases(models.ReleaseChannelStable, "4.14", common.AMD64CPUArchitecture).
 				Return(&ReleaseGraph{
@@ -1597,7 +1592,7 @@ var _ = Describe("SyncReleaseImages", func() {
 		handler.supportLevelClient = supportLevelsClientMock
 
 		setGetReleasesMock(releasesClientMock, requestResponseParams)
-		setGetSupportLevelsMock(supportLevelsClientMock, "4")
+		setGetSupportLevelsMock(supportLevelsClientMock)
 
 		expectedResult := models.ReleaseImages{
 			{


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

In our SaaS deployment we get the lifecycle data for OCP versions to determine the support level for those versions.
We get this data from https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+OCP major version.
However, the products name was changed to Red Hat OpenShift Container Platform.
While we can still access the info for OCP 4 because of the product’s former_names, there’s no guaranty that an endpoint for OCP 5 will be added.
We should instead get this data from https://access.redhat.com/product-life-cycles/api/v2/products?name=Red+Hat+OpenShift+Container+Platform.

## List all the issues related to this PR

Closes [MGMT-24610](https://redhat.atlassian.net/browse/MGMT-24610)

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched Red Hat Product Life Cycle API usage to the v2 product endpoint.
  * Updated support-level retrieval to no longer require an OpenShift major version, using a single fixed query name and directly applying results during release image synchronization.
* **Tests**
  * Refreshed support-level fixtures and revised expectations to be version-agnostic.
  * Updated mocks and test cases to match the new support-level client behavior and call signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->