### PR TITLE
MGMT-24443: remove label predicate from ConfigMap watch

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -2056,9 +2056,8 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 
 				found := &corev1.ConfigMap{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: testMirrorRegConfigmapName, Namespace: testNamespace}, found)).To(Succeed())
-				Expect(found.Labels).To(HaveLen(2))
+				Expect(found.Labels).To(HaveLen(1))
 				Expect(found.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
-				Expect(found.Labels).To(HaveKeyWithValue(WatchResourceLabel, WatchResourceValue))
 			})
 		})
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -2028,10 +2028,7 @@ func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&aiv1beta1.Agent{},
 			handler.EnqueueRequestsFromMapFunc(mapAgentToClusterDeployment),
 			agentSpecStatusChangedPredicate).
-		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToClusterDeployment),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return obj.GetLabels()[WatchResourceLabel] == WatchResourceValue
-			}))).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToClusterDeployment)).
 		WatchesRawSource(&source.Channel{Source: clusterDeploymentUpdates}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -137,15 +137,6 @@ func ensureConfigMapIsLabelled(ctx context.Context, c client.Client, cm *corev1.
 		}
 	}
 
-	// Add the label to configmap if not present
-	if !metav1.HasLabel(cm.ObjectMeta, WatchResourceLabel) {
-		metav1.SetMetaDataLabel(&cm.ObjectMeta, WatchResourceLabel, WatchResourceValue)
-		err := c.Update(ctx, cm)
-		if err != nil {
-			errorMessage := fmt.Sprintf("failed to set label %s:%s for configmap %s/%s", WatchResourceLabel, WatchResourceValue, key.Namespace, key.Name)
-			return errors.Wrap(err, errorMessage)
-		}
-	}
 	return nil
 }
 

--- a/subsystem/kubeapi/kubeapi_test.go
+++ b/subsystem/kubeapi/kubeapi_test.go
@@ -5399,6 +5399,59 @@ metadata:
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterReadyReason)
 	})
 
+	It("Creating a referenced ConfigMap after ACI triggers reconciliation", func() {
+		By("Create SNO cluster with Cilium network type, ConfigMap ref, and hold installation")
+		configMapName := "late-cni-manifests"
+		aciSNOSpec.Networking.NetworkType = models.ClusterNetworkTypeCilium
+		aciSNOSpec.ManifestsConfigMapRefs = []hiveext.ManifestsConfigMapReference{{Name: configMapName}}
+		aciSNOSpec.HoldInstallation = true
+
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSNOSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		infraEnvKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
+		configureLocalAgentClient(infraEnv.ID.String())
+		host := utils_test.TestContext.RegisterNode(ctx, *infraEnv.ID, "hostname1", utils_test.DefaultCIDRv4)
+		ips := hostutil.GenerateIPv4Addresses(1, utils_test.DefaultCIDRv4)
+		utils_test.TestContext.GenerateFullMeshConnectivity(ctx, ips[0], host)
+		key := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      host.ID.String(),
+		}
+		utils_test.TestContext.GenerateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		By("Approve Agent")
+		Eventually(func() error {
+			agent := getAgentCRD(ctx, kubeClient, key)
+			agent.Spec.Approved = true
+			return kubeClient.Update(ctx, agent)
+		}, "30s", "10s").Should(BeNil())
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+
+		By("Without ConfigMap, validation should fail")
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterValidatedCondition, hiveext.ClusterValidationsFailingReason)
+
+		By("Wait for reconciliation to settle")
+		checkAgentClusterInstallConditionConsistency(ctx, installkey, hiveext.ClusterValidatedCondition, hiveext.ClusterValidationsFailingReason)
+
+		By("Create ConfigMap after ACI — cluster should become ready (held)")
+		content := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: cilium`
+		cm := deployOrUpdateConfigMap(ctx, kubeClient, configMapName, map[string]string{"cilium-ns.yaml": content})
+		defer func() {
+			_ = kubeClient.Delete(ctx, cm)
+		}()
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterReadyReason)
+	})
+
 	It("delete agent and validate host deregistration", func() {
 		By("Deploy SNO cluster")
 		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)


### PR DESCRIPTION
The ConfigMap watch used a label predicate that required agent-install.openshift.io/watch=true on ConfigMaps before triggering reconciliation. The label was stamped by ensureManifestConfigMapsLabelled during reconcile, but only for ConfigMaps that already existed. When a ConfigMap was created after the ACI's initial reconcile, it never got labeled, so the watch never fired and validations stayed stale.

Remove the label predicate — the mapper already filters correctly using a field-index reverse lookup scoped by namespace. This matches how the Secret watch works (no label predicate, mapper handles filtering).

Add a subsystem test that creates the ConfigMap after the ACI and verifies that validation passes.

Assisted-by: Claude Code <noreply@anthropic.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster deployments now react to ConfigMap changes even when labels used for event filtering are not present.
  * Clusters waiting on custom manifest ConfigMaps now move forward once the previously missing ConfigMap is created, instead of remaining stuck on outdated validation.
* **Tests**
  * Added coverage to confirm reconciliation occurs when a referenced ConfigMap is created after an ACI deployment begins.
  * Updated label-related assertions for generated ConfigMaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->