### PR TITLE
OCPBUGS-87099: Add sourcedir /run/chrony-dhcp to generated chrony.conf

### DIFF
--- a/internal/ignition/templates/add-ntp-sources.sh
+++ b/internal/ignition/templates/add-ntp-sources.sh
@@ -4,7 +4,8 @@
 # Replace mode: use only the specified NTP sources, no default pool
 cat > /etc/chrony.conf <<.
 {{ range .DesiredNtpSources }}server {{ . }} iburst
-{{ end }}driftfile /var/lib/chrony/drift
+{{ end }}sourcedir /run/chrony-dhcp
+driftfile /var/lib/chrony/drift
 makestep 1.0 -1
 rtcsync
 logdir /var/log/chrony

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -67,6 +67,7 @@ const (
 
 const defaultChronyConf = `
 pool 0.rhel.pool.ntp.org iburst
+sourcedir /run/chrony-dhcp
 driftfile /var/lib/chrony/drift
 makestep 1.0 3
 rtcsync
@@ -202,6 +203,7 @@ const schedulableMastersManifestPatch = `---
 `
 
 const exclusiveChronyConf = `
+sourcedir /run/chrony-dhcp
 driftfile /var/lib/chrony/drift
 makestep 1.0 3
 rtcsync


### PR DESCRIPTION
When DHCP provides NTP servers, a NetworkManager dispatcher script writes them to /run/chrony-dhcp/<interface>.sources and triggers chronyc reload sources. However, chrony only reads that directory if chrony.conf contains `sourcedir /run/chrony-dhcp`. The chrony.conf generated by assisted-service does not include this directive, so DHCP-provided NTP servers are silently ignored.

Add `sourcedir /run/chrony-dhcp` to:
- defaultChronyConf (all installed clusters)
- exclusiveChronyConf (clusters using ntp_sources)
- add-ntp-sources.sh replace mode (discovery with ntp_sources)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network time synchronization now supports DHCP-provided NTP sources, enabling dynamic time server configuration alongside manually configured servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->