### PR TITLE
MGMT-24827: Resource-scoped auth for urlAuth endpoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -500,6 +500,7 @@ func main() {
 		//in the constructor due to a cyclic dependency with the event handler
 		ocmClient.SetMetrics(metricsManager)
 	}
+	authzHandler.SetMetrics(metricsManager)
 
 	Options.InstructionConfig.ReleaseImageMirror = Options.ReleaseImageMirror
 	Options.InstructionConfig.CheckClusterVersion = Options.CheckClusterVersion
@@ -737,7 +738,7 @@ func main() {
 		generator, eventsHandler, objectHandler, metricsManager, usageManager, operatorsManager, authHandler, authzHandler, ocpClient, ocmClient,
 		lead, pullSecretValidator, versionHandler, osImages, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder, staticNetworkConfig,
 		Options.GCConfig, providerRegistry, generateInsecureIPXEURLs, Options.GeneratorConfig.InstallInvoker, disconnectedIgnitionGenerator)
-	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"))
+	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"), db, metricsManager)
 
 	//Set inner handler chain. Inner handlers requires access to the Route
 	innerHandler := func() func(http.Handler) http.Handler {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -664,7 +664,7 @@ func generateStaticNetworkConfigDownloadURL(baseURL string, infraEnvId string, a
 		return downloadURL, nil
 	}
 
-	downloadURL, err = gencrypto.SignURL(downloadURL, infraEnvId, gencrypto.ClusterKey)
+	downloadURL, err = gencrypto.SignURL(downloadURL, infraEnvId, gencrypto.InfraEnvKey)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to sign static network config download URL for infraenv %s", infraEnvId)
 	}

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Add event", func() {
 		cfg := &auth.Config{AuthType: auth.TypeRHSSO, EnableOrgTenancy: true}
 		authz_handler := auth.NewAuthzHandler(cfg, nil, logrus.New(), db)
 		theEvents.(*Events).authz = authz_handler
