### PR TITLE
MGMT-24645: Scope local authentication tokens properly

### DIFF
--- a/internal/gencrypto/token.go
+++ b/internal/gencrypto/token.go
@@ -38,6 +38,8 @@ func LocalJWTForKey(id string, private_key_pem string, keyType LocalJWTKeyType) 
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		string(keyType): id,
+		"iat":           time.Now().Unix(),
+		"exp":           time.Now().Add(48 * time.Hour).Unix(),
 	})
 
 	tokenString, err := token.SignedString(priv)

--- a/internal/gencrypto/token_test.go
+++ b/internal/gencrypto/token_test.go
@@ -96,6 +96,27 @@ var _ = Context("with an ECDSA key pair", func() {
 
 		validateToken(tokenString, publicKey, id)
 	})
+
+	It("LocalJWTForKey includes iat and exp claims", func() {
+		id := uuid.New().String()
+		tokenString, err := LocalJWTForKey(id, privateKeyPEM, InfraEnvKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		parser := &jwt.Parser{ValidMethods: []string{jwt.SigningMethodES256.Alg()}}
+		parsed, err := parser.Parse(tokenString, func(t *jwt.Token) (interface{}, error) { return publicKey, nil })
+		Expect(err).ToNot(HaveOccurred())
+
+		claims, ok := parsed.Claims.(jwt.MapClaims)
+		Expect(ok).To(BeTrue())
+
+		iat, ok := claims["iat"].(float64)
+		Expect(ok).To(BeTrue())
+		Expect(iat).To(BeNumerically(">", 0))
+
+		exp, ok := claims["exp"].(float64)
+		Expect(ok).To(BeTrue())
+		Expect(exp).To(BeNumerically(">", iat))
+	})
 })
 
 var _ = Describe("JWTForSymmetricKey", func() {

--- a/pkg/auth/agent_local_authz_handler.go
+++ b/pkg/auth/agent_local_authz_handler.go
@@ -67,7 +67,10 @@ func (a *AgentLocalAuthzHandler) agentInstallerAuthorizer(request *http.Request,
 
 	authClaim, ok := claims["auth_scheme"].(string)
 	if !ok {
-		return common.NewApiError(http.StatusInternalServerError, fmt.Errorf("malformed auth_scheme claim"))
+		if authScheme == "agentAuth" {
+			return nil
+		}
+		return common.NewInfraError(http.StatusForbidden, fmt.Errorf("token lacks auth_scheme claim and endpoint requires %s", authScheme))
 	}
 
 	if authClaim == "" || authScheme == "" {

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -57,6 +57,8 @@ func NewAuthzHandler(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger,
 
 	case TypeAgentLocal:
 		authzr = &AgentLocalAuthzHandler{}
+	case TypeLocal:
+		authzr = &AgentLocalAuthzHandler{}
 	default:
 		authzr = &NoneHandler{}
 	}

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/gencrypto"
-	"github.com/openshift/assisted-service/pkg/ocm"
 	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -103,7 +102,7 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 		a.log.Debugf("Authenticating Cluster %s JWT", clusterID)
 	}
 
-	return ocm.AdminPayload(), nil
+	return claims, nil
 }
 
 func (a *LocalAuthenticator) AuthUserAuth(_ string) (interface{}, error) {

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -128,5 +129,17 @@ var _ = Describe("AuthAgentAuth", func() {
 		_, err := a.AuthAgentAuth(token)
 		Expect(err).To(HaveOccurred())
 		validateErrorResponse(err)
+	})
+
+	It("Returns JWT claims instead of AdminPayload", func() {
+		result, err := a.AuthAgentAuth(token)
+		Expect(err).ToNot(HaveOccurred())
+
+		claims, ok := result.(jwt.MapClaims)
+		Expect(ok).To(BeTrue())
+
+		infraEnvClaim, ok := claims[string(gencrypto.InfraEnvKey)].(string)
+		Expect(ok).To(BeTrue())
+		Expect(infraEnvClaim).To(Equal(infraEnv.ID.String()))
 	})
 })

--- a/pkg/auth/rhsso_authz_handler_test.go
+++ b/pkg/auth/rhsso_authz_handler_test.go
@@ -53,6 +53,16 @@ var _ = Describe("NewAuthzHandler", func() {
 		handler = NewAuthzHandler(cfg, nil, logrus.New(), nil)
 		_, ok = handler.(*NoneHandler)
 		Expect(ok).To(BeTrue())
+
+		cfg = &Config{AuthType: TypeLocal}
+		handler = NewAuthzHandler(cfg, nil, logrus.New(), nil)
+		_, ok = handler.(*AgentLocalAuthzHandler)
+		Expect(ok).To(BeTrue())
+
+		cfg = &Config{AuthType: TypeAgentLocal}
+		handler = NewAuthzHandler(cfg, nil, logrus.New(), nil)
+		_, ok = handler.(*AgentLocalAuthzHandler)
+		Expect(ok).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Restrict local auth token privileges and add token expiry to ensure tokens are properly scoped to their intended use.

- Add `case TypeLocal` to `NewAuthzHandler` so it uses `AgentLocalAuthzHandler` instead of falling through to `NoneHandler`
- Return scoped JWT claims from `AuthAgentAuth` instead of `AdminPayload()`
- Add `iat` and `exp` (48h) claims to `LocalJWTForKey`
- Handle tokens without `auth_scheme` claim in `AgentLocalAuthzHandler` for backward compatibility with local auth tokens

## List all the issues related to this PR

- [ ] New Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local authentication now includes standard token timestamps, helping tokens carry clear issuance and expiration times.
  * Local auth requests are now recognized in the same flow as agent-local auth.

* **Bug Fixes**
  * Improved handling of tokens missing required authorization details, returning a more appropriate access-denied response in some cases.
  * Local authentication now returns JWT claims directly, preserving infrastructure context in the authenticated result.

* **Tests**
  * Added coverage for token timestamp claims and local auth claim handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->