### PR TITLE
OCPBUGS-91733: manifest_generator add a label to LUKS root

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -305,6 +305,7 @@ spec:
     storage:
       luks:
         - name: root
+          label: luks-root
           device: /dev/disk/by-partlabel/root
           clevis:
 		  {{- if eq .MODE "tpm" }}

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	configv31 "github.com/coreos/ignition/v2/config/v3_1"
+	configv32 "github.com/coreos/ignition/v2/config/v3_2"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/google/uuid"
@@ -1162,6 +1163,30 @@ var _ = Describe("disk encryption manifest", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	}
+
+	It("LUKS label differs from filesystem label to prevent label collisions", func() {
+		var manifestParams = map[string]interface{}{
+			"ROLE":   "master",
+			"MODE":   "tpm",
+			"CIPHER": "aes-cbc-essiv:sha256",
+		}
+		content, err := fillTemplate(manifestParams, diskEncryptionManifest, logrus.New())
+		Expect(err).ToNot(HaveOccurred())
+
+		var mc mcfgv1.MachineConfig
+		err = yaml.Unmarshal(content, &mc)
+		Expect(err).ToNot(HaveOccurred())
+		config, _, err := configv32.Parse(mc.Spec.Config.Raw)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(config.Storage.Luks).To(HaveLen(1))
+		Expect(config.Storage.Luks[0].Label).ToNot(BeNil())
+		Expect(*config.Storage.Luks[0].Label).To(Equal("luks-root"))
+
+		Expect(config.Storage.Filesystems).To(HaveLen(1))
+		Expect(config.Storage.Filesystems[0].Label).ToNot(BeNil())
+		Expect(*config.Storage.Filesystems[0].Label).To(Equal("root"))
+	})
 })
 
 var _ = Describe("GetDiskEncryptionCipher", func() {

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -390,6 +390,7 @@ spec:
     storage:
       luks:
         - name: root
+          label: luks-root
           device: /dev/disk/by-partlabel/root
           clevis:
             tpm2: true
@@ -414,6 +415,7 @@ spec:
     storage:
       luks:
         - name: root
+          label: luks-root
           device: /dev/disk/by-partlabel/root
           clevis:
             tang:


### PR DESCRIPTION

When running a multipath system with LUKS enabled, the system's first
boot will fail. The generated MCO disk encryption config is:

```
storage:
  luks:
    - name: root
      device: /dev/disk/by-partlabel/root
      clevis:
        tpm2: true
      options: [--cipher, aes-cbc-essiv:sha256]
      wipeVolume: true
  filesystems:
    - device: /dev/mapper/root
      format: xfs
      wipeFilesystem: true
      label: root
```

When this config is used for a multipath system, there will be a
failure to boot with the following error:

```
Expected /dev/disk/by-label/root to point to /dev/dm-5, but points to /dev/dm-4; triggering udev
```

Taking a look at the state of the broken system from within the
emergency shell, we can see that the LUKS container (`dm-4`) has
`ID_FS_LABEL_ENC=root` and `L: 50`. The decrypted root (`dm-5`) also has
`ID_FS_LABEL_ENC=root` but `L: 0`. This leads to
`/dev/disk/by-label/root` to always point to the LUKS container rather
than the decrypted root, since when two devices claim the same
by-label symlink, udev resolves it to the device with the highest link
priority (L:).

```
:/# lsblk
NAME                     MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINTS
sda                        8:0    0   16G  0 disk  
|-sda1                     8:1    0    1M  0 part  
|-sda2                     8:2    0  127M  0 part  
|-sda3                     8:3    0  384M  0 part  
|-sda4                     8:4    0  2.7G  0 part  
`-0x3ce94dd89b8b7e02     253:0    0   16G  0 mpath 
  |-0x3ce94dd89b8b7e02p1 253:1    0    1M  0 part  
  |-0x3ce94dd89b8b7e02p2 253:2    0  127M  0 part  
  |-0x3ce94dd89b8b7e02p3 253:3    0  384M  0 part  
  `-0x3ce94dd89b8b7e02p4 253:4    0  2.7G  0 part  
    `-root               253:5    0  2.7G  0 crypt 
sdb                        8:16   0   16G  0 disk  
|-sdb1                     8:17   0    1M  0 part  
|-sdb2                     8:18   0  127M  0 part  
|-sdb3                     8:19   0  384M  0 part  
|-sdb4                     8:20   0  2.7G  0 part  
`-0x3ce94dd89b8b7e02     253:0    0   16G  0 mpath 
  |-0x3ce94dd89b8b7e02p1 253:1    0    1M  0 part  
  |-0x3ce94dd89b8b7e02p2 253:2    0  127M  0 part  
  |-0x3ce94dd89b8b7e02p3 253:3    0  384M  0 part  
  `-0x3ce94dd89b8b7e02p4 253:4    0  2.7G  0 part  
    `-root               253:5    0  2.7G  0 crypt 

:/# udevadm info /dev/dm-4
...
S: disk/by-partlabel/root
S: disk/by-label/root
E: ID_FS_LABEL_ENC=root
E: DEVLINKS=/dev/disk/by-partlabel/root /dev/disk/by-id/scsi-0x3ce94dd89b8b7e02-part4 /dev/disk/by-partuuid/e04614ad-0afa-2d4b-828e-2903e355889f /dev/mapper/0x3ce94dd89b8b7e02p4 /dev/disk/by-id/dm-uuid-part4-mpat
L: 50

:/# udevadm info /dev/dm-5
...
S: disk/by-label/root
S: gpt-auto-root
S: mapper/root
S: disk/by-id/dm-uuid-CRYPT-LUKS2-c80317df2093424c861a3dec8efe6f56-root
S: disk/by-id/dm-name-root
E: DM_NAME=root
E: DM_UUID=CRYPT-LUKS2-c80317df2093424c861a3dec8efe6f56-root
E: ID_FS_LABEL=root
E: ID_FS_LABEL_ENC=root
E: DEVLINKS=/dev/disk/by-label/root /dev/disk/by-diskseq/10 /dev/gpt-auto-root /dev/disk/by-uuid/469ac41d-bf19-4a6f-8129-675ab8147b07 /dev/mapper/root /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-c80317df2093424c861a3dect
L: 0

:/# ls -lah /dev/disk/by-label/
...
lrwxrwxrwx 1 root root  10 Jul 16 14:17 root -> ../../dm-4
```

Before encryption, the root partition was an XFS filesystem with
LABEL=root. After ignition overwrites it with the LUKS header, the
udev database will still hold the old ID_FS_LABEL_ENC=root for the
device. On the next udev event, the multipath rules will run
`IMPORT{db}`, and this will re-import the old and stale label, at
which point there will be two partitoin with the root label.

If we add the luks-root label, blkid will read it from the LUKS2
header and overwrite the stale root label, so the container will claim
`by-label/luks-root` instead of competing for `by-label/root`


Also, the reason why I set the label to `luks-root` and not some other
label is just to be consistent with butane, which also sets
`luks-root` when you use the `boot_device.luks` sugar [1].

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

The testing was done manually, by using the coreos-assembler to
simulate a multipath system, and trying to boot it with different
ignition config. More details were given above.

```
cosa run --ignition conf.ign	\
	--devshell-console			\
	-m 4500						\
	--qemu-multipath			\
	--kargs "rd.multipath=default"
```

Without label: luks-root, the boot fails. With the label added, the
system boots successfully and /dev/disk/by-label/root correctly
resolves to the decrypted device.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


[1] https://coreos.github.io/butane/examples/#luks-encrypted-storage
The following butane:

```
variant: fcos
version: 1.6.0
boot_device:
  luks:
    tpm2: true
```

Will generate:

```
{
  "ignition": {
    "version": "3.5.0"
  },
  "storage": {
    "filesystems": [
      {
        "device": "/dev/mapper/root",
        "format": "xfs",
        "label": "root",
        "wipeFilesystem": true
      }
    ],
    "luks": [
      {
        "clevis": {
          "tpm2": true
        },
        "device": "/dev/disk/by-partlabel/root",
        "label": "luks-root",
        "name": "root",
        "wipeVolume": true
      }
    ]
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an explicit `luks-root` label to generated disk encryption manifests to clearly identify the root encrypted volume.
  * Updated TPMv2 and Tang manifest generation and validation to align with the revised label information.
* **Tests**
  * Improved disk encryption manifest tests to verify the presence, uniqueness, and expected values of LUKS and filesystem labels using Ignition v3.2 parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->