### PR TITLE
MGMT-24644: Pin namespace references in operator controllers

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -208,7 +208,7 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 
 	if agent.Spec.ClusterDeploymentName != nil {
 		kubeKey := types.NamespacedName{
-			Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+			Namespace: agent.GetNamespace(),
 			Name:      agent.Spec.ClusterDeploymentName.Name,
 		}
 		clusterDeployment := &hivev1.ClusterDeployment{}
@@ -216,7 +216,7 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 		// Retrieve clusterDeployment
 		if err = r.Get(ctx, kubeKey, clusterDeployment); err != nil {
 			errMsg := fmt.Sprintf("failed to get clusterDeployment with name %s in namespace %s",
-				agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
+				agent.Spec.ClusterDeploymentName.Name, agent.GetNamespace())
 			log.WithError(err).Error(errMsg)
 			// Update that we failed to retrieve the clusterDeployment
 			//TODO MGMT-7844 add mapping CD-ACI to rnot requeue always
@@ -227,7 +227,7 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 		cluster, err2 := r.Installer.GetClusterByKubeKey(kubeKey)
 		if err2 != nil {
 			log.WithError(err2).Errorf("Fail to get cluster name: %s namespace: %s in backend",
-				agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
+				agent.Spec.ClusterDeploymentName.Name, agent.GetNamespace())
 			// Update that we failed to retrieve the cluster from the database
 			return r.updateStatus(ctx, log, agent, origAgent, &h.Host, nil, err2, true)
 		}
@@ -519,7 +519,7 @@ func (r *AgentReconciler) handleAgentFinalizer(ctx context.Context, log logrus.F
 				// only remove the spoke resources if the entire cluster isn't being deleted
 				clusterRef := types.NamespacedName{
 					Name:      agent.Spec.ClusterDeploymentName.Name,
-					Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+					Namespace: agent.GetNamespace(),
 				}
 				clusterExists, err := r.clusterExists(ctx, clusterRef)
 				if err != nil {
@@ -1702,7 +1702,7 @@ func (r *AgentReconciler) updateLabels(log logrus.FieldLogger, ctx context.Conte
 
 	namespace := ""
 	if agent.Spec.ClusterDeploymentName != nil {
-		namespace = agent.Spec.ClusterDeploymentName.Namespace
+		namespace = agent.GetNamespace()
 	}
 	changed = setAgentLabel(log, agent, AgentLabelClusterDeploymentNamespace, namespace) || changed
 
@@ -1853,7 +1853,7 @@ func (r *AgentReconciler) updateHostFencingCredentials(ctx context.Context, log 
 
 func (r *AgentReconciler) updateHostIgnitionEndpointToken(ctx context.Context, log logrus.FieldLogger, host *common.Host, agent *aiv1beta1.Agent, params *installer.V2UpdateHostParams) (bool, error) {
 	if agent.Spec.IgnitionEndpointTokenReference != nil {
-		token, err := r.getIgnitionToken(ctx, agent.Spec.IgnitionEndpointTokenReference)
+		token, err := r.getIgnitionToken(ctx, agent.Spec.IgnitionEndpointTokenReference, agent.GetNamespace())
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get ignition token")
 			return false, err
@@ -2045,8 +2045,8 @@ func updateInstallDisk(host *models.Host, desiredDiskID, desiredDiskByPath strin
 	return !matchesInstallDisk, diskID, nil
 }
 
-func (r *AgentReconciler) getIgnitionToken(ctx context.Context, ignitionEndpointTokenReference *aiv1beta1.IgnitionEndpointTokenReference) (string, error) {
-	secretRef := types.NamespacedName{Namespace: ignitionEndpointTokenReference.Namespace, Name: ignitionEndpointTokenReference.Name}
+func (r *AgentReconciler) getIgnitionToken(ctx context.Context, ignitionEndpointTokenReference *aiv1beta1.IgnitionEndpointTokenReference, ownerNamespace string) (string, error) {
+	secretRef := types.NamespacedName{Namespace: ownerNamespace, Name: ignitionEndpointTokenReference.Name}
 	secret, err := getSecret(ctx, r.Client, r.APIReader, secretRef)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get user-data secret")
@@ -2211,13 +2211,13 @@ func (r *AgentReconciler) restoreHostByAgent(ctx context.Context, log logrus.Fie
 	var cluster *common.Cluster
 	if agent.Spec.ClusterDeploymentName != nil {
 		clusterKey := types.NamespacedName{
-			Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+			Namespace: agent.GetNamespace(),
 			Name:      agent.Spec.ClusterDeploymentName.Name,
 		}
 		cluster, err = r.Installer.GetClusterByKubeKey(clusterKey)
 		if err != nil {
 			r.Log.WithError(err).Errorf("Failed to get cluster (name: %s namespace: %s)",
-				agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
+				agent.Spec.ClusterDeploymentName.Name, agent.GetNamespace())
 			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 		}
 		clusterID = cluster.ID

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1123,7 +1123,7 @@ func (r *BMACReconciler) reconcileDay2SpokeBMH(ctx context.Context, log logrus.F
 	}
 
 	key := types.NamespacedName{
-		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+		Namespace: agent.GetNamespace(),
 		Name:      getClusterDeploymentAdminKubeConfigSecretName(cd),
 	}
 	isNonePlatform, propagateError, err := isNonePlatformCluster(ctx, r.Client, cd)
@@ -1465,7 +1465,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 	}
 
 	key := types.NamespacedName{
-		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+		Namespace: agent.GetNamespace(),
 		Name:      getClusterDeploymentAdminKubeConfigSecretName(cd),
 	}
 
@@ -1813,7 +1813,7 @@ func (r *BMACReconciler) getClusterDeploymentAndCheckIfInstalled(ctx context.Con
 	clusterDeployment := &hivev1.ClusterDeployment{}
 
 	cdKey := types.NamespacedName{
-		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+		Namespace: agent.GetNamespace(),
 		Name:      agent.Spec.ClusterDeploymentName.Name,
 	}
 	var err error
@@ -1949,18 +1949,22 @@ func nodeUnreachable(node *corev1.Node) bool {
 func (r *BMACReconciler) drainAgentNode(ctx context.Context, log logrus.FieldLogger, agent *aiv1beta1.Agent) (bool, error) {
 	log = log.WithFields(logrus.Fields{
 		"spoke_cluster_name":      agent.Spec.ClusterDeploymentName.Name,
-		"spoke_cluster_namespace": agent.Spec.ClusterDeploymentName.Namespace,
+		"spoke_cluster_namespace": agent.GetNamespace(),
 	})
 	log.Info("Draining agent node...")
 	// get spoke connection
-	spokeSecret, err := spokeKubeconfigSecret(ctx, log, r.Client, r.APIReader, agent.Spec.ClusterDeploymentName)
+	pinnedRef := &aiv1beta1.ClusterReference{
+		Name:      agent.Spec.ClusterDeploymentName.Name,
+		Namespace: agent.GetNamespace(),
+	}
+	spokeSecret, err := spokeKubeconfigSecret(ctx, log, r.Client, r.APIReader, pinnedRef)
 	if err != nil {
 		log.WithError(err).Error("failed to get spoke kubeconfig secret")
 		return false, err
 	}
 
 	clusterDeploymentKey := types.NamespacedName{
-		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+		Namespace: agent.GetNamespace(),
 		Name:      agent.Spec.ClusterDeploymentName.Name,
 	}
 	clusterDeployment := &hivev1.ClusterDeployment{}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -874,8 +874,8 @@ func getHyperthreading(clusterInstall *hiveext.AgentClusterInstall) *string {
 }
 
 func (r *ClusterDeploymentsReconciler) getEncodedCACert(ctx context.Context,
-	caCertificateRef *hiveext.CaCertificateReference) (*string, error) {
-	secretRef := types.NamespacedName{Namespace: caCertificateRef.Namespace, Name: caCertificateRef.Name}
+	caCertificateRef *hiveext.CaCertificateReference, ownerNamespace string) (*string, error) {
+	secretRef := types.NamespacedName{Namespace: ownerNamespace, Name: caCertificateRef.Name}
 	caSecret, err := getSecret(ctx, r.Client, r.APIReader, secretRef)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting ca certificate secret")
@@ -893,14 +893,14 @@ func (r *ClusterDeploymentsReconciler) getEncodedCACert(ctx context.Context,
 }
 
 func (r *ClusterDeploymentsReconciler) parseIgnitionEndpoint(ctx context.Context,
-	kubeapiIgnitionEndpoint *hiveext.IgnitionEndpoint) (*models.IgnitionEndpoint, error) {
+	kubeapiIgnitionEndpoint *hiveext.IgnitionEndpoint, ownerNamespace string) (*models.IgnitionEndpoint, error) {
 
 	ignitionEndpoint := &models.IgnitionEndpoint{}
 	ignitionEndpoint.URL = swag.String(kubeapiIgnitionEndpoint.Url)
 
 	caCertificateReference := kubeapiIgnitionEndpoint.CaCertificateReference
 	if caCertificateReference != nil {
-		caCertificate, err := r.getEncodedCACert(ctx, caCertificateReference)
+		caCertificate, err := r.getEncodedCACert(ctx, caCertificateReference, ownerNamespace)
 		if err == nil {
 			ignitionEndpoint.CaCertificate = caCertificate
 		} else {
@@ -919,7 +919,7 @@ func (r *ClusterDeploymentsReconciler) updateIgnitionInUpdateParams(ctx context.
 	params *models.V2ClusterUpdateParams) (bool, error) {
 	update := false
 	if clusterInstall.Spec.IgnitionEndpoint != nil {
-		ignitionEndpoint, err := r.parseIgnitionEndpoint(ctx, clusterInstall.Spec.IgnitionEndpoint)
+		ignitionEndpoint, err := r.parseIgnitionEndpoint(ctx, clusterInstall.Spec.IgnitionEndpoint, clusterInstall.Namespace)
 		if err == nil {
 			params.IgnitionEndpoint = ignitionEndpoint
 			if cluster.IgnitionEndpoint == nil || !reflect.DeepEqual(cluster.IgnitionEndpoint, ignitionEndpoint) {
@@ -1593,7 +1593,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	var ignitionEndpoint *models.IgnitionEndpoint
 	var err error
 	if clusterInstall.Spec.IgnitionEndpoint != nil {
-		ignitionEndpoint, err = r.parseIgnitionEndpoint(ctx, clusterInstall.Spec.IgnitionEndpoint)
+		ignitionEndpoint, err = r.parseIgnitionEndpoint(ctx, clusterInstall.Spec.IgnitionEndpoint, clusterInstall.Namespace)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get and parse ignition ca certificate %s/%s", clusterInstall.Namespace, clusterInstall.Name)
 			return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, nil, err)
@@ -1911,11 +1911,11 @@ func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			return []reconcile.Request{}
 		}
 		if agent.Spec.ClusterDeploymentName != nil {
-			log.Debugf("Map Agent : %s %s CD ref name %s ns %s", agent.Namespace, agent.Name, agent.Spec.ClusterDeploymentName.Name, agent.Spec.ClusterDeploymentName.Namespace)
+			log.Debugf("Map Agent : %s %s CD ref name %s ns %s", agent.Namespace, agent.Name, agent.Spec.ClusterDeploymentName.Name, agent.GetNamespace())
 			return []reconcile.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+						Namespace: agent.GetNamespace(),
 						Name:      agent.Spec.ClusterDeploymentName.Name,
 					},
 				},
@@ -2610,7 +2610,7 @@ func getClusterDeploymentAdminKubeConfigSecretName(cd *hivev1.ClusterDeployment)
 
 // processMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap
 func (r *ClusterDeploymentsReconciler) processMirrorRegistryConfig(ctx context.Context, log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall) (*common.MirrorRegistryConfiguration, error) {
-	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, clusterInstall.Spec.MirrorRegistryRef)
+	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, clusterInstall.Spec.MirrorRegistryRef, clusterInstall.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -463,7 +463,7 @@ func getClusterDeploymentFromAgent(ctx context.Context, client client.Client, ag
 		return nil, errors.Errorf("No cluster deployment for agent %s/%s", agent.Namespace, agent.Name)
 	}
 	namespacedName := types.NamespacedName{
-		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
+		Namespace: agent.GetNamespace(),
 		Name:      agent.Spec.ClusterDeploymentName.Name,
 	}
 	if err := client.Get(ctx, namespacedName, &cd); err != nil {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -326,7 +326,7 @@ func (r *InfraEnvReconciler) processNMStateConfig(ctx context.Context, log logru
 	}
 
 	nmStateConfigs := &aiv1beta1.NMStateConfigList{}
-	if err = r.List(ctx, nmStateConfigs, &client.ListOptions{LabelSelector: selector}); err != nil {
+	if err = r.List(ctx, nmStateConfigs, client.InNamespace(infraEnv.Namespace), &client.ListOptions{LabelSelector: selector}); err != nil {
 		return staticNetworkConfig, errors.Wrapf(err, "failed to list nmstate configs for InfraEnv %v", infraEnv)
 	}
 
@@ -935,7 +935,7 @@ func (r *InfraEnvReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // processMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap
 func (r *InfraEnvReconciler) processMirrorRegistryConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) (*common.MirrorRegistryConfiguration, error) {
-	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, infraEnv.Spec.MirrorRegistryRef)
+	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, infraEnv.Spec.MirrorRegistryRef, infraEnv.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/controllers/mirrorregistry/mirror_registry_parser.go
+++ b/internal/controller/controllers/mirrorregistry/mirror_registry_parser.go
@@ -20,9 +20,9 @@ const (
 )
 
 // getUserTomlConfigMapData get registries.conf and ca-bundle.crt if exist in the provided configmap inside AgentClusterInstall
-func getUserTomlConfigMapData(ctx context.Context, log logrus.FieldLogger, c client.Client, ref *hiveext.MirrorRegistryConfigMapReference) (string, string, *corev1.ConfigMap, error) {
+func getUserTomlConfigMapData(ctx context.Context, log logrus.FieldLogger, c client.Client, ref *hiveext.MirrorRegistryConfigMapReference, ownerNamespace string) (string, string, *corev1.ConfigMap, error) {
 	userTomlConfigMap := &corev1.ConfigMap{}
-	namespacedName := types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}
+	namespacedName := types.NamespacedName{Name: ref.Name, Namespace: ownerNamespace}
 	err := c.Get(ctx, namespacedName, userTomlConfigMap)
 	if err != nil {
 		log.Error(err, "Failed to get ConfigMap", "ConfigMapName", ref.Name, "ConfigMapNamespace", ref.Namespace)
@@ -63,13 +63,13 @@ func ParseMirrorRegistryConfig(registriesConf, caBundleCrt string) (*common2.Mir
 }
 
 // ProcessMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap
-func ProcessMirrorRegistryConfig(ctx context.Context, log logrus.FieldLogger, c client.Client, ref *hiveext.MirrorRegistryConfigMapReference) (*common2.MirrorRegistryConfiguration, *corev1.ConfigMap, error) {
+func ProcessMirrorRegistryConfig(ctx context.Context, log logrus.FieldLogger, c client.Client, ref *hiveext.MirrorRegistryConfigMapReference, ownerNamespace string) (*common2.MirrorRegistryConfiguration, *corev1.ConfigMap, error) {
 	if ref == nil {
 		return nil, nil, nil
 	}
 
-	log.Infof("Getting cluster mirror registry configurations %s %s ", ref.Namespace, ref.Name)
-	registriesConf, caBundleCrt, userTomlConfigMap, err := getUserTomlConfigMapData(ctx, log, c, ref)
+	log.Infof("Getting cluster mirror registry configurations %s %s ", ownerNamespace, ref.Name)
+	registriesConf, caBundleCrt, userTomlConfigMap, err := getUserTomlConfigMapData(ctx, log, c, ref, ownerNamespace)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -808,7 +808,7 @@ func (r *PreprovisioningImageReconciler) handlePreprovisioningImageDeletion(ctx 
 
 // processMirrorRegistryConfig retrieves the mirror registry configuration from the referenced ConfigMap
 func (r *PreprovisioningImageReconciler) processMirrorRegistryConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) (*common.MirrorRegistryConfiguration, error) {
-	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, infraEnv.Spec.MirrorRegistryRef)
+	mirrorRegistryConfiguration, userTomlConfigMap, err := mirrorregistry.ProcessMirrorRegistryConfig(ctx, log, r.Client, infraEnv.Spec.MirrorRegistryRef, infraEnv.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/spoke_k8s_client/factory.go
+++ b/internal/spoke_k8s_client/factory.go
@@ -132,7 +132,12 @@ func (f *spokeK8sClientFactory) restConfigFromSecret(secret *corev1.Secret) (*re
 	if err != nil {
 		return nil, err
 	}
-	return clientConfig.ClientConfig()
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	f.logger.Infof("Creating spoke client for API server: %s (secret: %s/%s)", restConfig.Host, secret.Namespace, secret.Name)
+	return restConfig, nil
 }
 
 func (f *spokeK8sClientFactory) kubeConfigFromSecret(secret *corev1.Secret) ([]byte, error) {

--- a/pkg/webhooks/agentinstall/v1beta1/agent_admission_hook.go
+++ b/pkg/webhooks/agentinstall/v1beta1/agent_admission_hook.go
@@ -169,6 +169,10 @@ func (a *AgentValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1
 		}
 	}
 
+	if resp := validateAgentNamespaceRefs(contextLogger, newObject, admissionSpec.Namespace); resp != nil {
+		return resp
+	}
+
 	contextLogger.Info("Successful validation")
 	return &admissionv1.AdmissionResponse{
 		Allowed: true,
@@ -226,6 +230,10 @@ func (a *AgentValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1
 		}
 	}
 
+	if resp := validateAgentNamespaceRefs(contextLogger, newObject, admissionSpec.Namespace); resp != nil {
+		return resp
+	}
+
 	if !areClusterRefsEqual(oldObject.Spec.ClusterDeploymentName, newObject.Spec.ClusterDeploymentName) {
 		if !isClusterRefChangeAllowed(newObject.Spec.ClusterDeploymentName, newObject.Status.DebugInfo.State, newObject.Status.Kind) {
 			// Fail validation only if the Cluster Deployment is changed to a different cluster or if the host is not day-2
@@ -266,4 +274,34 @@ func isClusterRefChangeAllowed(clusterRef *v1beta1.ClusterReference, currentStat
 	}
 
 	return hostKind == models.HostKindAddToExistingClusterHost && clusterRef == nil
+}
+
+func validateAgentNamespaceRefs(contextLogger *log.Entry, agent *v1beta1.Agent, agentNamespace string) *admissionv1.AdmissionResponse {
+	if ref := agent.Spec.ClusterDeploymentName; ref != nil {
+		if ref.Namespace != "" && ref.Namespace != agentNamespace {
+			message := "Spec.ClusterDeploymentName.Namespace must match the Agent namespace"
+			contextLogger.Infof("Failed validation: %v", message)
+			return &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+					Message: message,
+				},
+			}
+		}
+	}
+	if ref := agent.Spec.IgnitionEndpointTokenReference; ref != nil {
+		if ref.Namespace != "" && ref.Namespace != agentNamespace {
+			message := "Spec.IgnitionEndpointTokenReference.Namespace must match the Agent namespace"
+			contextLogger.Infof("Failed validation: %v", message)
+			return &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+					Message: message,
+				},
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/webhooks/agentinstall/v1beta1/agent_admission_hook_test.go
+++ b/pkg/webhooks/agentinstall/v1beta1/agent_admission_hook_test.go
@@ -93,30 +93,30 @@ var _ = Describe("agent web validate", func() {
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "newName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
-			name: "Test Agent.Spec.ClusterDeploymentName.Namespace is immutable for day 1 host, state installing",
+			name: "Test Agent.Spec.ClusterDeploymentName is immutable for day 1 host, state installing",
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
-					Name:      "oldName",
-					Namespace: "newNamespace",
+					Name:      "newName",
+					Namespace: "test-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -124,17 +124,17 @@ var _ = Describe("agent web validate", func() {
 			newStatus:       v1beta1.AgentStatus{DebugInfo: v1beta1.DebugInfo{State: models.HostStatusInstalling}, Kind: models.HostKindHost},
 		},
 		{
-			name: "Test Agent.Spec.ClusterDeploymentName.Namespace is immutable for day 2 host, state installing",
+			name: "Test Agent.Spec.ClusterDeploymentName is immutable for day 2 host, state installing",
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
-					Name:      "oldName",
-					Namespace: "newNamespace",
+					Name:      "newName",
+					Namespace: "test-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -146,13 +146,13 @@ var _ = Describe("agent web validate", func() {
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "newName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -167,7 +167,7 @@ var _ = Describe("agent web validate", func() {
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -175,17 +175,17 @@ var _ = Describe("agent web validate", func() {
 			newStatus:       v1beta1.AgentStatus{DebugInfo: v1beta1.DebugInfo{State: models.HostStatusInstalling}, Kind: models.HostKindAddToExistingClusterHost},
 		},
 		{
-			name: "Test Agent.Spec.ClusterDeploymentName.Namespace is mutable, state known",
+			name: "Test Agent.Spec.ClusterDeploymentName.Name is mutable, state known",
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
-					Name:      "oldName",
-					Namespace: "newNamespace",
+					Name:      "newName",
+					Namespace: "test-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -193,17 +193,35 @@ var _ = Describe("agent web validate", func() {
 			newStatus:       v1beta1.AgentStatus{DebugInfo: v1beta1.DebugInfo{State: models.HostStatusKnown}},
 		},
 		{
-			name: "Test Agent update does not fail when ClusterReference is set and remains the same",
+			name: "Test Agent.Spec.ClusterDeploymentName.Namespace cross-namespace is rejected",
 			newSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "other-namespace",
 				},
 			},
 			oldSpec: v1beta1.AgentSpec{
 				ClusterDeploymentName: &v1beta1.ClusterReference{
 					Name:      "oldName",
-					Namespace: "oldNamespace",
+					Namespace: "test-namespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+			newStatus:       v1beta1.AgentStatus{DebugInfo: v1beta1.DebugInfo{State: models.HostStatusKnown}},
+		},
+		{
+			name: "Test Agent update does not fail when ClusterReference is set and remains the same",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "test-namespace",
+				},
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "test-namespace",
 				},
 			},
 			operation:       admissionv1.Update,
@@ -368,6 +386,7 @@ var _ = Describe("agent web validate", func() {
 			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  *tc.gvr,
+				Namespace: "test-namespace",
 				Object: runtime.RawExtension{
 					Raw: tc.newObjectRaw,
 				},


### PR DESCRIPTION
Ensure controller reconcilers use the owning CR's namespace for all object references instead of trusting user-supplied namespace fields. Add admission webhook validation to reject cross-namespace references at create/update time. Add namespace filter to NMStateConfig list query. Add audit logging for spoke client API server URL.

## List all the issues related to this PR

- [ ] New Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md