### PR TITLE
[release-ocm-2.13] ACM-35866: CVE-2026-39828/39829/39830 Bump golang.org/x/crypto to v0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/thedevsaddam/retry v1.2.1
 	github.com/thoas/go-funk v0.9.3
 	github.com/vincent-petithory/dataurl v1.0.0
-	golang.org/x/crypto v0.46.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.42.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1162,7 +1162,7 @@ go.uber.org/zap/zapgrpc
 # go.yaml.in/yaml/v2 v2.4.3
 ## explicit; go 1.15
 go.yaml.in/yaml/v2
-# golang.org/x/crypto v0.46.0 => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
+# golang.org/x/crypto v0.52.0 => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 ## explicit; go 1.20
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish


### PR DESCRIPTION
Bump `golang.org/x/crypto` to v0.52.0 to fix three SSH vulnerabilities:

- **CVE-2026-39828** — SSH certificate restriction bypass via PartialSuccessError
- **CVE-2026-39829** — DoS via oversized RSA/DSA key parameters
- **CVE-2026-39830** — Server deadlock via unsolicited global request responses

## Changes
- `golang.org/x/crypto` → v0.52.0
- Transitive updates to x/net, x/sync, x/sys as needed
- Vendor updated

https://redhat.atlassian.net/browse/ACM-35866