### PR TITLE
APPSRE-14691: add monitoring.rhobs/v1 ServiceMonitors for COO compatibility

### DIFF
--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -44,3 +44,39 @@ objects:
     selector:
       matchLabels:
         app: assisted-installer-prometheus-postgres-exporter
+- apiVersion: monitoring.rhobs/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
+    name: servicemonitor-assisted-installer-${NAMESPACE}
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: assisted-svc
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        app: assisted-service
+- apiVersion: monitoring.rhobs/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
+    name: servicemonitor-assisted-installer-postgres-${NAMESPACE}
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        app: assisted-installer-prometheus-postgres-exporter


### PR DESCRIPTION
## Summary

- Add `monitoring.rhobs/v1` ServiceMonitor for `assisted-service` alongside the existing `monitoring.coreos.com/v1` one
- Add `monitoring.rhobs/v1` ServiceMonitor for the postgres exporter alongside the existing `monitoring.coreos.com/v1` one

## Context

As part of the App-SRE COO (Cluster Observability Operator) migration, the COO Prometheus stack uses `monitoring.rhobs/v1` resources. Without a COO-compatible ServiceMonitor, the COO Prometheus has no scrape target for `job="assisted-service"`, causing the `Assisted Installer - Service Is Down` alert to fire as a false positive via `absent()`.

The `monitoring.coreos.com/v1` SMs are kept for now to maintain compatibility with the existing non-COO Prometheus stack during the transition period.

Relates to: https://redhat.atlassian.net/browse/APPSRE-14691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring resources to use the latest supported monitoring API version for improved compatibility with OpenShift monitoring.
  * Kept the existing labels, selectors, endpoint settings, and namespace selection unchanged to ensure monitoring behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->