### PR TITLE
NO-ISSUE: Update oc-mirror locations to CGW following openshift release decoupling

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -274,7 +274,7 @@ function registry_configs_for_os_image_stream_sources() {
 }
 
 function install_oc_mirrorv2(){
-  OC_MIRROR_URL=${OC_MIRROR_URL:-https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.19/oc-mirror.tar.gz}
+  OC_MIRROR_URL=${OC_MIRROR_URL:-https://mirror.openshift.com/pub/cgw/oc-mirror/oc-mirror.tar.gz}
   curl -L --retry 5 --connect-timeout 30 -s "${OC_MIRROR_URL}" | tar xvz -C /usr/local/bin/
   chmod +x /usr/local/bin/oc-mirror
 }

--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -274,7 +274,7 @@ function registry_configs_for_os_image_stream_sources() {
 }
 
 function install_oc_mirrorv2(){
-  OC_MIRROR_URL=${OC_MIRROR_URL:-https://mirror.openshift.com/pub/cgw/oc-mirror/oc-mirror.tar.gz}
+  OC_MIRROR_URL=${OC_MIRROR_URL:-https://mirror.openshift.com/pub/cgw/oc-mirror/latest/oc-mirror-rhel9-linux-amd64.tar.gz}
   curl -L --retry 5 --connect-timeout 30 -s "${OC_MIRROR_URL}" | tar xvz -C /usr/local/bin/
   chmod +x /usr/local/bin/oc-mirror
 }


### PR DESCRIPTION
Changes the oc-mirror download mirror location to the new content gateway (CGW) location following the decoupling of oc-mirror from the openshift release process in version 5.0+.

See:
- https://redhat.atlassian.net/browse/CLID-525
- https://redhat.atlassian.net/browse/ART-20686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mirror installer reliability by updating the default mirror tarball URL used when no custom URL is provided.
  * Made the release-mirroring step more resilient to transient registry/network issues by adding controlled retries with configurable counts/delays and smarter retry conditions.
* **New Features**
  * Enhanced OS image stream discovery for mirroring by adding automatic derivation of source repositories, with fallbacks when primary discovery is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->