### PR TITLE
MGMT-24834: Standalone cluster import fails — assisted-service fails to set ClusterDeployment.spec.installed after  Day1 completion

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -2691,6 +2691,12 @@ func (r *ClusterDeploymentsReconciler) handleClusterInstalled(ctx context.Contex
 		err = r.updateClusterMetadata(ctx, log, clusterDeployment, cluster, clusterInstall)
 		if err != nil {
 			log.WithError(err).Error("failed to update cluster metadata")
+		} else {
+			clusterDeployment.Spec.Installed = true
+			if updateErr := r.Update(ctx, clusterDeployment); updateErr != nil {
+				log.WithError(updateErr).Error("failed to set ClusterDeployment.Spec.Installed")
+				return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, updateErr)
+			}
 		}
 		return r.updateStatus(ctx, log, clusterInstall, clusterDeployment, cluster, err)
 	}

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -2385,6 +2385,32 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(aci.Status.DebugInfo.State).To(Equal(models.ClusterStatusAddingHosts))
 		})
 
+		It("should set ClusterDeployment.Spec.Installed to true after Day1 completion", func() {
+			openshiftID := strfmt.UUID(uuid.New().String())
+			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
+			backEndCluster.OpenshiftClusterID = openshiftID
+			backEndCluster.Kind = swag.String(models.ClusterKindCluster)
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
+			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			kubeconfig := "kubeconfig content"
+			mockInstallerInternal.EXPECT().GetCredentialsInternal(gomock.Any(), gomock.Any()).Return(&models.Credentials{Password: "foo", Username: "bar"}, nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
+			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).AnyTimes()
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any(), gomock.Any()).Return(backEndCluster, nil).AnyTimes()
+
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			aci = getTestClusterInstall()
+			Expect(aci.Status.DebugInfo.State).To(Equal(models.ClusterStatusInstalled))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Reason).To(Equal(hiveext.ClusterInstalledReason))
+
+			cluster = getTestCluster()
+			Expect(cluster.Spec.Installed).To(BeTrue())
+		})
+
 		It("update kubeconfig ingress", func() {
 			openshiftID := strfmt.UUID(uuid.New().String())
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalling)


### PR DESCRIPTION
When a standalone cluster completes Day1 installation, `handleClusterInstalled()` in `clusterdeployments_controller.go `updates the `AgentClusterInstall` metadata and status conditions but never sets `ClusterDeployment.Spec.Installed = true`. 
The assisted-service reconciler doesn't notice because` isInstalled()` has a fallback that checks the AgentClusterInstall condition, but external components like Hive and MCE check Spec.Installed directly - since it remains false, standalone cluster import fails. 
The fix sets `clusterDeployment.Spec.Installed = true` and persists the ClusterDeployment after successful metadata update, matching the existing pattern in `local_cluster_import_controller.go`. A unit test was added to verify Spec.Installed is set to true after Day1 completion.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster deployments are now marked as installed only after cluster metadata updates complete successfully.
  * Errors encountered while saving the installed status are now reported immediately.

* **Tests**
  * Added coverage to verify installed clusters are marked correctly and receive the expected completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->