-		api = &Api{handler: theEvents, log: log}
+		api = &Api{handler: theEvents, log: log, db: db}
 		inputEvent = &models.Event{
 			Message:  swag.String(eventMessage),
 			Name:     eventName,

--- a/internal/events/events_api.go
+++ b/internal/events/events_api.go
@@ -3,15 +3,20 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/models"
 	logutil "github.com/openshift/assisted-service/pkg/log"
+	"github.com/openshift/assisted-service/pkg/ocm"
 	"github.com/openshift/assisted-service/restapi"
 	"github.com/openshift/assisted-service/restapi/operations/events"
 	"github.com/pkg/errors"
@@ -22,14 +27,18 @@ import (
 var _ restapi.EventsAPI = &Api{}
 
 type Api struct {
-	handler eventsapi.Handler
-	log     logrus.FieldLogger
+	handler    eventsapi.Handler
+	log        logrus.FieldLogger
+	db         *gorm.DB
+	metricsAPI metrics.API
 }
 
-func NewApi(handler eventsapi.Handler, log logrus.FieldLogger) *Api {
+func NewApi(handler eventsapi.Handler, log logrus.FieldLogger, db *gorm.DB, metricsAPI metrics.API) *Api {
 	return &Api{
-		handler: handler,
-		log:     log,
+		handler:    handler,
+		log:        log,
+		db:         db,
+		metricsAPI: metricsAPI,
 	}
 }
 
@@ -87,6 +96,16 @@ func (a *Api) V2TriggerEvent(ctx context.Context, params events.V2TriggerEventPa
 
 func (a *Api) V2ListEvents(ctx context.Context, params events.V2ListEventsParams) middleware.Responder {
 	log := logutil.FromContext(ctx, a.log)
+
+	// Merge deprecated HostID into HostIds before scope enforcement
+	if params.HostID != nil {
+		params.HostIds = append(params.HostIds, *params.HostID)
+	}
+
+	if err := a.enforceEventsScopeFromPayload(ctx, params); err != nil {
+		return err
+	}
+
 	V2getEventsParams := common.V2GetEventsParams{
 		ClusterID:    params.ClusterID,
 		HostIds:      params.HostIds,
@@ -99,11 +118,6 @@ func (a *Api) V2ListEvents(ctx context.Context, params events.V2ListEventsParams
 		DeletedHosts: params.DeletedHosts,
 		ClusterLevel: params.ClusterLevel,
 		Categories:   params.Categories,
-	}
-
-	// DEPRECATED
-	if params.HostID != nil {
-		V2getEventsParams.HostIds = append(V2getEventsParams.HostIds, *params.HostID)
 	}
 
 	response, err := a.handler.V2GetEvents(ctx, &V2getEventsParams)
@@ -140,4 +154,97 @@ func (a *Api) V2ListEvents(ctx context.Context, params events.V2ListEventsParams
 		WithSeverityCountCritical((*eventSeverityCount)[models.EventSeverityCritical]).
 		WithEventCount(*eventCount).
 		WithPayload(ret)
+}
+
+// enforceEventsScopeFromPayload verifies that a scoped urlAuth token may only
+// access events for the resource it was issued for.  Unscoped tokens (e.g.
+// agentAuth or admin tokens with no ResourceType) are allowed through.
+func (a *Api) enforceEventsScopeFromPayload(ctx context.Context, params events.V2ListEventsParams) middleware.Responder {
+	payload := ocm.PayloadFromContext(ctx)
+	if payload.ResourceType == "" {
+		return nil
+	}
+
+	deny := func(format string, args ...interface{}) middleware.Responder {
+		a.log.WithFields(logrus.Fields{
+			"token_resource_type": payload.ResourceType,
+			"token_resource_id":   payload.ResourceID,
+		}).Warnf(format, args...)
+		a.recordScopeCheck(payload.ResourceType, "denied")
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+	}
+
+	allow := func() middleware.Responder {
+		a.recordScopeCheck(payload.ResourceType, "allowed")
+		return nil
+	}
+
+	switch payload.ResourceType {
+	case gencrypto.InfraEnvKey:
+		if params.InfraEnvID != nil {
+			if payload.ResourceID != params.InfraEnvID.String() {
+				return deny("Events scope mismatch: query infra_env_id=%s", params.InfraEnvID)
+			}
+			return allow()
+		}
+		if len(params.HostIds) > 0 {
+			return a.verifyHostsBelongToInfraEnv(payload.ResourceID, params.HostIds)
+		}
+		return deny("Events scope rejected: infra_env_id token requires infra_env_id or host_ids filter")
+
+	case gencrypto.ClusterKey:
+		if params.ClusterID != nil {
+			if payload.ResourceID != params.ClusterID.String() {
+				return deny("Events scope mismatch: query cluster_id=%s", params.ClusterID)
+			}
+			return allow()
+		}
+		return deny("Events scope rejected: cluster_id token requires cluster_id filter")
+
+	default:
+		a.log.WithFields(logrus.Fields{
+			"token_resource_type": payload.ResourceType,
+			"token_resource_id":   payload.ResourceID,
+		}).Error("Events scope check: unrecognized resource type in urlAuth token")
+		a.recordScopeCheck(payload.ResourceType, "denied")
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+	}
+}
+
+func (a *Api) verifyHostsBelongToInfraEnv(infraEnvID string, hostIds []strfmt.UUID) middleware.Responder {
+	resourceType := gencrypto.InfraEnvKey
+	hostIdStrings := make([]string, len(hostIds))
+	for i, id := range hostIds {
+		hostIdStrings[i] = id.String()
+	}
+	var count int64
+	err := a.db.Model(&common.Host{}).
+		Where("id IN ? AND infra_env_id = ?", hostIdStrings, infraEnvID).
+		Count(&count).Error
+	if err != nil {
+		a.log.WithFields(logrus.Fields{
+			"host_ids":     hostIdStrings,
+			"infra_env_id": infraEnvID,
+		}).WithError(err).Error("Failed to verify hosts belong to infra_env for events scope check")
+		a.recordScopeCheck(resourceType, "denied")
+		return common.NewApiError(http.StatusInternalServerError, fmt.Errorf("failed to verify host ownership"))
+	}
+	if count != int64(len(hostIds)) {
+		a.log.WithFields(logrus.Fields{
+			"host_ids":     hostIdStrings,
+			"infra_env_id": infraEnvID,
+			"matched":      count,
+			"requested":    len(hostIds),
+		}).Warn("Events scope rejected: not all hosts belong to token's infra_env")
+		a.recordScopeCheck(resourceType, "denied")
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+	}
+	a.recordScopeCheck(resourceType, "allowed")
+	return nil
+}
+
+func (a *Api) recordScopeCheck(resourceType gencrypto.LocalJWTKeyType, result string) {
+	if a.metricsAPI != nil {
+		a.metricsAPI.URLAuthScopeCheck(string(resourceType), "query", result)
+	}
 }

--- a/internal/events/events_api_test.go
+++ b/internal/events/events_api_test.go
@@ -1,0 +1,187 @@
+package events
+
+import (
+	"context"
+	"io"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/openshift/assisted-service/restapi"
+	"github.com/openshift/assisted-service/restapi/operations/events"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+func newScopedPayload(resourceType gencrypto.LocalJWTKeyType, resourceID string) *ocm.AuthPayload {
+	p := ocm.AdminPayload()
+	p.ResourceType = resourceType
+	p.ResourceID = resourceID
+	return p
+}
+
+func ctxWithPayload(payload *ocm.AuthPayload) context.Context {
+	return context.WithValue(context.Background(), restapi.AuthKey, payload)
+}
+
+func uuidStr() string { return uuid.New().String() }
+
+func uuidPtr(s string) *strfmt.UUID {
+	id := strfmt.UUID(s)
+	return &id
+}
+
+var _ = Describe("events scope enforcement", func() {
+	var (
+		api    *Api
+		db     *gorm.DB
+		dbName string
+		log    logrus.FieldLogger
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		l := logrus.New()
+		l.SetOutput(io.Discard)
+		log = l
+		api = &Api{log: log, db: db}
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	Describe("enforceEventsScopeFromPayload", func() {
+		Context("unscoped token", func() {
+			It("allows request with no ResourceType", func() {
+				ctx := ctxWithPayload(ocm.AdminPayload())
+				params := events.V2ListEventsParams{}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).To(BeNil())
+			})
+		})
+
+		Context("infra_env_id token", func() {
+			var infraEnvID string
+
+			BeforeEach(func() {
+				infraEnvID = uuidStr()
+			})
+
+			It("allows matching infra_env_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+				params := events.V2ListEventsParams{InfraEnvID: uuidPtr(infraEnvID)}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).To(BeNil())
+			})
+
+			It("denies mismatched infra_env_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+				params := events.V2ListEventsParams{InfraEnvID: uuidPtr(uuidStr())}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+
+			It("denies infra_env_id token with only cluster_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+				params := events.V2ListEventsParams{ClusterID: uuidPtr(uuidStr())}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+
+			It("denies infra_env_id token with no filter params", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+				params := events.V2ListEventsParams{}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+
+			Context("host_ids filter", func() {
+				var hostID strfmt.UUID
+
+				BeforeEach(func() {
+					infraEnvUUID := strfmt.UUID(infraEnvID)
+					hostID = strfmt.UUID(uuidStr())
+
+					infraEnv := &common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvUUID}}
+					Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+					status := "known"
+					host := &common.Host{Host: models.Host{
+						ID:         &hostID,
+						InfraEnvID: infraEnvUUID,
+						Status:     &status,
+					}}
+					Expect(db.Create(host).Error).ToNot(HaveOccurred())
+				})
+
+				It("allows host_ids that belong to the token's infra_env", func() {
+					ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+					params := events.V2ListEventsParams{HostIds: []strfmt.UUID{hostID}}
+					Expect(api.enforceEventsScopeFromPayload(ctx, params)).To(BeNil())
+				})
+
+				It("denies host_ids that belong to a different infra_env", func() {
+					otherInfraEnvID := strfmt.UUID(uuidStr())
+					ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, otherInfraEnvID.String()))
+					params := events.V2ListEventsParams{HostIds: []strfmt.UUID{hostID}}
+					Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+				})
+
+				It("denies non-existent host_ids", func() {
+					nonExistent := strfmt.UUID(uuidStr())
+					ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+					params := events.V2ListEventsParams{HostIds: []strfmt.UUID{nonExistent}}
+					Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+				})
+
+				It("denies when any host_id does not belong to the infra_env", func() {
+					nonExistent := strfmt.UUID(uuidStr())
+					ctx := ctxWithPayload(newScopedPayload(gencrypto.InfraEnvKey, infraEnvID))
+					params := events.V2ListEventsParams{HostIds: []strfmt.UUID{hostID, nonExistent}}
+					Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+				})
+			})
+		})
+
+		Context("cluster_id token", func() {
+			var clusterID string
+
+			BeforeEach(func() {
+				clusterID = uuidStr()
+			})
+
+			It("allows matching cluster_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.ClusterKey, clusterID))
+				params := events.V2ListEventsParams{ClusterID: uuidPtr(clusterID)}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).To(BeNil())
+			})
+
+			It("denies mismatched cluster_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.ClusterKey, clusterID))
+				params := events.V2ListEventsParams{ClusterID: uuidPtr(uuidStr())}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+
+			It("denies cluster_id token with only infra_env_id query param", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.ClusterKey, clusterID))
+				params := events.V2ListEventsParams{InfraEnvID: uuidPtr(uuidStr())}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+
+			It("denies cluster_id token with no filter params", func() {
+				ctx := ctxWithPayload(newScopedPayload(gencrypto.ClusterKey, clusterID))
+				params := events.V2ListEventsParams{}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+		})
+
+		Context("unknown resource type", func() {
+			It("denies tokens with unrecognized resource type", func() {
+				ctx := ctxWithPayload(newScopedPayload("unknown_key", uuidStr()))
+				params := events.V2ListEventsParams{}
+				Expect(api.enforceEventsScopeFromPayload(ctx, params)).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -47,6 +47,8 @@ const (
 	// blacklist metrics
 	counterClusterBlacklistedEvents = "assisted_installer_cluster_blacklisted_events_total"
 	gaugeBlacklistedClustersCurrent = "assisted_installer_blacklisted_clusters_current"
+	// url auth scope metrics
+	counterURLAuthScopeCheck = "assisted_installer_urlauth_scope_checks_total"
 )
 
 const (
@@ -76,6 +78,8 @@ const (
 	// blacklist metric descriptions
 	counterDescriptionClusterBlacklistedEvents = "Counts cluster blacklisting events (no cluster labels to avoid high cardinality)"
 	gaugeDescriptionBlacklistedClustersCurrent = "Current number of clusters that are blacklisted"
+	// url auth scope metric descriptions
+	counterDescriptionURLAuthScopeCheck = "Number of URL auth resource scope checks, by resource_type, scope (path or query), and result (allowed or denied)"
 )
 
 const (
@@ -120,6 +124,8 @@ type API interface {
 	// blacklist metrics
 	BlacklistedClusterInc()
 	BlacklistedClustersCurrent(count int)
+	// url auth scope metrics
+	URLAuthScopeCheck(resourceType, scope, result string)
 }
 
 type MetricsManager struct {
@@ -153,6 +159,8 @@ type MetricsManager struct {
 	// blacklist metrics
 	serviceLogicClusterBlacklistedEvents   *prometheus.CounterVec
 	serviceLogicBlacklistedClustersCurrent *prometheus.GaugeVec
+	// url auth scope metrics
+	serviceLogicURLAuthScopeCheck *prometheus.CounterVec
 
 	collectors []prometheus.Collector
 }
@@ -378,6 +386,14 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler eventsapi.H
 				Name:      gaugeBlacklistedClustersCurrent,
 				Help:      gaugeDescriptionBlacklistedClustersCurrent,
 			}, []string{}),
+
+		serviceLogicURLAuthScopeCheck: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      counterURLAuthScopeCheck,
+				Help:      counterDescriptionURLAuthScopeCheck,
+			}, []string{"resource_type", "scope", "result"}),
 	}
 
 	m.collectors = append(m.collectors, newDirectoryUsageCollector(metricsManagerConfig.DirectoryUsageMonitorConfig.Directories, diskStatsHelper, log))
@@ -409,6 +425,8 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler eventsapi.H
 		// blacklist metrics
 		m.serviceLogicClusterBlacklistedEvents,
 		m.serviceLogicBlacklistedClustersCurrent,
+		// url auth scope metrics
+		m.serviceLogicURLAuthScopeCheck,
 	)
 
 	for _, collector := range m.collectors {
@@ -616,4 +634,8 @@ func (m *MetricsManager) InstallerCacheGetReleaseCached(releaseId string, cacheH
 
 func (m *MetricsManager) InstallerCacheReleaseEvicted(success bool) {
 	m.serviceLogicInstallerReleaseEvicted.WithLabelValues(fmt.Sprintf("%t", success)).Inc()
+}
+
+func (m *MetricsManager) URLAuthScopeCheck(resourceType, scope, result string) {
+	m.serviceLogicURLAuthScopeCheck.WithLabelValues(resourceType, scope, result).Inc()
 }

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -282,3 +282,15 @@ func (mr *MockAPIMockRecorder) ReportHostInstallationMetrics(ctx, clusterVersion
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportHostInstallationMetrics", reflect.TypeOf((*MockAPI)(nil).ReportHostInstallationMetrics), ctx, clusterVersion, clusterID, emailDomain, boot, h, previousProgress, currentStage)
 }
+
+// URLAuthScopeCheck mocks base method.
+func (m *MockAPI) URLAuthScopeCheck(resourceType, scope, result string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "URLAuthScopeCheck", resourceType, scope, result)
+}
+
+// URLAuthScopeCheck indicates an expected call of URLAuthScopeCheck.
+func (mr *MockAPIMockRecorder) URLAuthScopeCheck(resourceType, scope, result any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URLAuthScopeCheck", reflect.TypeOf((*MockAPI)(nil).URLAuthScopeCheck), resourceType, scope, result)
+}

--- a/pkg/auth/agent_local_authz_handler.go
+++ b/pkg/auth/agent_local_authz_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/restapi"
 	"gorm.io/gorm"
 )
@@ -42,6 +43,8 @@ func (a *AgentLocalAuthzHandler) HasAccessTo(ctx context.Context, obj interface{
 func (a *AgentLocalAuthzHandler) HasOrgBasedCapability(ctx context.Context, capability string) (bool, error) {
 	return true, nil
 }
+
+func (a *AgentLocalAuthzHandler) SetMetrics(metricsAPI metrics.API) {}
 
 func (a *AgentLocalAuthzHandler) authorizerMiddleware(request *http.Request) error {
 	route := middleware.MatchedRouteFrom(request)

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -38,10 +38,11 @@ type Config struct {
 	JwkCertURL     string   `envconfig:"JWKS_URL" default:"https://api.openshift.com/.well-known/jwks.json"`
 	ECPublicKeyPEM string   `envconfig:"EC_PUBLIC_KEY_PEM"`
 	// Will be split with "," as separator
-	AllowedDomains             string   `envconfig:"ALLOWED_DOMAINS" default:""`
-	AdminUsers                 []string `envconfig:"ADMIN_USERS" default:""`
-	EnableOrgTenancy           bool     `envconfig:"ENABLE_ORG_TENANCY" default:"false"`
-	EnableOrgBasedFeatureGates bool     `envconfig:"ENABLE_ORG_BASED_FEATURE_GATES" default:"false"`
+	AllowedDomains                string   `envconfig:"ALLOWED_DOMAINS" default:""`
+	AdminUsers                    []string `envconfig:"ADMIN_USERS" default:""`
+	EnableOrgTenancy              bool     `envconfig:"ENABLE_ORG_TENANCY" default:"false"`
+	EnableOrgBasedFeatureGates    bool     `envconfig:"ENABLE_ORG_BASED_FEATURE_GATES" default:"false"`
+	LocalAuthEnforceResourceScope bool     `envconfig:"LOCAL_AUTH_ENFORCE_RESOURCE_SCOPE" default:"true"`
 }
 
 func NewAuthenticator(cfg *Config, ocmClient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) (a Authenticator, err error) {

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/pkg/ocm"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -42,6 +43,10 @@ type Authorizer interface {
 
 	/* verify that the current user has a capability (based on their organization capabilities)  */
 	HasOrgBasedCapability(ctx context.Context, capability string) (bool, error)
+
+	/* Injects the metrics API for recording auth-related counters.
+	 * Called post-construction to break cyclic init dependencies. */
+	SetMetrics(metricsAPI metrics.API)
 }
 
 func NewAuthzHandler(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) Authorizer {
@@ -57,6 +62,8 @@ func NewAuthzHandler(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger,
 
 	case TypeAgentLocal:
 		authzr = &AgentLocalAuthzHandler{}
+	case TypeLocal:
+		authzr = NewLocalAuthzHandler(cfg, log)
 	default:
 		authzr = &NoneHandler{}
 	}

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -79,6 +79,9 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 		return nil, common.NewInfraError(http.StatusUnauthorized, err)
 	}
 
+	var resourceType gencrypto.LocalJWTKeyType
+	var resourceID string
+
 	if infraEnvOk {
 		_, exists := a.cache.Get(infraEnvID)
 		if !exists {
@@ -89,6 +92,8 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 				return nil, common.NewInfraError(http.StatusUnauthorized, err)
 			}
 		}
+		resourceType = gencrypto.InfraEnvKey
+		resourceID = infraEnvID
 		a.log.Debugf("Authenticating infraEnv %s JWT", infraEnvID)
 	} else if clusterOk {
 		_, exists := a.cache.Get(clusterID)
@@ -100,10 +105,15 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 				return nil, common.NewInfraError(http.StatusUnauthorized, err)
 			}
 		}
+		resourceType = gencrypto.ClusterKey
+		resourceID = clusterID
 		a.log.Debugf("Authenticating Cluster %s JWT", clusterID)
 	}
 
-	return ocm.AdminPayload(), nil
+	payload := ocm.AdminPayload()
+	payload.ResourceType = resourceType
+	payload.ResourceID = resourceID
+	return payload, nil
 }
 
 func (a *LocalAuthenticator) AuthUserAuth(_ string) (interface{}, error) {

--- a/pkg/auth/local_authz_handler.go
+++ b/pkg/auth/local_authz_handler.go
@@ -1,0 +1,162 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/internal/metrics"
+	ctxparams "github.com/openshift/assisted-service/pkg/context"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/openshift/assisted-service/restapi"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// LocalAuthzHandler is the authorizer middleware for AUTH_TYPE=local.
+// When resource-scope enforcement is enabled, it verifies that scoped
+// tokens (those carrying a resource claim) can only access the specific
+// resource identified by their claim. Unscoped requests (e.g. agentAuth)
+// are permitted without resource verification.
+//
+// Endpoints that use query parameters rather than path parameters (e.g.
+// /v2/events) must enforce their own scope check in the handler itself.
+type LocalAuthzHandler struct {
+	log          logrus.FieldLogger
+	enforceScope bool
+	schemeFor    func(*http.Request) string
+	metricsAPI   metrics.API
+}
+
+func NewLocalAuthzHandler(cfg *Config, log logrus.FieldLogger) *LocalAuthzHandler {
+	return &LocalAuthzHandler{
+		log:          log,
+		enforceScope: cfg.LocalAuthEnforceResourceScope,
+		schemeFor:    authSchemeFromRoute,
+	}
+}
+
+func authSchemeFromRoute(r *http.Request) string {
+	route := middleware.MatchedRouteFrom(r)
+	if route == nil {
+		return ""
+	}
+	return route.Authenticator.Schemes[0]
+}
+
+func (h *LocalAuthzHandler) CreateAuthorizer() func(*http.Request) error {
+	return h.authorizerMiddleware
+}
+
+func (h *LocalAuthzHandler) IsAdmin(ctx context.Context) bool {
+	if !h.enforceScope {
+		return true
+	}
+	payload := ocm.PayloadFromContext(ctx)
+	// Scoped tokens are not admin — they should not bypass OwnedBy filters.
+	if payload.ResourceType != "" {
+		return false
+	}
+	return true
+}
+
+func (h *LocalAuthzHandler) OwnedBy(_ context.Context, db *gorm.DB) *gorm.DB {
+	return db
+}
+
+func (h *LocalAuthzHandler) OwnedByUser(_ context.Context, db *gorm.DB, _ string) *gorm.DB {
+	return db
+}
+
+func (h *LocalAuthzHandler) HasAccessTo(_ context.Context, _ interface{}, _ Action) (bool, error) {
+	return true, nil
+}
+
+func (h *LocalAuthzHandler) HasOrgBasedCapability(_ context.Context, _ string) (bool, error) {
+	return true, nil
+}
+
+func (h *LocalAuthzHandler) SetMetrics(metricsAPI metrics.API) {
+	h.metricsAPI = metricsAPI
+}
+
+func (h *LocalAuthzHandler) authorizerMiddleware(request *http.Request) error {
+	authScheme := h.schemeFor(request)
+
+	// Only enforce resource scoping for urlAuth requests.
+	if authScheme != "urlAuth" {
+		return nil
+	}
+
+	if !h.enforceScope {
+		return nil
+	}
+
+	payload := request.Context().Value(restapi.AuthKey)
+	if payload == nil {
+		return common.NewApiError(http.StatusUnauthorized, fmt.Errorf("payload missing from authenticated context"))
+	}
+	authPayload, ok := payload.(*ocm.AuthPayload)
+	if !ok {
+		return common.NewApiError(http.StatusUnauthorized, fmt.Errorf("malformed auth payload"))
+	}
+
+	if authPayload.ResourceType == "" || authPayload.ResourceID == "" {
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+	}
+
+	return h.verifyResourceScope(request, authPayload)
+}
+
+func (h *LocalAuthzHandler) verifyResourceScope(request *http.Request, payload *ocm.AuthPayload) error {
+	ctx := request.Context()
+	infraEnvID := ctxparams.GetParam(ctx, ctxparams.InfraEnvId)
+	clusterID := ctxparams.GetParam(ctx, ctxparams.ClusterId)
+
+	if infraEnvID == "" && clusterID == "" {
+		return nil
+	}
+
+	switch payload.ResourceType {
+	case gencrypto.InfraEnvKey:
+		if infraEnvID != "" && payload.ResourceID == infraEnvID {
+			h.recordScopeCheck(payload.ResourceType, "allowed")
+			return nil
+		}
+		h.log.WithFields(logrus.Fields{
+			"token_resource_type":  payload.ResourceType,
+			"token_resource_id":    payload.ResourceID,
+			"request_infra_env_id": infraEnvID,
+		}).Warn("URL auth resource scope mismatch")
+		h.recordScopeCheck(payload.ResourceType, "denied")
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+
+	case gencrypto.ClusterKey:
+		if clusterID != "" && payload.ResourceID == clusterID {
+			h.recordScopeCheck(payload.ResourceType, "allowed")
+			return nil
+		}
+		h.log.WithFields(logrus.Fields{
+			"token_resource_type": payload.ResourceType,
+			"token_resource_id":   payload.ResourceID,
+			"request_cluster_id":  clusterID,
+		}).Warn("URL auth resource scope mismatch")
+		h.recordScopeCheck(payload.ResourceType, "denied")
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
+
+	default:
+		h.log.WithField("token_resource_type", payload.ResourceType).
+			Error("URL auth token has unrecognized resource type")
+		h.recordScopeCheck(payload.ResourceType, "denied")
+		return common.NewApiError(http.StatusUnauthorized, fmt.Errorf("unrecognized resource type in urlAuth token"))
+	}
+}
+
+func (h *LocalAuthzHandler) recordScopeCheck(resourceType gencrypto.LocalJWTKeyType, result string) {
+	if h.metricsAPI != nil {
+		h.metricsAPI.URLAuthScopeCheck(string(resourceType), "path", result)
+	}
+}

--- a/pkg/auth/local_authz_handler_test.go
+++ b/pkg/auth/local_authz_handler_test.go
@@ -1,0 +1,230 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	ctxparams "github.com/openshift/assisted-service/pkg/context"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/openshift/assisted-service/restapi"
+	"github.com/sirupsen/logrus"
+)
+
+func setPayloadInContext(ctx context.Context, payload *ocm.AuthPayload) context.Context {
+	return context.WithValue(ctx, restapi.AuthKey, payload)
+}
+
+func buildRequest(ctx context.Context, urlStr string) *http.Request {
+	u, err := url.Parse(urlStr)
+	Expect(err).ToNot(HaveOccurred())
+	req := &http.Request{URL: u}
+	return req.WithContext(ctx)
+}
+
+var _ = Describe("LocalAuthzHandler", func() {
+	var (
+		handler *LocalAuthzHandler
+		log     logrus.FieldLogger
+	)
+
+	BeforeEach(func() {
+		l := logrus.New()
+		l.SetOutput(io.Discard)
+		log = l
+	})
+
+	Describe("IsAdmin", func() {
+		It("returns true for unscoped payloads when enforcement enabled", func() {
+			cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: true}
+			handler = NewLocalAuthzHandler(cfg, log)
+
+			payload := ocm.AdminPayload()
+			ctx := setPayloadInContext(context.Background(), payload)
+			Expect(handler.IsAdmin(ctx)).To(BeTrue())
+		})
+
+		It("returns false for scoped payloads when enforcement enabled", func() {
+			cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: true}
+			handler = NewLocalAuthzHandler(cfg, log)
+
+			payload := ocm.AdminPayload()
+			payload.ResourceType = gencrypto.InfraEnvKey
+			payload.ResourceID = uuid.New().String()
+			ctx := setPayloadInContext(context.Background(), payload)
+			Expect(handler.IsAdmin(ctx)).To(BeFalse())
+		})
+
+		It("returns true for scoped payloads when enforcement disabled", func() {
+			cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: false}
+			handler = NewLocalAuthzHandler(cfg, log)
+
+			payload := ocm.AdminPayload()
+			payload.ResourceType = gencrypto.InfraEnvKey
+			payload.ResourceID = uuid.New().String()
+			ctx := setPayloadInContext(context.Background(), payload)
+			Expect(handler.IsAdmin(ctx)).To(BeTrue())
+		})
+	})
+
+	Describe("NewAuthzHandler returns LocalAuthzHandler for TypeLocal", func() {
+		It("creates a LocalAuthzHandler", func() {
+			cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: true}
+			authzr := NewAuthzHandler(cfg, nil, log, nil)
+			_, ok := authzr.(*LocalAuthzHandler)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("authorizerMiddleware scheme gating", func() {
+		var scopedPayload *ocm.AuthPayload
+
+		BeforeEach(func() {
+			cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: true}
+			handler = NewLocalAuthzHandler(cfg, log)
+
+			scopedPayload = ocm.AdminPayload()
+			scopedPayload.ResourceType = gencrypto.InfraEnvKey
+			scopedPayload.ResourceID = uuid.New().String()
+		})
+
+		authorizer := func(scheme string) func(*http.Request) error {
+			handler.schemeFor = func(*http.Request) string { return scheme }
+			return handler.CreateAuthorizer()
+		}
+
+		for _, scheme := range []string{"agentAuth", "userAuth", "imageAuth", "imageURLAuth"} {
+			It("passes through without scope check for "+scheme, func() {
+				ctx := setPayloadInContext(context.Background(), scopedPayload)
+				req := buildRequest(ctx, "http://localhost/v2/clusters")
+				Expect(authorizer(scheme)(req)).To(Succeed())
+			})
+		}
+
+		It("passes urlAuth through when no path params are present", func() {
+			ctx := setPayloadInContext(context.Background(), scopedPayload)
+			req := buildRequest(ctx, "http://localhost/v2/events")
+			Expect(authorizer("urlAuth")(req)).To(Succeed())
+		})
+
+		It("passes urlAuth through when enforcement is disabled", func() {
+			handler.enforceScope = false
+			ctx := setPayloadInContext(context.Background(), scopedPayload)
+			req := buildRequest(ctx, "http://localhost/v2/events")
+			Expect(authorizer("urlAuth")(req)).To(Succeed())
+		})
+	})
+
+	Describe("verifyResourceScope", func() {
+		Context("with enforcement enabled", func() {
+			BeforeEach(func() {
+				cfg := &Config{AuthType: TypeLocal, LocalAuthEnforceResourceScope: true}
+				handler = NewLocalAuthzHandler(cfg, log)
+			})
+
+			It("allows matching infra_env_id path param", func() {
+				infraEnvID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.InfraEnvKey
+				payload.ResourceID = infraEnvID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.InfraEnvId, infraEnvID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/infra-envs/%s/downloads/files", infraEnvID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("denies mismatched infra_env_id path param", func() {
+				infraEnvID := uuid.New().String()
+				otherID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.InfraEnvKey
+				payload.ResourceID = infraEnvID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.InfraEnvId, otherID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/infra-envs/%s/downloads/files", otherID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("denies infra_env_id token on cluster path param", func() {
+				infraEnvID := uuid.New().String()
+				clusterID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.InfraEnvKey
+				payload.ResourceID = infraEnvID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.ClusterId, clusterID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/clusters/%s/logs", clusterID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("allows matching cluster_id path param", func() {
+				clusterID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.ClusterKey
+				payload.ResourceID = clusterID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.ClusterId, clusterID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/clusters/%s/logs", clusterID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("denies mismatched cluster_id path param", func() {
+				clusterID := uuid.New().String()
+				otherClusterID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.ClusterKey
+				payload.ResourceID = clusterID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.ClusterId, otherClusterID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/clusters/%s/logs", otherClusterID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("denies cluster_id token on infra_env path param", func() {
+				clusterID := uuid.New().String()
+				infraEnvID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.ClusterKey
+				payload.ResourceID = clusterID
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.InfraEnvId, infraEnvID)
+				req := buildRequest(ctx, fmt.Sprintf("http://localhost/v2/infra-envs/%s/downloads/files", infraEnvID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("passes through when no path params present to allow handler-level scope enforcement", func() {
+				clusterID := uuid.New().String()
+				payload := ocm.AdminPayload()
+				payload.ResourceType = gencrypto.ClusterKey
+				payload.ResourceID = clusterID
+
+				req := buildRequest(context.Background(), fmt.Sprintf("http://localhost/v2/events?cluster_id=%s", clusterID))
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("errors on unrecognized resource type", func() {
+				payload := ocm.AdminPayload()
+				payload.ResourceType = "unknown_key"
+				payload.ResourceID = uuid.New().String()
+
+				ctx := ctxparams.SetParam(context.Background(), ctxparams.InfraEnvId, uuid.New().String())
+				req := buildRequest(ctx, "http://localhost/v2/infra-envs")
+				err := handler.verifyResourceScope(req, payload)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/auth/none_authz_handler.go
+++ b/pkg/auth/none_authz_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/openshift/assisted-service/internal/metrics"
 	"gorm.io/gorm"
 )
 
@@ -42,3 +43,5 @@ func (*NoneHandler) IsAdmin(ctx context.Context) bool {
 func (*NoneHandler) HasOrgBasedCapability(ctx context.Context, capability string) (bool, error) {
 	return true, nil
 }
+
+func (*NoneHandler) SetMetrics(metricsAPI metrics.API) {}

--- a/pkg/auth/rhsso_authz_handler.go
+++ b/pkg/auth/rhsso_authz_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/models"
 	params "github.com/openshift/assisted-service/pkg/context"
 	"github.com/openshift/assisted-service/pkg/ocm"
@@ -193,6 +194,8 @@ func (a *AuthzHandler) HasOrgBasedCapability(ctx context.Context, capability str
 
 	return isAllowed, err
 }
+
+func (a *AuthzHandler) SetMetrics(metricsAPI metrics.API) {}
 
 func (a *AuthzHandler) checkClusterBasedAccess(id string, action Action, payload *ocm.AuthPayload) (bool, error) {
 	if a.db == nil {

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
@@ -176,4 +177,9 @@ type AuthPayload struct {
 	ClientID     string   `json:"clientId"`
 	Role         RoleType `json:"scope"`
 	IsAuthorized bool     `json:"is_authorized"`
+	// ResourceType is the claim key from a LocalJWT token (e.g. "infra_env_id" or "cluster_id").
+	// Empty for non-local-auth or non-scoped requests.
+	ResourceType gencrypto.LocalJWTKeyType `json:"resource_type,omitempty"`
+	// ResourceID is the resource UUID from the token's claim.
+	ResourceID string `json:"resource_id,omitempty"`
 }


### PR DESCRIPTION
Enforce resource-scoped authorization for `AUTH_TYPE=local` by propagating token resource claims through the auth context, replacing the permissive `NoneHandler` with a default-deny `LocalAuthzHandler`, and verifying the token's resource ID matches the accessed resource on all `urlAuth` endpoints — including events endpoint filtering with host-to-InfraEnv ownership verification.

Includes monitoring per https://redhat.atlassian.net/browse/MGMT-24829

## List all the issues related to this PR

- [ ] New Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added resource-scoped authorization for local authentication using token claims.
* Added resource scope details for infrastructure environment and cluster access.
* Added configurable scope enforcement for event and host-related requests, enabled by default.
* Added metrics to track allowed and denied resource-scope checks.

## Bug Fixes
* Corrected static network configuration download URL signing for non-local authentication.

## Tests
* Added coverage for local authorization, resource-scope validation, event access, and authorization metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->