### PR TITLE
MGMT-24327: upgrade assisted-service postgresql from 15 to 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ DEBUG_SERVICE_PORT := $(or ${DEBUG_SERVICE_PORT},40000)
 SERVICE := $(or ${SERVICE},${ASSISTED_ORG}/assisted-service:${ASSISTED_TAG})
 IMAGE_SERVICE := $(or ${IMAGE_SERVICE},${ASSISTED_ORG}/assisted-image-service:${ASSISTED_TAG})
 ASSISTED_UI := $(or ${ASSISTED_UI},${ASSISTED_ORG}/assisted-installer-ui:${ASSISTED_TAG})
-PSQL_IMAGE := $(or ${PSQL_IMAGE},quay.io/sclorg/postgresql-15-c9s:latest)
+PSQL_IMAGE := $(or ${PSQL_IMAGE},quay.io/sclorg/postgresql-16-c9s:latest)
 BUNDLE_IMAGE := $(or ${BUNDLE_IMAGE},${ASSISTED_ORG}/assisted-service-operator-bundle:${ASSISTED_TAG})
 INDEX_IMAGE := $(or ${INDEX_IMAGE},${ASSISTED_ORG}/assisted-service-index:${ASSISTED_TAG})
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
           - name: IMAGE_SERVICE_IMAGE
             value: quay.io/edge-infrastructure/assisted-image-service:latest
           - name: DATABASE_IMAGE
-            value: quay.io/sclorg/postgresql-15-c9s:latest
+            value: quay.io/sclorg/postgresql-16-c9s:latest
           - name: AGENT_IMAGE
             value: quay.io/edge-infrastructure/assisted-installer-agent:latest
           - name: CONTROLLER_IMAGE

--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -186,7 +186,7 @@ spec:
     name: controller
   - image: quay.io/edge-infrastructure/assisted-image-service:latest
     name: image-service
-  - image: quay.io/sclorg/postgresql-15-c9s:latest
+  - image: quay.io/sclorg/postgresql-16-c9s:latest
     name: postgresql
   - image: quay.io/edge-infrastructure/assisted-installer:latest
     name: installer

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -908,7 +908,7 @@ spec:
                 - name: IMAGE_SERVICE_IMAGE
                   value: quay.io/edge-infrastructure/assisted-image-service:latest
                 - name: DATABASE_IMAGE
-                  value: quay.io/sclorg/postgresql-15-c9s:latest
+                  value: quay.io/sclorg/postgresql-16-c9s:latest
                 - name: AGENT_IMAGE
                   value: quay.io/edge-infrastructure/assisted-installer-agent:latest
                 - name: CONTROLLER_IMAGE
@@ -1047,7 +1047,7 @@ spec:
     name: controller
   - image: quay.io/edge-infrastructure/assisted-image-service:latest
     name: image-service
-  - image: quay.io/sclorg/postgresql-15-c9s:latest
+  - image: quay.io/sclorg/postgresql-16-c9s:latest
     name: postgresql
   - image: quay.io/edge-infrastructure/assisted-installer:latest
     name: installer

--- a/deploy/podman/pod-persistent-disconnected.yml
+++ b/deploy/podman/pod-persistent-disconnected.yml
@@ -8,7 +8,7 @@ spec:
   containers:
   - args:
     - run-postgresql
-    image: quay.io/sclorg/postgresql-15-c9s:latest
+    image: quay.io/sclorg/postgresql-16-c9s:latest
     name: db
     envFrom:
     - configMapRef:

--- a/deploy/podman/pod-persistent.yml
+++ b/deploy/podman/pod-persistent.yml
@@ -8,7 +8,7 @@ spec:
   containers:
   - args:
     - run-postgresql
-    image: quay.io/sclorg/postgresql-15-c9s:latest
+    image: quay.io/sclorg/postgresql-16-c9s:latest
     name: db
     envFrom:
     - configMapRef:

--- a/deploy/podman/pod.yml
+++ b/deploy/podman/pod.yml
@@ -8,7 +8,7 @@ spec:
   containers:
   - args:
     - run-postgresql
-    image: quay.io/sclorg/postgresql-15-c9s:latest
+    image: quay.io/sclorg/postgresql-16-c9s:latest
     name: db
     envFrom:
     - configMapRef:

--- a/deploy/podman/pod_tls.yml
+++ b/deploy/podman/pod_tls.yml
@@ -8,7 +8,7 @@ spec:
   containers:
     - args:
         - run-postgresql
-      image: quay.io/sclorg/postgresql-15-c9s:latest
+      image: quay.io/sclorg/postgresql-16-c9s:latest
       name: db
       envFrom:
         - configMapRef:

--- a/deploy/postgres/postgres-deployment-ephemeral.yaml
+++ b/deploy/postgres/postgres-deployment-ephemeral.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: quay.io/sclorg/postgresql-15-c9s
+          image: quay.io/sclorg/postgresql-16-c9s
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/deploy/postgres/postgres-deployment.yaml
+++ b/deploy/postgres/postgres-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: quay.io/sclorg/postgresql-15-c9s
+          image: quay.io/sclorg/postgresql-16-c9s
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -36,7 +36,7 @@ $ podman ps
 
 CONTAINER ID  IMAGE                                                      COMMAND               CREATED        STATUS        PORTS                                                                   NAMES
 487e6c1bdb9a  localhost/podman-pause:4.9.3-1708357294                                          4 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  7c18ebd0915a-infra
-8479b5eb8a8d  quay.io/sclorg/postgresql-15-c9s:latest                    run-postgresql        4 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  assisted-installer-db
+8479b5eb8a8d  quay.io/sclorg/postgresql-16-c9s:latest                    run-postgresql        4 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  assisted-installer-db
 ffb9013c4fab  quay.io/edge-infrastructure/assisted-installer-ui:latest   /deploy/start.sh      3 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  assisted-installer-ui
 100c865abfd6  quay.io/edge-infrastructure/assisted-image-service:latest  /assisted-image-s...  3 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  assisted-installer-image-service
 78924b68f7af  quay.io/edge-infrastructure/assisted-service:latest        /assisted-service     3 minutes ago  Up 3 minutes  0.0.0.0:8080->8080/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8888->8888/tcp  assisted-installer-service

--- a/docs/dev/postgresql-upgrade.md
+++ b/docs/dev/postgresql-upgrade.md
@@ -45,9 +45,9 @@ The sclorg container images define these environment variables (baked into each 
 
 You can verify these by inspecting the container:
 ```bash
-podman run --rm quay.io/sclorg/postgresql-15-c9s:latest env | grep POSTGRESQL
-# POSTGRESQL_VERSION=15
-# POSTGRESQL_PREV_VERSION=13
+podman run --rm quay.io/sclorg/postgresql-16-c9s:latest env | grep POSTGRESQL
+# POSTGRESQL_VERSION=16
+# POSTGRESQL_PREV_VERSION=15
 ```
 
 ### Hardlink Mode

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -132,7 +132,7 @@ func (c *K8SDBContext) Create() error {
 					Containers: []corev1.Container{
 						{
 							Name:  "psql",
-							Image: "quay.io/sclorg/postgresql-15-c9s",
+							Image: "quay.io/sclorg/postgresql-16-c9s",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "tcp-5433",

--- a/internal/common/testcontainers_db_context.go
+++ b/internal/common/testcontainers_db_context.go
@@ -20,7 +20,7 @@ func (c *TestContainersDBContext) Create() error {
 	var err error
 	c.dbContainer, err = testcontainers.GenericContainer(c.ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "quay.io/sclorg/postgresql-15-c9s:latest",
+			Image:        "quay.io/sclorg/postgresql-16-c9s:latest",
 			Env:          map[string]string{"POSTGRESQL_ADMIN_PASSWORD": "admin"},
 			ExposedPorts: []string{fmt.Sprintf("%s/tcp", dbDefaultPort)},
 			Name:         dbDockerName,

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -41,7 +41,7 @@ func ImageServiceImage() string {
 }
 
 func DatabaseImage() string {
-	return getEnvVar("DATABASE_IMAGE", "quay.io/sclorg/postgresql-15-c9s:latest")
+	return getEnvVar("DATABASE_IMAGE", "quay.io/sclorg/postgresql-16-c9s:latest")
 }
 
 func AgentImage() string {


### PR DESCRIPTION
## Summary

Upgrade PostgreSQL from 15 to 16 using sclorg's native upgrade mechanism.

**Changes:**
- Update DATABASE_IMAGE to `postgresql-16-c9s` (PG16 on RHEL9) across all deployment manifests, test infrastructure, and documentation
- Update `docs/dev/postgresql-upgrade.md` with current version info

**How it works:**
When the new image starts against existing PG15 data, the `postgres_startup.sh` wrapper (added in [MGMT-16090](https://redhat.atlassian.net/browse/MGMT-16090)) detects the version mismatch and sets `POSTGRESQL_UPGRADE=hardlink`. The sclorg container then runs `pg_upgrade --link` to migrate data in-place.

**Depends on:** https://github.com/openshift/release/pull/80951 (CI image mirroring — merged)

## Test plan
- [x] Unit tests pass against PG16 database (91 packages + 1012 specs in bminventory/host, 0 failures)
- [x] Local podman upgrade test: PG15→PG16 via pg_upgrade, data preserved (3 clusters, 5 hosts, 15 events)
- [x] Restart test (PG16→PG16): normal startup, no re-upgrade triggered
- [ ] CI tests

https://issues.redhat.com/browse/MGMT-24327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default database container image to PostgreSQL 16 across deployments, test environments, and local container setups.
  * Aligned related image references so runtime and catalog metadata stay consistent.

* **Documentation**
  * Refreshed developer docs and upgrade examples to reflect the newer PostgreSQL version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->