### PR TITLE
MGMT-24830: Remove urlAuth from endpoints that do not need it

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1249,9 +1249,6 @@ func init() {
           },
           {
             "agentAuth": []
-          },
-          {
-            "urlAuth": []
           }
         ],
         "description": "Downloads files relating to the installed/installing cluster.",
@@ -3630,9 +3627,6 @@ func init() {
             "agentAuth": []
           },
           {
-            "urlAuth": []
-          },
-          {
             "imageAuth": []
           },
           {
@@ -4171,9 +4165,6 @@ func init() {
               "read-only-admin",
               "user"
             ]
-          },
-          {
-            "urlAuth": []
           },
           {
             "imageAuth": []
@@ -12892,9 +12883,6 @@ func init() {
           },
           {
             "agentAuth": []
-          },
-          {
-            "urlAuth": []
           }
         ],
         "description": "Downloads files relating to the installed/installing cluster.",
@@ -15278,9 +15266,6 @@ func init() {
             "agentAuth": []
           },
           {
-            "urlAuth": []
-          },
-          {
             "imageAuth": []
           },
           {
@@ -15819,9 +15804,6 @@ func init() {
               "read-only-admin",
               "user"
             ]
-          },
-          {
-            "urlAuth": []
           },
           {
             "imageAuth": []

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -580,7 +580,6 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
-        - urlAuth: []
         - imageAuth: []
         - imageURLAuth: []
       description: Retrieves the details of the infra-env.
@@ -2052,7 +2051,6 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
-        - urlAuth: []
       description: Downloads files relating to the installed/installing cluster.
       operationId: V2DownloadClusterFiles
       produces:
@@ -2245,7 +2243,6 @@ paths:
         - installer
       security:
         - userAuth: [admin, read-only-admin, user]
-        - urlAuth: []
         - imageAuth: []
       description: |
         Get the initial ramdisk for minimal ISO based installations.


### PR DESCRIPTION
## Summary

Remove `urlAuth` from three endpoints that accept URL-based token authentication but have no controller-generated presigned URLs:

- **GetInfraEnv** (`/v2/infra-envs/{infra_env_id}`)
- **V2DownloadClusterFiles** (`/v2/clusters/{cluster_id}/downloads/files`)
- **DownloadMinimalInitrd** (`/v2/infra-envs/{infra_env_id}/downloads/minimal-initrd`)

This follows the precedent set by commit 723e33c78 which removed `urlAuth` from the credentials endpoint.

## What type of PR is this?

/kind enhancement

## What does this PR do / why do we need it?

These endpoints should not accept `urlAuth` because no controller generates presigned URLs for them. Removing `urlAuth` ensures tokens scoped via URL signing cannot be used on endpoints that were never intended to receive them.

## Which issue(s) this PR fixes

Fixes part of [MGMT-23952](https://issues.redhat.com/browse/MGMT-23952)

## Affected components

- Operator Managed Deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the documented authentication requirements for selected read-only endpoints, including cluster file downloads, infrastructure environment details, and minimal initrd downloads.
  * These endpoints now advertise the intended authentication method and no longer list URL-based authentication, aligning the security documentation with the expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->