### PR TITLE
OCPBUGS-91974: Stop setting DevPreviewNoUpgrade for TNF clusters

### DIFF
--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -621,20 +621,29 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect(supportLevel).To(Equal(result))
 			},
 			Entry(
-				"dev-preview openshift version with platform filter",
+				"tech-preview openshift version with platform filter",
 				SupportLevelFilters{
 					OpenshiftVersion: common.MinimumVersionForTwoNodesWithFencing,
 					PlatformType:     models.PlatformTypeBaremetal.Pointer(),
 				},
-				models.SupportLevelDevPreview,
+				models.SupportLevelTechPreview,
 			),
 
 			Entry(
-				"dev-preview openshift version without platform filter",
+				"tech-preview openshift version without platform filter",
 				SupportLevelFilters{
 					OpenshiftVersion: common.MinimumVersionForTwoNodesWithFencing,
 				},
-				models.SupportLevelDevPreview,
+				models.SupportLevelTechPreview,
+			),
+
+			Entry(
+				"tech-preview openshift version 4.21",
+				SupportLevelFilters{
+					OpenshiftVersion: "4.21",
+					PlatformType:     models.PlatformTypeBaremetal.Pointer(),
+				},
+				models.SupportLevelTechPreview,
 			),
 
 			Entry(

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -621,20 +621,37 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect(supportLevel).To(Equal(result))
 			},
 			Entry(
-				"tech preview openshift version with platform filter",
+				"dev-preview openshift version with platform filter",
 				SupportLevelFilters{
 					OpenshiftVersion: common.MinimumVersionForTwoNodesWithFencing,
 					PlatformType:     models.PlatformTypeBaremetal.Pointer(),
 				},
-				models.SupportLevelTechPreview,
+				models.SupportLevelDevPreview,
 			),
 
 			Entry(
-				"tech preview openshift version without platform filter",
+				"dev-preview openshift version without platform filter",
 				SupportLevelFilters{
 					OpenshiftVersion: common.MinimumVersionForTwoNodesWithFencing,
 				},
-				models.SupportLevelTechPreview,
+				models.SupportLevelDevPreview,
+			),
+
+			Entry(
+				"supported openshift version with platform filter",
+				SupportLevelFilters{
+					OpenshiftVersion: "4.22",
+					PlatformType:     models.PlatformTypeBaremetal.Pointer(),
+				},
+				models.SupportLevelSupported,
+			),
+
+			Entry(
+				"supported openshift version without platform filter",
+				SupportLevelFilters{
+					OpenshiftVersion: "4.22",
+				},
+				models.SupportLevelSupported,
 			),
 
 			Entry(

--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -170,12 +170,15 @@ func (feature *TnfFeature) getSupportLevel(filters SupportLevelFilters) (models.
 		return models.SupportLevelUnavailable, models.IncompatibilityReasonPlatform
 	}
 
-	fencingClustersSupported, err := common.BaseVersionGreaterOrEqual(common.MinimumVersionForTwoNodesWithFencing, filters.OpenshiftVersion)
-	if !fencingClustersSupported || err != nil {
-		return models.SupportLevelUnavailable, models.IncompatibilityReasonOpenshiftVersion
+	if isMinVersion, _ := common.BaseVersionEqual(common.MinimumVersionForTwoNodesWithFencing, filters.OpenshiftVersion); isMinVersion {
+		return models.SupportLevelDevPreview, ""
 	}
 
-	return models.SupportLevelTechPreview, ""
+	if fencingClustersSupported, _ := common.BaseVersionGreaterOrEqual(common.MinimumVersionForTwoNodesWithFencing, filters.OpenshiftVersion); fencingClustersSupported {
+		return models.SupportLevelSupported, ""
+	}
+
+	return models.SupportLevelUnavailable, models.IncompatibilityReasonOpenshiftVersion
 }
 
 func (feature *TnfFeature) getIncompatibleFeatures(string) []models.FeatureSupportLevelID {

--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -170,12 +170,14 @@ func (feature *TnfFeature) getSupportLevel(filters SupportLevelFilters) (models.
 		return models.SupportLevelUnavailable, models.IncompatibilityReasonPlatform
 	}
 
-	if isMinVersion, _ := common.BaseVersionEqual(common.MinimumVersionForTwoNodesWithFencing, filters.OpenshiftVersion); isMinVersion {
-		return models.SupportLevelDevPreview, ""
+	// TNF is GA from 4.22
+	if isGA, _ := common.BaseVersionGreaterOrEqual("4.22", filters.OpenshiftVersion); isGA {
+		return models.SupportLevelSupported, ""
 	}
 
+	// TNF is TechPreview in 4.20-4.21
 	if fencingClustersSupported, _ := common.BaseVersionGreaterOrEqual(common.MinimumVersionForTwoNodesWithFencing, filters.OpenshiftVersion); fencingClustersSupported {
-		return models.SupportLevelSupported, ""
+		return models.SupportLevelTechPreview, ""
 	}
 
 	return models.SupportLevelUnavailable, models.IncompatibilityReasonOpenshiftVersion

--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -397,9 +397,9 @@ func (i *installConfigBuilder) handleFencing(cfg *installcfg.InstallerConfigBare
 
 	cfg.ControlPlane.Fencing = &installcfg.Fencing{Credentials: fencingCredentials}
 
-	// TNF is DevPreview in 4.20 and GA in greater versions
-	if is420, _ := common.BaseVersionEqual(common.MinimumVersionForTwoNodesWithFencing, cluster.OpenshiftVersion); is420 {
-		cfg.FeatureSet = configv1.DevPreviewNoUpgrade
+	// TNF is TechPreview in 4.20-4.21, GA from 4.22
+	if isGA, _ := common.BaseVersionGreaterOrEqual("4.22", cluster.OpenshiftVersion); !isGA {
+		cfg.FeatureSet = configv1.TechPreviewNoUpgrade
 	}
 
 	return nil

--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -398,7 +398,11 @@ func (i *installConfigBuilder) handleFencing(cfg *installcfg.InstallerConfigBare
 	cfg.ControlPlane.Fencing = &installcfg.Fencing{Credentials: fencingCredentials}
 
 	// TNF is TechPreview in 4.20-4.21, GA from 4.22
-	if isGA, _ := common.BaseVersionGreaterOrEqual("4.22", cluster.OpenshiftVersion); !isGA {
+	isGA, err := common.BaseVersionGreaterOrEqual("4.22", cluster.OpenshiftVersion)
+	if err != nil {
+		return err
+	}
+	if !isGA {
 		cfg.FeatureSet = configv1.TechPreviewNoUpgrade
 	}
 

--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -396,7 +396,11 @@ func (i *installConfigBuilder) handleFencing(cfg *installcfg.InstallerConfigBare
 	}
 
 	cfg.ControlPlane.Fencing = &installcfg.Fencing{Credentials: fencingCredentials}
-	cfg.FeatureSet = configv1.DevPreviewNoUpgrade
+
+	// TNF is DevPreview in 4.20 and GA in greater versions
+	if is420, _ := common.BaseVersionEqual(common.MinimumVersionForTwoNodesWithFencing, cluster.OpenshiftVersion); is420 {
+		cfg.FeatureSet = configv1.DevPreviewNoUpgrade
+	}
 
 	return nil
 }

--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -192,7 +192,7 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(result.Arbiter.Replicas).To(Equal(1))
 	})
 
-	It("create_configuration_with_all_hosts - TNF cluster DevPreview", func() {
+	It("create_configuration_with_all_hosts - TNF cluster", func() {
 		certificateVerificationEnabled := installcfg.CertificateVerificationEnabled
 		certificateVerificationDisabled := installcfg.CertificateVerificationDisabled
 		fencingCredentials1 := models.FencingCredentialsParams{
@@ -244,6 +244,45 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(result.Networking.NetworkType).To(Equal(models.ClusterNetworkTypeOpenShiftSDN))
 		Expect(result.Arbiter).Should(BeNil())
 		Expect(result.FeatureSet).To(Equal(configv1.DevPreviewNoUpgrade))
+		Expect(result.FeatureGates).To(HaveLen(0))
+	})
+
+	It("create_configuration_with_all_hosts - TNF cluster GA", func() {
+		certificateVerificationEnabled := installcfg.CertificateVerificationEnabled
+		fencingCredentials1 := models.FencingCredentialsParams{
+			Address:                 swag.String("https://address1.example.com"),
+			CertificateVerification: swag.String(string(certificateVerificationEnabled)),
+			Password:                swag.String("password"),
+			Username:                swag.String("username"),
+		}
+		fencingCredentials2 := models.FencingCredentialsParams{
+			Address:                 swag.String("https://address2.example.com"),
+			Password:                swag.String("password"),
+			Username:                swag.String("username"),
+		}
+		fencingCredentialsHost1String, err := json.Marshal(fencingCredentials1)
+		Expect(err).ShouldNot(HaveOccurred())
+		fencingCredentialsHost2String, err := json.Marshal(fencingCredentials2)
+		Expect(err).ShouldNot(HaveOccurred())
+		host1.FencingCredentials = string(fencingCredentialsHost1String)
+		host1.Role = models.HostRoleMaster
+		host2.FencingCredentials = string(fencingCredentialsHost2String)
+		host2.Role = models.HostRoleMaster
+		cluster.Hosts = []*models.Host{&host1, &host2}
+		cluster.ControlPlaneCount = 2
+		cluster.OpenshiftVersion = "4.22"
+
+		var result installcfg.InstallerConfigBaremetal
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		data, err := installConfig.GetInstallConfig(&cluster, clusterInfraenvs, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = json.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result.ControlPlane.Fencing).Should(Not(BeNil()))
+		Expect(result.ControlPlane.Fencing.Credentials).To(HaveLen(2))
+		Expect(result.Networking.NetworkType).To(Equal(models.ClusterNetworkTypeOpenShiftSDN))
+		Expect(result.Arbiter).Should(BeNil())
+		Expect(result.FeatureSet).To(Equal(configv1.Default))
 		Expect(result.FeatureGates).To(HaveLen(0))
 	})
 

--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -243,7 +243,7 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		}))
 		Expect(result.Networking.NetworkType).To(Equal(models.ClusterNetworkTypeOpenShiftSDN))
 		Expect(result.Arbiter).Should(BeNil())
-		Expect(result.FeatureSet).To(Equal(configv1.DevPreviewNoUpgrade))
+		Expect(result.FeatureSet).To(Equal(configv1.TechPreviewNoUpgrade))
 		Expect(result.FeatureGates).To(HaveLen(0))
 	})
 


### PR DESCRIPTION
## Summary

- Remove unconditional `DevPreviewNoUpgrade` FeatureSet override from `handleFencing()` in the install-config builder
- Update TNF feature support level from `TechPreview` to `Supported` — TNF (DualReplica) is GA in 4.22
- Update tests to match new behavior

## Root Cause

`handleFencing()` in `internal/installcfg/builder/builder.go` unconditionally set `cfg.FeatureSet = configv1.DevPreviewNoUpgrade` for every TNF cluster. This blocked upgrades with: `FeatureGatesUpgradeable: "DevPreviewNoUpgrade" does not allow updates`.

The `DualReplica` feature gate is in the `Default` feature set since 4.22, so no FeatureSet override is needed. The Arbiter (TNA) feature in the same file already handles this correctly — it only sets `TechPreviewNoUpgrade` for its minimum version (4.19).

## Test plan

- [x] `go test ./internal/installcfg/builder/` passes
- [x] `go test ./internal/featuresupport/` passes
- [ ] Deploy TNF cluster via ABI — confirm no `DevPreviewNoUpgrade` in cluster FeatureGates
- [ ] Upgrade deployed cluster — confirm upgrade is not blocked

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TNF (two nodes with fencing) support-level determination by adding a GA cutoff for newer OpenShift versions and refining TechPreview/Unavailable behavior around minimum supported releases, including updated handling for OpenShift **4.21** and Support behavior for **4.22**.
  * Updated TNF install-config feature-set selection so **4.22+** follows default GA behavior, while older versions use the expected TechPreview setting.
* **Tests**
  * Updated TNF test expectations, including revised table wording/coverage for TechPreview entries and new/adjusted assertions for **4.22** scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->