### PR TITLE
MGMT-24487: Allow https scheme in HTTPS proxy URL

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -110,7 +110,7 @@ type Cluster struct {
 	HTTPProxy string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -64,7 +64,7 @@ type ClusterCreateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/proxy.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -57,7 +57,7 @@ type V2ClusterUpdateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -110,7 +110,7 @@ type Cluster struct {
 	HTTPProxy string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -64,7 +64,7 @@ type ClusterCreateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/proxy.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -57,7 +57,7 @@ type V2ClusterUpdateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4890,7 +4890,7 @@ func validateProxySettings(httpProxy, httpsProxy, noProxy, ocpVersion *string) e
 		}
 	}
 	if httpsProxy != nil && *httpsProxy != "" {
-		if err := pkgvalidations.ValidateHTTPProxyFormat(*httpsProxy); err != nil {
+		if err := pkgvalidations.ValidateHTTPSProxyFormat(*httpsProxy); err != nil {
 			return errors.Errorf("Failed to validate HTTPS Proxy: %s", err)
 		}
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3755,6 +3755,13 @@ var _ = Describe("cluster", func() {
 				_ = updateCluster("http://proxy.proxy", "", "proxy.proxy")
 			})
 
+			It("set a valid https proxy", func() {
+				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+					eventstest.WithNameMatcher(eventgen.ProxySettingsChangedEventName),
+					eventstest.WithClusterIdMatcher(clusterID.String())))
+				_ = updateCluster("", "https://proxy.proxy", "")
+			})
+
 			It("set a valid noProxy wildcard", func() {
 				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ProxySettingsChangedEventName),
@@ -10416,6 +10423,10 @@ var _ = Describe("infraEnvs", func() {
 
 			It("set a valid proxy", func() {
 				_ = updateInfraEnv("http://proxy.proxy", "", "proxy.proxy")
+			})
+
+			It("set a valid https proxy", func() {
+				_ = updateInfraEnv("", "https://proxy.proxy", "")
 			})
 
 			It("set a valid noProxy wildcard", func() {

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -110,7 +110,7 @@ type Cluster struct {
 	HTTPProxy string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -64,7 +64,7 @@ type ClusterCreateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/models/proxy.go
+++ b/models/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -57,7 +57,7 @@ type V2ClusterUpdateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -95,8 +95,7 @@ func ValidateHTTPFormat(theurl string) error {
 	return nil
 }
 
-// ValidateHTTPProxyFormat validates the HTTP Proxy and HTTPS Proxy format
-func ValidateHTTPProxyFormat(proxyURL string) error {
+func validateProxyURLFormat(proxyURL string, allowedSchemes ...string) error {
 	if !govalidator.IsURL(proxyURL) {
 		return errors.Errorf("Proxy URL format is not valid: '%s'", proxyURL)
 	}
@@ -104,13 +103,23 @@ func ValidateHTTPProxyFormat(proxyURL string) error {
 	if err != nil {
 		return errors.Errorf("Proxy URL format is not valid: '%s'", proxyURL)
 	}
-	if u.Scheme == "https" {
-		return errors.Errorf("The URL scheme must be http; https is currently not supported: '%s'", proxyURL)
+	for _, scheme := range allowedSchemes {
+		if u.Scheme == scheme {
+			return nil
+		}
 	}
-	if u.Scheme != "http" {
-		return errors.Errorf("The URL scheme must be http and specified in the URL: '%s'", proxyURL)
-	}
-	return nil
+	return errors.Errorf("The URL scheme must be %s and specified in the URL: '%s'",
+		strings.Join(allowedSchemes, " or "), proxyURL)
+}
+
+// ValidateHTTPProxyFormat validates the HTTP Proxy format (http scheme only)
+func ValidateHTTPProxyFormat(proxyURL string) error {
+	return validateProxyURLFormat(proxyURL, "http")
+}
+
+// ValidateHTTPSProxyFormat validates the HTTPS Proxy URL format (http or https schemes are valid)
+func ValidateHTTPSProxyFormat(proxyURL string) error {
+	return validateProxyURLFormat(proxyURL, "http", "https")
 }
 
 func validateNoProxyEntry(entry string) error {

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -37,7 +37,7 @@ var _ = Describe("URL validations", func() {
 			},
 			{
 				"https://proxy.com:3128",
-				"The URL scheme must be http; https is currently not supported: 'https://proxy.com:3128'",
+				"The URL scheme must be http and specified in the URL: 'https://proxy.com:3128'",
 			},
 			{
 				"ftp://proxy.com:3128",
@@ -72,6 +72,50 @@ var _ = Describe("URL validations", func() {
 		It("validates proxy URL input", func() {
 			for _, param := range parameters {
 				err := ValidateHTTPProxyFormat(param.input)
+				if param.err == "" {
+					Expect(err).Should(BeNil())
+				} else {
+					Expect(err).ShouldNot(BeNil())
+					Expect(err.Error()).To(Equal(param.err))
+				}
+			}
+		})
+	})
+
+	Context("test HTTPS proxy URL", func() {
+		var parameters = []struct {
+			input, err string
+		}{
+			{"http://proxy.com:3128", ""},
+			{"http://username:pswd@proxy.com", ""},
+			{"http://10.9.8.7:123", ""},
+			{"http://username:pswd@10.9.8.7:123", ""},
+			{"https://proxy.com:3128", ""},
+			{"https://username:pswd@proxy.com", ""},
+			{"https://10.9.8.7:123", ""},
+			{"https://username:pswd@10.9.8.7:443", ""},
+			{"https://[1080:0:0:0:8:800:200C:417A]:8888", ""},
+			{
+				"ftp://proxy.com:3128",
+				"The URL scheme must be http or https and specified in the URL: 'ftp://proxy.com:3128'",
+			},
+			{
+				"proxy.com:3128",
+				"The URL scheme must be http or https and specified in the URL: 'proxy.com:3128'",
+			},
+			{
+				"xyz",
+				"Proxy URL format is not valid: 'xyz'",
+			},
+			{
+				"",
+				"Proxy URL format is not valid: ''",
+			},
+		}
+
+		It("validates HTTPS proxy URL input", func() {
+			for _, param := range parameters {
+				err := ValidateHTTPSProxyFormat(param.input)
 				if param.err == "" {
 					Expect(err).Should(BeNil())
 				} else {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6717,7 +6717,7 @@ func init() {
           "type": "string"
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-go-custom-tag": "gorm:\"column:https_proxy\""
         },
@@ -7092,7 +7092,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-nullable": true
         },
@@ -10718,7 +10718,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-go-custom-tag": "gorm:\"column:https_proxy\"",
           "x-nullable": true
@@ -11301,7 +11301,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-nullable": true
         },
@@ -18510,7 +18510,7 @@ func init() {
           "type": "string"
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-go-custom-tag": "gorm:\"column:https_proxy\""
         },
@@ -18885,7 +18885,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-nullable": true
         },
@@ -22468,7 +22468,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-go-custom-tag": "gorm:\"column:https_proxy\"",
           "x-nullable": true
@@ -23025,7 +23025,7 @@ func init() {
           "x-nullable": true
         },
         "https_proxy": {
-          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e or https://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
           "x-nullable": true
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5252,7 +5252,7 @@ definitions:
         type: string
         description: |
           A proxy URL to use for creating HTTPS connections outside the cluster.
-          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
         x-nullable: true
       no_proxy:
         type: string
@@ -5488,7 +5488,7 @@ definitions:
         type: string
         description: |
           A proxy URL to use for creating HTTPS connections outside the cluster.
-          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
         x-nullable: true
       no_proxy:
         type: string
@@ -5718,7 +5718,7 @@ definitions:
         type: string
         description: |
           A proxy URL to use for creating HTTPS connections outside the cluster.
-          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
         x-go-custom-tag: gorm:"column:https_proxy"
       no_proxy:
         type: string
@@ -7979,7 +7979,7 @@ definitions:
         type: string
         description: |
           A proxy URL to use for creating HTTPS connections outside the cluster.
-          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
         x-nullable: true
         x-go-custom-tag: gorm:"column:https_proxy"
       no_proxy:

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -110,7 +110,7 @@ type Cluster struct {
 	HTTPProxy string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -64,7 +64,7 @@ type ClusterCreateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/proxy.go
+++ b/vendor/github.com/openshift/assisted-service/models/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -57,7 +57,7 @@ type V2ClusterUpdateParams struct {
 	HTTPProxy *string `json:"http_proxy,omitempty"`
 
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
-	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\> or https://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
 	HTTPSProxy *string `json:"https_proxy,omitempty"`
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Allow `https://` scheme in the `https_proxy` proxy URL field. Previously, the `https_proxy` field only accepted `http://` URLs. This change enables users to configure HTTPS-based proxy servers for their clusters.

- **Commit 1**: Update swagger `https_proxy` field description to document both `http://` and `https://` schemes
- **Commit 2**: `skipper make generate` — regenerate models and embedded spec
- **Commit 3**: Add `ValidateHTTPSProxyFormat` for `httpsProxy` validation


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTPS proxy values are now validated using HTTPS-aware rules, allowing both `http://` and `https://` proxy URL formats where applicable.
* **Documentation**
  * Updated API schema and embedded API documentation to clearly state that `https_proxy` can be provided as either `http://...` or `https://...`.
* **Tests**
  * Expanded test coverage for HTTPS proxy validation and added scenarios verifying HTTPS proxy handling across cluster update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->