### PR TITLE
MGMT-24682: Remove LSO and LVMS as CNV operator dependencies

### DIFF
--- a/internal/bminventory/detailed_supported_features_test.go
+++ b/internal/bminventory/detailed_supported_features_test.go
@@ -43,7 +43,7 @@ var _ = Describe("GetDetailedSupportedFeatures", func() {
 			{
 				OperatorName:     "cnv",
 				FeatureSupportID: models.FeatureSupportLevelIDCNV,
-				Dependencies:     []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLSO, models.FeatureSupportLevelIDLVM},
+				Dependencies:     []models.FeatureSupportLevelID{},
 			},
 		}).AnyTimes()
 	}

--- a/internal/operators/amdgpu/amd_gpu_operator.go
+++ b/internal/operators/amdgpu/amd_gpu_operator.go
@@ -72,11 +72,11 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
+func (o *operator) GetDependencies(c *common.Cluster) []string {
 	return []string{
 		nodefeaturediscovery.Operator.Name,
 		kmm.Operator.Name,
-	}, nil
+	}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -246,24 +246,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -273,7 +265,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/amdgpu/amd_gpu_operator_test.go
+++ b/internal/operators/amdgpu/amd_gpu_operator_test.go
@@ -282,14 +282,13 @@ var _ = Describe("Operator", func() {
 
 	Context("Dependencies", func() {
 		It("Depends on the node feature discovery operator", func() {
-			deps, err := operator.GetDependencies(&common.Cluster{})
-			Expect(err).ToNot(HaveOccurred())
+			deps := operator.GetDependencies(&common.Cluster{})
 			Expect(deps).To(ContainElement(nodefeaturediscovery.Operator.Name))
+
 		})
 
 		It("Depends on the kmm operator", func() {
-			deps, err := operator.GetDependencies(&common.Cluster{})
-			Expect(err).ToNot(HaveOccurred())
+			deps := operator.GetDependencies(&common.Cluster{})
 			Expect(deps).To(ContainElement(kmm.Operator.Name))
 		})
 	})

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -34,7 +34,7 @@ type Operator interface {
 	// GetFullName reports the full name of the specified Operator
 	GetFullName() string
 	// GetDependencies provides a list of dependencies of the Operator
-	GetDependencies(cluster *common.Cluster) ([]string, error)
+	GetDependencies(cluster *common.Cluster) []string
 	// GetDependenciesFeatureSupportID provides a list of all feature ids that are potential dependencies
 	GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID
 	// ValidateCluster verifies whether this operator is valid for given cluster
@@ -54,7 +54,7 @@ type Operator interface {
 	// GetMonitoredOperator returns MonitoredOperator corresponding to the Operator implementation
 	GetMonitoredOperator() *models.MonitoredOperator
 	// GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-	GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error)
+	GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements
 	// GetFeatureSupportID returns the operator unique feature-support ID
 	GetFeatureSupportID() models.FeatureSupportLevelID
 	// GetBundleLabels returns the list of bundles names associated with the operator based on the given feature IDs

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -87,12 +87,11 @@ func (mr *MockOperatorMockRecorder) GetClusterValidationIDs() *gomock.Call {
 }
 
 // GetDependencies mocks base method.
-func (m *MockOperator) GetDependencies(cluster *common.Cluster) ([]string, error) {
+func (m *MockOperator) GetDependencies(cluster *common.Cluster) []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDependencies", cluster)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetDependencies indicates an expected call of GetDependencies.
@@ -201,12 +200,11 @@ func (mr *MockOperatorMockRecorder) GetName() *gomock.Call {
 }
 
 // GetPreflightRequirements mocks base method.
-func (m *MockOperator) GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+func (m *MockOperator) GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightRequirements", ctx, cluster)
 	ret0, _ := ret[0].(*models.OperatorHardwareRequirements)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetPreflightRequirements indicates an expected call of GetPreflightRequirements.

--- a/internal/operators/authorino/authorino_operator.go
+++ b/internal/operators/authorino/authorino_operator.go
@@ -58,8 +58,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) (result []string, err error) {
-	return
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -106,24 +106,17 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (result *models.ClusterHostRequirementsDetails, err error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		return
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	result = preflightRequirements.Requirements.Worker.Quantitative
 	return
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -133,7 +126,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/authorino/authorino_operator.go
+++ b/internal/operators/authorino/authorino_operator.go
@@ -63,7 +63,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/clusterobservability/cluster_observability_operator.go
+++ b/internal/operators/clusterobservability/cluster_observability_operator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/openshift/assisted-service/internal/common"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
+	"github.com/openshift/assisted-service/internal/operators/openshiftlogging"
 	"github.com/openshift/assisted-service/internal/templating"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -51,7 +52,7 @@ func (o *operator) GetFullName() string {
 
 // GetDependencies provides a list of dependencies of the Operator
 func (o *operator) GetDependencies(cluster *common.Cluster) []string {
-	return []string{"openshift-logging"}
+	return []string{openshiftlogging.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/clusterobservability/cluster_observability_operator.go
+++ b/internal/operators/clusterobservability/cluster_observability_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{"openshift-logging"}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{"openshift-logging"}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/clusterobservability/cluster_observability_requirements.go
+++ b/internal/operators/clusterobservability/cluster_observability_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -11,8 +11,6 @@ import (
 	"github.com/openshift/assisted-service/internal/hardware/virt"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
-	"github.com/openshift/assisted-service/internal/operators/lso"
-	"github.com/openshift/assisted-service/internal/operators/lvm"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -67,30 +65,11 @@ func (o *operator) GetFullName() string {
 
 // GetDependencies provides a list of dependencies of the Operator
 func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	lsoOperator := []string{lso.Operator.Name}
-	lvmOperator := []string{lvm.Operator.Name}
-
-	// Disable lso for ARM deployment as it's not supported
-	// to allow CNV ARM operator
-	if cluster.CPUArchitecture == common.ARM64CPUArchitecture || cluster.CPUArchitecture == common.MultiCPUArchitecture {
-		return make([]string, 0), nil
-	}
-
-	if cluster.OpenshiftVersion == "" {
-		return lsoOperator, nil
-	}
-
-	// SNO
-	if common.IsSingleNodeCluster(cluster) {
-		if isGreaterOrEqual, _ := common.BaseVersionGreaterOrEqual(lvm.LvmsMinOpenshiftVersion4_12, cluster.OpenshiftVersion); isGreaterOrEqual {
-			return lvmOperator, nil
-		}
-	}
-	return lsoOperator, nil
+	return []string{}, nil
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLSO, models.FeatureSupportLevelIDLVM}
+	return nil
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -69,7 +69,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -64,8 +64,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -178,11 +178,7 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot Retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
 
 	if common.IsSingleNodeCluster(cluster) {
 		overhead, err := o.getDevicesMemoryOverhead(host)
@@ -221,7 +217,7 @@ func (o *operator) getWorkerRequirements(ctx context.Context, cluster *common.Cl
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(_ context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+func (o *operator) GetPreflightRequirements(_ context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	qualitativeRequirements := []string{
 		"Additional 1GiB of RAM per each supported GPU",
 		"Additional 1GiB of RAM per each supported SR-IOV NIC",
@@ -231,13 +227,9 @@ func (o *operator) GetPreflightRequirements(_ context.Context, cluster *common.C
 		qualitativeRequirements = append(qualitativeRequirements, fmt.Sprintf("Additional disk with %d Gi", o.config.SNOPoolSizeRequestHPPGib))
 	}
 
-	cnvODependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
 	requirements := models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: cnvODependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: qualitativeRequirements,
@@ -261,7 +253,7 @@ func (o *operator) GetPreflightRequirements(_ context.Context, cluster *common.C
 		requirements.Requirements.Master.Quantitative.RAMMib += WorkerMemory
 	}
 
-	return &requirements, nil
+	return &requirements
 }
 
 func (o *operator) getDevicesMemoryOverhead(host *models.Host) (int64, error) {

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -37,8 +37,7 @@ var _ = Describe("CNV operator", func() {
 
 	Context("GetDependencies", func() {
 		It("should return no dependencies", func() {
-			dependencies, err := operator.GetDependencies(&common.Cluster{})
-			Expect(err).ToNot(HaveOccurred())
+			dependencies := operator.GetDependencies(&common.Cluster{})
 			Expect(dependencies).To(BeEmpty())
 		})
 	})
@@ -293,8 +292,7 @@ var _ = Describe("CNV operator", func() {
 
 	DescribeTable("GetPreflightRequirements, should be returned", func(cfg cnv.Config, cluster common.Cluster) {
 		cnvOperator := cnv.NewCNVOperator(log, cfg)
-		requirements, err := cnvOperator.GetPreflightRequirements(context.TODO(), &cluster)
-		Expect(err).ToNot(HaveOccurred())
+		requirements := cnvOperator.GetPreflightRequirements(context.TODO(), &cluster)
 		Expect(requirements.OperatorName).To(BeEquivalentTo(cnv.Operator.Name))
 		numQualitative := 3
 		workerRequirements := newRequirements(cnv.WorkerCPU, cnv.WorkerMemory)

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/cnv"
-	"github.com/openshift/assisted-service/internal/operators/lso"
-	"github.com/openshift/assisted-service/internal/operators/lvm"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
@@ -37,24 +35,20 @@ var _ = Describe("CNV operator", func() {
 		operator = cnv.NewCNVOperator(log, cfg)
 	})
 
-	DescribeTable("getDependencies", func(ocpVersion string, haMode int64, expectedOperator string) {
-		cluster := common.Cluster{
-			Cluster: models.Cluster{ControlPlaneCount: haMode, OpenshiftVersion: ocpVersion},
-		}
+	Context("GetDependencies", func() {
+		It("should return no dependencies", func() {
+			dependencies, err := operator.GetDependencies(&common.Cluster{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dependencies).To(BeEmpty())
+		})
+	})
 
-		requirements, err := operator.GetDependencies(&cluster)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(requirements).ToNot(BeNil())
-
-		Expect(requirements[0]).To(BeEquivalentTo(expectedOperator))
-	},
-
-		Entry("LVM, Single node 4.12", "4.12", int64(1), lvm.Operator.Name),
-		Entry("LSO, Multi node 4.15", "4.15", int64(common.MinMasterHostsNeededForInstallationInHaMode), lso.Operator.Name),
-		Entry("LSO, Multi node 4.21", "4.21", int64(common.MinMasterHostsNeededForInstallationInHaMode), lso.Operator.Name),
-		Entry("LSO, Multi node 4.12", "4.12", int64(common.MinMasterHostsNeededForInstallationInHaMode), lso.Operator.Name),
-		Entry("LSO, Single node 4.11", "4.11", int64(1), lso.Operator.Name),
-	)
+	Context("GetDependenciesFeatureSupportID", func() {
+		It("should return no dependencies", func() {
+			dependencies := operator.GetDependenciesFeatureSupportID()
+			Expect(dependencies).To(BeEmpty())
+		})
+	})
 
 	Context("host requirements", func() {
 
@@ -62,7 +56,7 @@ var _ = Describe("CNV operator", func() {
 
 		BeforeEach(func() {
 			cluster = common.Cluster{
-				Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, OpenshiftVersion: lvm.LvmsMinOpenshiftVersion4_12},
+				Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode, OpenshiftVersion: "4.12.0"},
 			}
 		})
 
@@ -227,7 +221,7 @@ var _ = Describe("CNV operator", func() {
 		It("should return reqs for SNO", func() {
 			host := models.Host{Role: models.HostRoleMaster}
 			cluster = common.Cluster{
-				Cluster: models.Cluster{ControlPlaneCount: 1, OpenshiftVersion: lvm.LvmsMinOpenshiftVersion4_12},
+				Cluster: models.Cluster{ControlPlaneCount: 1, OpenshiftVersion: "4.12.0"},
 			}
 
 			requirements, err := operator.GetHostRequirements(context.TODO(), &cluster, &host)
@@ -301,7 +295,6 @@ var _ = Describe("CNV operator", func() {
 		cnvOperator := cnv.NewCNVOperator(log, cfg)
 		requirements, err := cnvOperator.GetPreflightRequirements(context.TODO(), &cluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(requirements.Dependencies).To(ConsistOf(lso.Operator.Name))
 		Expect(requirements.OperatorName).To(BeEquivalentTo(cnv.Operator.Name))
 		numQualitative := 3
 		workerRequirements := newRequirements(cnv.WorkerCPU, cnv.WorkerMemory)

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{operatorsCommon.NodeHealthcheckOperatorName}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{operatorsCommon.NodeHealthcheckOperatorName}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/fenceagentsremediation/fence_agents_remediation_requirements.go
+++ b/internal/operators/fenceagentsremediation/fence_agents_remediation_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/kmm/kmm_operator.go
+++ b/internal/operators/kmm/kmm_operator.go
@@ -65,7 +65,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/kmm/kmm_operator.go
+++ b/internal/operators/kmm/kmm_operator.go
@@ -60,9 +60,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	result := []string{}
-	return result, nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -143,24 +142,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -170,7 +161,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/kubedescheduler/kube_descheduler_operator.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/kubedescheduler/kube_descheduler_operator.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_operator.go
@@ -55,7 +55,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/kubedescheduler/kube_descheduler_requirements.go
+++ b/internal/operators/kubedescheduler/kube_descheduler_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/loki/loki_operator.go
+++ b/internal/operators/loki/loki_operator.go
@@ -64,7 +64,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/loki/loki_operator.go
+++ b/internal/operators/loki/loki_operator.go
@@ -59,8 +59,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -121,24 +121,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // GetHostRequirements provides the requirements that the host needs to satisfy
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{
@@ -154,7 +146,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 // GetFeatureSupportID returns the operator unique feature-support ID

--- a/internal/operators/loki/loki_operator_test.go
+++ b/internal/operators/loki/loki_operator_test.go
@@ -40,8 +40,7 @@ var _ = Describe("Loki Operator", func() {
 
 	Context("GetDependencies", func() {
 		It("should return no dependencies", func() {
-			deps, err := operator.GetDependencies(cluster)
-			Expect(err).ToNot(HaveOccurred())
+			deps := operator.GetDependencies(cluster)
 			Expect(deps).To(BeEmpty())
 		})
 	})
@@ -73,8 +72,7 @@ var _ = Describe("Loki Operator", func() {
 
 	Context("GetPreflightRequirements", func() {
 		It("should return zero requirements", func() {
-			reqs, err := operator.GetPreflightRequirements(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+			reqs := operator.GetPreflightRequirements(ctx, cluster)
 			Expect(reqs.OperatorName).To(Equal("loki"))
 			Expect(reqs.Requirements.Master.Quantitative.CPUCores).To(Equal(int64(0)))
 			Expect(reqs.Requirements.Master.Quantitative.RAMMib).To(Equal(int64(0)))

--- a/internal/operators/loki/loki_operator_test.go
+++ b/internal/operators/loki/loki_operator_test.go
@@ -46,9 +46,9 @@ var _ = Describe("Loki Operator", func() {
 	})
 
 	Context("GetDependenciesFeatureSupportID", func() {
-		It("should return nil for no dependencies", func() {
+		It("should return no dependencies", func() {
 			deps := operator.GetDependenciesFeatureSupportID()
-			Expect(deps).To(BeNil())
+			Expect(deps).To(BeEmpty())
 		})
 	})
 

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -40,8 +40,8 @@ func (l *lsOperator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (l *lsOperator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (l *lsOperator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *lsOperator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -93,14 +93,10 @@ func (l *lsOperator) GetHostRequirements(context.Context, *common.Cluster, *mode
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (l *lsOperator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := l.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
+func (l *lsOperator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: l.GetName(),
-		Dependencies: dependecies,
+		Dependencies: l.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -109,7 +105,7 @@ func (l *lsOperator) GetPreflightRequirements(context context.Context, cluster *
 				Quantitative: &models.ClusterHostRequirementsDetails{},
 			},
 		},
-	}, nil
+	}
 }
 
 func (l *lsOperator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -45,7 +45,7 @@ func (l *lsOperator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *lsOperator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/api"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
 	"github.com/openshift/assisted-service/models"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -67,8 +66,8 @@ func (o *operator) StorageClassName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -172,12 +171,7 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot retrieve preflight requirements for host %s", host.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
 
 	role := common.GetEffectiveRole(host)
 	areSchedulable := common.ShouldMastersBeSchedulable(&cluster.Cluster)
@@ -193,12 +187,7 @@ func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Clus
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
-
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	memoryRequirements := o.Config.LvmMemoryPerHostMiB
 	if ok, _ := common.BaseVersionLessThan(LvmsMinOpenshiftVersion_ForNewResourceRequirements, cluster.OpenshiftVersion); ok {
 		memoryRequirements = o.Config.LvmMemoryPerHostMiBBefore4_13
@@ -215,7 +204,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependecies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: requirementMessage,
@@ -232,7 +221,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -71,7 +71,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -112,17 +112,13 @@ type API interface {
 
 // GetPreflightRequirementsBreakdownForCluster provides host requirements breakdown for each supported OLM operator
 func (mgr Manager) GetPreflightRequirementsBreakdownForCluster(ctx context.Context, cluster *common.Cluster) ([]*models.OperatorHardwareRequirements, error) {
-	logger := logutil.FromContext(ctx, mgr.log)
 	var requirements []*models.OperatorHardwareRequirements
 	if common.IsDay2Cluster(cluster) {
 		return requirements, nil
 	}
-	for operatorName, operator := range mgr.olmOperators {
-		reqs, err := operator.GetPreflightRequirements(ctx, cluster)
-		if err != nil {
-			logger.WithError(err).Errorf("Cannot get preflight requirements for %s operator", operatorName)
-			return nil, err
-		}
+	for _, operator := range mgr.olmOperators {
+		reqs := operator.GetPreflightRequirements(ctx, cluster)
+
 		requirements = append(requirements, reqs)
 	}
 	return requirements, nil
@@ -534,10 +530,7 @@ func (mgr *Manager) ResolveDependencies(cluster *common.Cluster, operators []*mo
 	}
 
 	// Get dependent operators
-	allDependentOperators, err := mgr.getDependencies(cluster, ret)
-	if err != nil {
-		return nil, err
-	}
+	allDependentOperators := mgr.getDependencies(cluster, ret)
 
 	for operatorName := range allDependentOperators {
 		if funk.Contains(alreadyPresent, operatorName) {
@@ -566,7 +559,7 @@ func (mgr *Manager) getDependency(name string, definitions map[string]*models.Mo
 	return mgr.GetOperatorByName(name)
 }
 
-func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models.MonitoredOperator) (map[string]bool, error) {
+func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models.MonitoredOperator) map[string]bool {
 	fifo := list.New()
 	visited := make(map[string]bool)
 	for _, op := range operators {
@@ -574,10 +567,8 @@ func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models
 			continue
 		}
 		mgr.log.Debugf("Attempting to resolve %s operator dependencies", op.Name)
-		deps, err := mgr.olmOperators[op.Name].GetDependencies(cluster)
-		if err != nil {
-			return map[string]bool{}, err
-		}
+		deps := mgr.olmOperators[op.Name].GetDependencies(cluster)
+
 		visited[op.Name] = true
 		mgr.log.Debugf("Dependencies found for %s operator: %+v ", op.Name, deps)
 		for _, dep := range deps {
@@ -587,10 +578,8 @@ func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models
 	for fifo.Len() > 0 {
 		first := fifo.Front()
 		op := first.Value.(string)
-		deps, err := mgr.olmOperators[op].GetDependencies(cluster)
-		if err != nil {
-			return map[string]bool{}, err
-		}
+		deps := mgr.olmOperators[op].GetDependencies(cluster)
+
 		for _, dep := range deps {
 			if !visited[dep] {
 				fifo.PushBack(dep)
@@ -600,7 +589,7 @@ func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models
 		fifo.Remove(first)
 	}
 
-	return visited, nil
+	return visited
 }
 
 func (mgr *Manager) GetMonitoredOperatorsList() map[string]*models.MonitoredOperator {

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -1012,9 +1012,9 @@ var _ = Describe("Operators manager", func() {
 		})
 		It("should be provided for configured operators", func() {
 			requirements1 := models.OperatorHardwareRequirements{OperatorName: operatorName1}
-			operator1.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(&requirements1, nil)
+			operator1.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(&requirements1)
 			requirements2 := models.OperatorHardwareRequirements{OperatorName: operatorName2}
-			operator2.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(&requirements2, nil)
+			operator2.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(&requirements2)
 
 			reqBreakdown, err := manager.GetPreflightRequirementsBreakdownForCluster(context.TODO(), cluster)
 
@@ -1024,17 +1024,6 @@ var _ = Describe("Operators manager", func() {
 				&models.OperatorHardwareRequirements{OperatorName: operatorName1},
 				&models.OperatorHardwareRequirements{OperatorName: operatorName2},
 			))
-		})
-
-		It("should return error", func() {
-			theError := errors.New("boom")
-			operator1.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(nil, theError).AnyTimes()
-			operator2.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(nil, theError).AnyTimes()
-
-			_, err := manager.GetPreflightRequirementsBreakdownForCluster(context.TODO(), cluster)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeEquivalentTo(theError))
 		})
 	})
 

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -892,7 +892,7 @@ var _ = Describe("Operators manager", func() {
 		),
 		Entry("when only CNV is specified",
 			[]*models.MonitoredOperator{&cnv.Operator},
-			[]*models.MonitoredOperator{&cnv.Operator, &lsoDependency},
+			[]*models.MonitoredOperator{&cnv.Operator},
 		),
 		Entry("when CNV, ODF and LSO are specified",
 			[]*models.MonitoredOperator{&cnv.Operator, &odf.Operator, &lso.Operator},

--- a/internal/operators/mce/mce_operator.go
+++ b/internal/operators/mce/mce_operator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
@@ -64,8 +63,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -167,12 +166,7 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 
 // GetHostRequirements provides the requirements that the host needs to satisfy in order to be able to install the operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
 
 	if common.IsSingleNodeCluster(cluster) {
 		// SNO req
@@ -190,14 +184,10 @@ func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Clus
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: []string{},
@@ -214,7 +204,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func (o *operator) GetSupportedArchitectures() []string {

--- a/internal/operators/mce/mce_operator.go
+++ b/internal/operators/mce/mce_operator.go
@@ -68,7 +68,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/metallb/metallb_operator.go
+++ b/internal/operators/metallb/metallb_operator.go
@@ -68,9 +68,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 
 // GetDependenciesFeatureSupportID returns feature support level IDs for the Operator
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return []models.FeatureSupportLevelID{
-		models.FeatureSupportLevelIDMETALLB,
-	}
+	return nil
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/metallb/metallb_operator.go
+++ b/internal/operators/metallb/metallb_operator.go
@@ -68,7 +68,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 
 // GetDependenciesFeatureSupportID returns feature support level IDs for the Operator
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/metallb/metallb_operator.go
+++ b/internal/operators/metallb/metallb_operator.go
@@ -62,8 +62,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 // GetDependenciesFeatureSupportID returns feature support level IDs for the Operator
@@ -113,15 +113,10 @@ func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Clus
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
-
+func (o *operator) GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative:  []string{},
@@ -132,7 +127,7 @@ func (o *operator) GetPreflightRequirements(ctx context.Context, cluster *common
 				Quantitative: &models.ClusterHostRequirementsDetails{},
 			},
 		},
-	}, nil
+	}
 }
 
 // GetFeatureSupportID returns the feature support level ID for MetalLB

--- a/internal/operators/metallb/metallb_operator_test.go
+++ b/internal/operators/metallb/metallb_operator_test.go
@@ -30,8 +30,7 @@ var _ = Describe("MetalLB operator", func() {
 
 	It("GetDependencies", func() {
 		cluster := common.Cluster{}
-		dependencies, err := metalLBOp.GetDependencies(&cluster)
-		Expect(err).To(Not(HaveOccurred()))
+		dependencies := metalLBOp.GetDependencies(&cluster)
 		Expect(dependencies).To(BeEmpty())
 	})
 

--- a/internal/operators/mtv/operator.go
+++ b/internal/operators/mtv/operator.go
@@ -13,7 +13,6 @@ import (
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,8 +53,8 @@ func (o *operator) GetFullName() string {
 	return FullName
 }
 
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{cnv.Operator.Name}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{cnv.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -141,30 +140,20 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot retrieve preflight requirements for host %s", host.ID)
-		return nil, err
-	}
-
 	if host.Role == models.HostRoleArbiter {
 		return &models.ClusterHostRequirementsDetails{}, nil
 	}
+
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
 
 	return preflightRequirements.Requirements.Master.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
-
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependecies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: []string{
@@ -187,7 +176,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 // GetProperties provides description of operator properties: none required

--- a/internal/operators/mtv/operator_test.go
+++ b/internal/operators/mtv/operator_test.go
@@ -72,8 +72,7 @@ var _ = Describe("MTV Operator", func() {
 		)
 
 		It("should return the dependencies", func() {
-			preflightRequirements, err := operator.GetPreflightRequirements(context.TODO(), &cluster)
-			Expect(err).To(BeNil())
+			preflightRequirements := operator.GetPreflightRequirements(context.TODO(), &cluster)
 			Expect(preflightRequirements.Dependencies).To(Equal([]string{cnv.Operator.Name}))
 		})
 	})

--- a/internal/operators/nmstate/operator.go
+++ b/internal/operators/nmstate/operator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/api"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
 	"github.com/openshift/assisted-service/models"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -120,25 +119,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot retrieve preflight requirements for host %s", host.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
-
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependecies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -147,7 +137,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				Quantitative: &models.ClusterHostRequirementsDetails{},
 			},
 		},
-	}, nil
+	}
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/nmstate/operator.go
+++ b/internal/operators/nmstate/operator.go
@@ -55,7 +55,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
+++ b/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
@@ -65,7 +65,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
+++ b/internal/operators/nodefeaturediscovery/node_feature_discovery_operator.go
@@ -60,8 +60,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -110,24 +110,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -137,7 +129,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/nodehealthcheck/node_healthcheck_operator.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_operator.go
@@ -58,8 +58,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/nodehealthcheck/node_healthcheck_requirements.go
+++ b/internal/operators/nodehealthcheck/node_healthcheck_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/nodemaintenance/node_maintenance_operator.go
+++ b/internal/operators/nodemaintenance/node_maintenance_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/nodemaintenance/node_maintenance_operator.go
+++ b/internal/operators/nodemaintenance/node_maintenance_operator.go
@@ -55,7 +55,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/nodemaintenance/node_maintenance_requirements.go
+++ b/internal/operators/nodemaintenance/node_maintenance_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/numaresources/numaresources_operator.go
+++ b/internal/operators/numaresources/numaresources_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/numaresources/numaresources_operator.go
+++ b/internal/operators/numaresources/numaresources_operator.go
@@ -55,7 +55,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/numaresources/numaresources_requirements.go
+++ b/internal/operators/numaresources/numaresources_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/nvidiagpu/nvidia_gpu_operator.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator.go
@@ -71,11 +71,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	result := []string{
-		nodefeaturediscovery.Operator.Name,
-	}
-	return result, nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{nodefeaturediscovery.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -244,24 +241,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -271,7 +260,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
+++ b/internal/operators/nvidiagpu/nvidia_gpu_operator_test.go
@@ -301,8 +301,7 @@ var _ = Describe("Operator", func() {
 	})
 
 	It("Depends on the node feature discovery operator", func() {
-		deps, err := operator.GetDependencies(&common.Cluster{})
-		Expect(err).ToNot(HaveOccurred())
+		deps := operator.GetDependencies(&common.Cluster{})
 		Expect(deps).To(ContainElement(nodefeaturediscovery.Operator.Name))
 	})
 })

--- a/internal/operators/oadp/oadp_operator.go
+++ b/internal/operators/oadp/oadp_operator.go
@@ -50,8 +50,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/oadp/oadp_operator.go
+++ b/internal/operators/oadp/oadp_operator.go
@@ -55,7 +55,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/oadp/oadp_requirements.go
+++ b/internal/operators/oadp/oadp_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/odf/odf_operator.go
+++ b/internal/operators/odf/odf_operator.go
@@ -80,8 +80,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{lso.Operator.Name}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{lso.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -287,14 +287,10 @@ func (o *operator) GetHostRequirements(_ context.Context, cluster *common.Cluste
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{
@@ -321,7 +317,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/openshiftai/openshift_ai_operator.go
+++ b/internal/operators/openshiftai/openshift_ai_operator.go
@@ -73,11 +73,12 @@ func (o *operator) GetFullName() string {
 // GetDependencies provides a list of dependencies of the Operator.
 // GPU vendors (NVIDIA, AMD) are no longer auto-selected as dependencies — users
 // must explicitly choose them via the bundle's optional_operators.
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
+func (o *operator) GetDependencies(c *common.Cluster) []string {
 	if common.IsSingleNodeCluster(c) {
-		return []string{lvm.Operator.Name}, nil
+		return []string{lvm.Operator.Name}
 	}
-	return []string{}, nil
+
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -231,11 +232,8 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (result *models.ClusterHostRequirementsDetails, err error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	switch common.GetEffectiveRole(host) {
 	case models.HostRoleMaster:
 		result = preflightRequirements.Requirements.Master.Quantitative
@@ -248,15 +246,10 @@ func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Clus
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: []string{},
@@ -274,7 +267,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetSupportedArchitectures() []string {

--- a/internal/operators/openshiftai/openshift_ai_operator_test.go
+++ b/internal/operators/openshiftai/openshift_ai_operator_test.go
@@ -114,15 +114,13 @@ var _ = Describe("GetDependencies", func() {
 				Hosts: []*models.Host{{}},
 			},
 		}
-		dependencies, err := operator.GetDependencies(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		dependencies := operator.GetDependencies(cluster)
 		Expect(dependencies).To(BeEmpty())
 	})
 
 	It("should return no dependencies for a cluster without hosts", func() {
 		cluster := &common.Cluster{}
-		dependencies, err := operator.GetDependencies(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		dependencies := operator.GetDependencies(cluster)
 		Expect(dependencies).To(BeEmpty())
 	})
 
@@ -132,8 +130,7 @@ var _ = Describe("GetDependencies", func() {
 				ControlPlaneCount: 1,
 			},
 		}
-		dependencies, err := operator.GetDependencies(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		dependencies := operator.GetDependencies(cluster)
 		Expect(dependencies).To(ConsistOf(lvm.Operator.Name))
 	})
 })

--- a/internal/operators/openshiftlogging/openshift_logging_operator.go
+++ b/internal/operators/openshiftlogging/openshift_logging_operator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	operatorscommon "github.com/openshift/assisted-service/internal/operators/common"
+	"github.com/openshift/assisted-service/internal/operators/loki"
 	"github.com/openshift/assisted-service/internal/templating"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -61,7 +62,7 @@ func (o *operator) GetFullName() string {
 // GetDependencies provides a list of dependencies of the Operator
 func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 	// OpenShift Logging depends on Loki Operator
-	return []string{"loki"}
+	return []string{loki.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/openshiftlogging/openshift_logging_operator.go
+++ b/internal/operators/openshiftlogging/openshift_logging_operator.go
@@ -59,9 +59,9 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 	// OpenShift Logging depends on Loki Operator
-	return []string{"loki"}, nil
+	return []string{"loki"}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -122,24 +122,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // GetHostRequirements provides the requirements that the host needs to satisfy
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{
@@ -155,7 +147,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 // GetFeatureSupportID returns the operator unique feature-support ID

--- a/internal/operators/openshiftlogging/openshift_logging_operator_test.go
+++ b/internal/operators/openshiftlogging/openshift_logging_operator_test.go
@@ -40,8 +40,7 @@ var _ = Describe("OpenShift Logging Operator", func() {
 
 	Context("GetDependencies", func() {
 		It("should return Loki as dependency", func() {
-			deps, err := operator.GetDependencies(cluster)
-			Expect(err).ToNot(HaveOccurred())
+			deps := operator.GetDependencies(cluster)
 			Expect(deps).To(ContainElement("loki"))
 		})
 	})
@@ -73,8 +72,7 @@ var _ = Describe("OpenShift Logging Operator", func() {
 
 	Context("GetPreflightRequirements", func() {
 		It("should return zero requirements", func() {
-			reqs, err := operator.GetPreflightRequirements(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+			reqs := operator.GetPreflightRequirements(ctx, cluster)
 			Expect(reqs.OperatorName).To(Equal("openshift-logging"))
 			Expect(reqs.Requirements.Master.Quantitative.CPUCores).To(Equal(int64(0)))
 			Expect(reqs.Requirements.Master.Quantitative.RAMMib).To(Equal(int64(0)))

--- a/internal/operators/osc/operator.go
+++ b/internal/operators/osc/operator.go
@@ -58,7 +58,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{models.FeatureSupportLevelIDNODEFEATUREDISCOVERY}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the Operator

--- a/internal/operators/osc/operator.go
+++ b/internal/operators/osc/operator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/nodefeaturediscovery"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,8 +53,8 @@ func (o *operator) GetFullName() string {
 	return FullName
 }
 
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{nodefeaturediscovery.Operator.Name}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{nodefeaturediscovery.Operator.Name}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -141,12 +140,8 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	log := logutil.FromContext(ctx, o.log)
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		log.WithError(err).Errorf("Cannot retrieve preflight requirements for host %s", host.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	role := common.GetEffectiveRole(host)
 	switch role {
 	case models.HostRoleMaster:
@@ -160,15 +155,10 @@ func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Clus
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
-func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return &models.OperatorHardwareRequirements{}, err
-	}
-
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependecies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Qualitative: []string{
@@ -191,7 +181,7 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 // GetProperties provides description of operator properties: none required

--- a/internal/operators/osc/operator_test.go
+++ b/internal/operators/osc/operator_test.go
@@ -47,6 +47,10 @@ var _ = Describe("OSC Operator", func() {
 			deps := operator.GetDependencies(&cluster)
 			Expect(deps).To(HaveLen(1))
 			Expect(deps[0]).To(Equal(nodefeaturediscovery.Operator.Name))
+
+			depIDs := operator.GetDependenciesFeatureSupportID()
+			Expect(depIDs).To(HaveLen(1))
+			Expect(depIDs[0]).To(Equal(models.FeatureSupportLevelIDNODEFEATUREDISCOVERY))
 		})
 
 	})

--- a/internal/operators/osc/operator_test.go
+++ b/internal/operators/osc/operator_test.go
@@ -44,8 +44,7 @@ var _ = Describe("OSC Operator", func() {
 				Cluster: models.Cluster{ControlPlaneCount: common.MinMasterHostsNeededForInstallationInHaMode},
 			}
 
-			deps, err := operator.GetDependencies(&cluster)
-			Expect(err).ToNot(HaveOccurred())
+			deps := operator.GetDependencies(&cluster)
 			Expect(deps).To(HaveLen(1))
 			Expect(deps[0]).To(Equal(nodefeaturediscovery.Operator.Name))
 		})

--- a/internal/operators/pipelines/pipelines_operator.go
+++ b/internal/operators/pipelines/pipelines_operator.go
@@ -66,9 +66,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	result := []string{}
-	return result, nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -117,24 +116,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -144,7 +135,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/pipelines/pipelines_operator.go
+++ b/internal/operators/pipelines/pipelines_operator.go
@@ -71,7 +71,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/selfnoderemediation/self_node_remediation_operator.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_operator.go
@@ -48,8 +48,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
-	return []string{operatorsCommon.NodeHealthcheckOperatorName}, nil
+func (o *operator) GetDependencies(cluster *common.Cluster) []string {
+	return []string{operatorsCommon.NodeHealthcheckOperatorName}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {

--- a/internal/operators/selfnoderemediation/self_node_remediation_requirements.go
+++ b/internal/operators/selfnoderemediation/self_node_remediation_requirements.go
@@ -11,24 +11,16 @@ import (
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -38,5 +30,4 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }

--- a/internal/operators/serverless/serverless_operator.go
+++ b/internal/operators/serverless/serverless_operator.go
@@ -66,9 +66,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	result := []string{}
-	return result, nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -117,24 +116,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -144,7 +135,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/serverless/serverless_operator.go
+++ b/internal/operators/serverless/serverless_operator.go
@@ -71,7 +71,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/internal/operators/servicemesh/servicemesh_operator.go
+++ b/internal/operators/servicemesh/servicemesh_operator.go
@@ -66,8 +66,8 @@ func (o *operator) GetFullName() string {
 }
 
 // GetDependencies provides a list of dependencies of the Operator
-func (o *operator) GetDependencies(c *common.Cluster) ([]string, error) {
-	return make([]string, 0), nil
+func (o *operator) GetDependencies(c *common.Cluster) []string {
+	return []string{}
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
@@ -116,24 +116,16 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // operator.
 func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster,
 	host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
-	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
-	if err != nil {
-		o.log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
-		return nil, err
-	}
+	preflightRequirements := o.GetPreflightRequirements(ctx, cluster)
+
 	return preflightRequirements.Requirements.Worker.Quantitative, nil
 }
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only.
-func (o *operator) GetPreflightRequirements(context context.Context,
-	cluster *common.Cluster) (result *models.OperatorHardwareRequirements, err error) {
-	dependencies, err := o.GetDependencies(cluster)
-	if err != nil {
-		return
-	}
-	result = &models.OperatorHardwareRequirements{
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) *models.OperatorHardwareRequirements {
+	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependencies,
+		Dependencies: o.GetDependencies(cluster),
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{},
@@ -143,7 +135,6 @@ func (o *operator) GetPreflightRequirements(context context.Context,
 			},
 		},
 	}
-	return
 }
 
 func (o *operator) GetFeatureSupportID() models.FeatureSupportLevelID {

--- a/internal/operators/servicemesh/servicemesh_operator.go
+++ b/internal/operators/servicemesh/servicemesh_operator.go
@@ -71,7 +71,7 @@ func (o *operator) GetDependencies(c *common.Cluster) []string {
 }
 
 func (o *operator) GetDependenciesFeatureSupportID() []models.FeatureSupportLevelID {
-	return nil
+	return []models.FeatureSupportLevelID{}
 }
 
 // GetClusterValidationIDs returns cluster validation IDs for the operator.

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -19,6 +19,7 @@ volumes:
   # cache
   - $HOME/.cache/go-build:/go/pkg/mod
   - $HOME/.cache/golangci-lint:$HOME/.cache/golangci-lint
+  - $HOME/.cache/goimports:$HOME/.cache/goimports
 
   # libvirt
   - /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -399,42 +399,12 @@ var _ = Describe("Operators endpoint tests", func() {
 			Expect(*reason).To(ContainSubstring(fmt.Sprintf("cannot use Local Storage Operator because it's not compatible with the arm64 architecture on version %s", common.TestVersion().ForArch("arm64").Version())))
 		})
 
-		It("should lvm installed as cnv dependency", func() {
-			cluster := registerNewCluster(
-				common.TestVersion().GreaterThanOrEqual("4.12").Version(),
-				int64(1),
-				[]*models.OperatorCreateParams{{Name: cnv.Operator.Name}},
-				nil,
-				nil,
-			)
-			ops, err := utils_test.TestContext.Agent2BMClient.Operators.V2ListOfClusterOperators(ctx, opclient.NewV2ListOfClusterOperatorsParams().WithClusterID(*cluster.Payload.ID))
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(ops.GetPayload())).To(BeNumerically(">=", 3))
-
-			var operatorNames []string
-			for _, op := range ops.GetPayload() {
-				operatorNames = append(operatorNames, op.Name)
-			}
-
-			// Builtin
-			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
-				Expect(operatorNames).To(ContainElements(builtinOperator.Name))
-			}
-
-			// OLM
-			Expect(operatorNames).To(ContainElements(
-				cnv.Operator.Name,
-				lvm.Operator.Name,
-			))
-		})
-
 		// LVM subscription name changed at 4.12: lvmo (<4.12) -> lvms (>=4.12)
 		It("should lvm have right subscription name on version >= 4.12", func() {
 			cluster := registerNewCluster(
 				common.TestVersion().GreaterThanOrEqual("4.12").Version(),
 				int64(1),
-				[]*models.OperatorCreateParams{{Name: cnv.Operator.Name}},
+				[]*models.OperatorCreateParams{{Name: lvm.Operator.Name}},
 				nil,
 				nil,
 			)


### PR DESCRIPTION
CNV no longer auto-installs Local Storage Operator or Logical Volume Manager Storage when selected. Storage operators must now be enabled explicitly by the user when persistent storage is required.

Update unit, manager, and subsystem tests to reflect the new behavior.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator dependency/preflight handling so dependency resolution and preflight requirements no longer rely on error-return paths.
  * CNV dependency behavior was corrected to exclude LSO/LVM-related dependencies.
  * OpenShift Logging now derives its Loki dependency name from the Loki operator.
* **Tests**
  * Updated operator, manager, and subsystem tests to match the new dependency/preflight behavior.
* **Chores**
  * Added a CI volume mount for the Go imports cache to speed up builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->