### PR TITLE
OCPBUGS-88511: Honor custom ingress domain for apps DNS validation

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -146,6 +146,13 @@ type Cluster struct {
 	// reflect the actual cluster they represent
 	Imported *bool `json:"imported,omitempty"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips" gorm:"foreignkey:ClusterID;references:ID"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -68,6 +68,13 @@ type V2ClusterUpdateParams struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain *string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -146,6 +146,13 @@ type Cluster struct {
 	// reflect the actual cluster they represent
 	Imported *bool `json:"imported,omitempty"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips" gorm:"foreignkey:ClusterID;references:ID"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -68,6 +68,13 @@ type V2ClusterUpdateParams struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain *string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips"`
 

--- a/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
+++ b/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
@@ -167,6 +167,20 @@ var _ = DescribeTable(
 			UserManagedNetworking: swag.Bool(false),
 		},
 	}),
+	Entry("ingress domain from import-cluster-config", importCase{
+		files: map[string]string{
+			"import-cluster-config.json": "{\"networking\": {\"userManagedNetworking\": true}, \"ingressDomain\": \"abc.example.com\"}",
+		},
+		expectedImportParams: &models.ImportClusterParams{
+			APIVipDnsname:      swag.String("api.ostest"),
+			Name:               swag.String("ostest"),
+			OpenshiftClusterID: &clusterID,
+		},
+		expectedUpdateParams: &models.V2ClusterUpdateParams{
+			UserManagedNetworking: swag.Bool(true),
+			IngressDomain:         swag.String("abc.example.com"),
+		},
+	}),
 )
 
 func TestAgentbasedinstaller(t *testing.T) {

--- a/cmd/agentbasedinstaller/import.go
+++ b/cmd/agentbasedinstaller/import.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/client"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
@@ -72,7 +73,8 @@ type Networking struct {
 	UserManagedNetworking *bool `json:"userManagedNetworking,omitempty"`
 }
 type ClusterConfig struct {
-	Networking Networking `json:"networking"`
+	Networking    Networking `json:"networking"`
+	IngressDomain string     `json:"ingressDomain,omitempty"`
 }
 
 func configureClusterParams(fsys fs.FS, params *models.V2ClusterUpdateParams) error {
@@ -89,6 +91,9 @@ func configureClusterParams(fsys fs.FS, params *models.V2ClusterUpdateParams) er
 	log.Info("Read import cluster config file")
 
 	params.UserManagedNetworking = clusterConfig.Networking.UserManagedNetworking
+	if clusterConfig.IngressDomain != "" {
+		params.IngressDomain = swag.String(clusterConfig.IngressDomain)
+	}
 	return nil
 }
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2668,6 +2668,7 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 	updates := map[string]interface{}{}
 	optionalParam(params.ClusterUpdateParams.Name, "name", updates)
 	optionalParam(params.ClusterUpdateParams.BaseDNSDomain, "base_dns_domain", updates)
+	optionalParam(params.ClusterUpdateParams.IngressDomain, "ingress_domain", updates)
 	optionalParam(params.ClusterUpdateParams.HTTPProxy, "http_proxy", updates)
 	optionalParam(params.ClusterUpdateParams.HTTPSProxy, "https_proxy", updates)
 	optionalParam(params.ClusterUpdateParams.NoProxy, "no_proxy", updates)

--- a/internal/host/hostcommands/domain_name_resolution_cmd.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/constants"
+	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
@@ -48,7 +49,12 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	}
 	apiDomainName := fmt.Sprintf("api.%s.%s", clusterName, baseDNSDomain)
 	apiInternalDomainName := fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain)
-	appsDomainName := fmt.Sprintf("%s.apps.%s.%s", constants.AppsSubDomainNameHostDNSValidation, clusterName, baseDNSDomain)
+	appsDomainName := network.GetAppsDomainProbeHost(&cluster.Cluster)
+	if appsDomainName == "" {
+		err := errors.Errorf("unable to determine apps domain for cluster %s", host.ClusterID)
+		f.log.WithError(err).Warn("Apps domain is empty")
+		return "", err
+	}
 	wildcardDomainNameWithDot := fmt.Sprintf("%s.%s.%s.", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
 	wildcardDomainNameNoDot := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
 

--- a/internal/host/hostcommands/domain_name_resolution_cmd_test.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd_test.go
@@ -78,6 +78,33 @@ var _ = Describe("domainNameResolution", func() {
 		))
 	})
 
+	It("uses custom ingress_domain for apps probe only", func() {
+		cluster = common.Cluster{Cluster: models.Cluster{
+			ID:            &clusterID,
+			Name:          name,
+			BaseDNSDomain: baseDNSDomain,
+			IngressDomain: "abc.example.com",
+		}}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{URL: swag.String("quay.io/release")}, nil)
+		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
+		Expect(stepErr).ShouldNot(HaveOccurred())
+		Expect(stepReply).ToNot(BeNil())
+		var request models.DomainResolutionRequest
+		Expect(json.Unmarshal([]byte(stepReply[0].Args[0]), &request)).ToNot(HaveOccurred())
+		req := func(s string) models.DomainResolutionRequestDomain {
+			return models.DomainResolutionRequestDomain{DomainName: swag.String(s)}
+		}
+		Expect(request.Domains).To(ContainElements(
+			req(fmt.Sprintf("api.%s.%s", name, baseDNSDomain)),
+			req(fmt.Sprintf("api-int.%s.%s", name, baseDNSDomain)),
+			req(constants.AppsSubDomainNameHostDNSValidation+".abc.example.com"),
+		))
+		Expect(request.Domains).ToNot(ContainElement(
+			req(fmt.Sprintf("%s.apps.%s.%s", constants.AppsSubDomainNameHostDNSValidation, name, baseDNSDomain)),
+		))
+	})
+
 	It("Missing cluster name", func() {
 		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, BaseDNSDomain: baseDNSDomain}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1623,8 +1623,9 @@ func (v *validator) isAPIInternalDomainNameResolvedCorrectly(c *validationContex
 
 func (v *validator) isAppsDomainNameResolvedCorrectly(c *validationContext) (ValidationStatus, string) {
 	target := "application ingress"
-	domainName := domainNameToResolve(c, fmt.Sprintf("%s.apps", constants.AppsSubDomainNameHostDNSValidation))
-	printableDomain := printableDomain(c, domainNameToResolve(c, "*.apps"), target)
+	appsDomain := network.GetClusterAppsDomain(&c.cluster.Cluster)
+	domainName := network.GetAppsDomainProbeHost(&c.cluster.Cluster)
+	printableDomain := printableDomain(c, "*."+appsDomain, target)
 
 	return v.isDomainNameResolvedCorrectly(c, domainName, printableDomain, target)
 }

--- a/internal/network/apps_domain.go
+++ b/internal/network/apps_domain.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/assisted-service/internal/constants"
+	"github.com/openshift/assisted-service/models"
+)
+
+// GetClusterAppsDomain returns the domain used for application-ingress DNS checks.
+// When IngressDomain is set (typically from ingress.config.openshift.io/cluster
+// .spec.domain, or .spec.appsDomain when present), that value is used as-is.
+// Otherwise the legacy apps.<cluster-name>.<base-dns-domain> formula is used.
+func GetClusterAppsDomain(c *models.Cluster) string {
+	if c == nil {
+		return ""
+	}
+	if d := strings.TrimSpace(c.IngressDomain); d != "" {
+		return strings.TrimPrefix(d, "*.")
+	}
+	if c.Name == "" || c.BaseDNSDomain == "" {
+		return ""
+	}
+	return fmt.Sprintf("apps.%s.%s", c.Name, c.BaseDNSDomain)
+}
+
+// GetAppsDomainProbeHost returns the concrete hostname used to verify apps DNS
+// resolution (console-openshift-console.<apps-domain>).
+func GetAppsDomainProbeHost(c *models.Cluster) string {
+	appsDomain := GetClusterAppsDomain(c)
+	if appsDomain == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s.%s", constants.AppsSubDomainNameHostDNSValidation, appsDomain)
+}

--- a/internal/network/apps_domain_test.go
+++ b/internal/network/apps_domain_test.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/constants"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("GetClusterAppsDomain", func() {
+	It("derives apps.<name>.<base> when ingress_domain is empty", func() {
+		c := &models.Cluster{Name: "abc-int", BaseDNSDomain: "example.com"}
+		Expect(GetClusterAppsDomain(c)).To(Equal("apps.abc-int.example.com"))
+	})
+
+	It("uses ingress_domain when set", func() {
+		c := &models.Cluster{
+			Name:           "abc-int",
+			BaseDNSDomain:  "example.com",
+			IngressDomain:  "abc.example.com",
+		}
+		Expect(GetClusterAppsDomain(c)).To(Equal("abc.example.com"))
+	})
+
+	It("strips a leading wildcard prefix from ingress_domain", func() {
+		c := &models.Cluster{IngressDomain: "*.abc.example.com"}
+		Expect(GetClusterAppsDomain(c)).To(Equal("abc.example.com"))
+	})
+
+	It("returns empty when cluster metadata is incomplete", func() {
+		Expect(GetClusterAppsDomain(nil)).To(Equal(""))
+		Expect(GetClusterAppsDomain(&models.Cluster{Name: "x"})).To(Equal(""))
+		Expect(GetClusterAppsDomain(&models.Cluster{BaseDNSDomain: "y"})).To(Equal(""))
+	})
+})
+
+var _ = Describe("GetAppsDomainProbeHost", func() {
+	It("builds console probe under derived apps domain", func() {
+		c := &models.Cluster{Name: "abc-int", BaseDNSDomain: "example.com"}
+		Expect(GetAppsDomainProbeHost(c)).To(Equal(
+			constants.AppsSubDomainNameHostDNSValidation + ".apps.abc-int.example.com"))
+	})
+
+	It("builds console probe under custom ingress domain", func() {
+		c := &models.Cluster{IngressDomain: "abc.example.com"}
+		Expect(GetAppsDomainProbeHost(c)).To(Equal(
+			constants.AppsSubDomainNameHostDNSValidation + ".abc.example.com"))
+	})
+})

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -146,6 +146,13 @@ type Cluster struct {
 	// reflect the actual cluster they represent
 	Imported *bool `json:"imported,omitempty"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips" gorm:"foreignkey:ClusterID;references:ID"`
 

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -68,6 +68,13 @@ type V2ClusterUpdateParams struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain *string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6764,6 +6764,10 @@ func init() {
           "type": "boolean",
           "default": false
         },
+        "ingress_domain": {
+          "description": "Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain\n(or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of\nderiving apps.\u003ccluster_name\u003e.\u003cbase_dns_domain\u003e. Intended for Day-2 / add-hosts flows where the\nlive ingress domain may differ from the original install-config.\n",
+          "type": "string"
+        },
         "ingress_vips": {
           "description": "The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
           "type": "array",
@@ -11324,6 +11328,11 @@ func init() {
         "ignition_endpoint": {
           "description": "Explicit ignition endpoint overrides the default ignition endpoint.",
           "$ref": "#/definitions/ignition-endpoint"
+        },
+        "ingress_domain": {
+          "description": "Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain\n(or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of\nderiving apps.\u003ccluster_name\u003e.\u003cbase_dns_domain\u003e. Intended for Day-2 / add-hosts flows where the\nlive ingress domain may differ from the original install-config.\n",
+          "type": "string",
+          "x-nullable": true
         },
         "ingress_vips": {
           "description": "The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
@@ -18557,6 +18566,10 @@ func init() {
           "type": "boolean",
           "default": false
         },
+        "ingress_domain": {
+          "description": "Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain\n(or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of\nderiving apps.\u003ccluster_name\u003e.\u003cbase_dns_domain\u003e. Intended for Day-2 / add-hosts flows where the\nlive ingress domain may differ from the original install-config.\n",
+          "type": "string"
+        },
         "ingress_vips": {
           "description": "The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",
           "type": "array",
@@ -23048,6 +23061,11 @@ func init() {
         "ignition_endpoint": {
           "description": "Explicit ignition endpoint overrides the default ignition endpoint.",
           "$ref": "#/definitions/ignition-endpoint"
+        },
+        "ingress_domain": {
+          "description": "Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain\n(or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of\nderiving apps.\u003ccluster_name\u003e.\u003cbase_dns_domain\u003e. Intended for Day-2 / add-hosts flows where the\nlive ingress domain may differ from the original install-config.\n",
+          "type": "string",
+          "x-nullable": true
         },
         "ingress_vips": {
           "description": "The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5427,6 +5427,14 @@ definitions:
         type: string
         description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
         x-nullable: true
+      ingress_domain:
+        type: string
+        description: |
+          Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+          (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+          deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+          live ingress domain may differ from the original install-config.
+        x-nullable: true
       cluster_network_cidr:
         type: string
         description: IP address block from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
@@ -5671,6 +5679,13 @@ definitions:
       base_dns_domain:
         type: string
         description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
+      ingress_domain:
+        type: string
+        description: |
+          Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+          (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+          deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+          live ingress domain may differ from the original install-config.
       cluster_network_cidr:
         type: string
         description: IP address block from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -146,6 +146,13 @@ type Cluster struct {
 	// reflect the actual cluster they represent
 	Imported *bool `json:"imported,omitempty"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips" gorm:"foreignkey:ClusterID;references:ID"`
 

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -68,6 +68,13 @@ type V2ClusterUpdateParams struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Cluster application ingress domain, typically from ingress.config.openshift.io/cluster .spec.domain
+	// (or .spec.appsDomain when set). When provided, apps DNS validation uses this value instead of
+	// deriving apps.<cluster_name>.<base_dns_domain>. Intended for Day-2 / add-hosts flows where the
+	// live ingress domain may differ from the original install-config.
+	//
+	IngressDomain *string `json:"ingress_domain,omitempty"`
+
 	// The virtual IPs used for cluster ingress traffic. Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at most one IP address per IP stack used). The order of stacks should be the same as order of subnets in Cluster Networks, Service Networks, and Machine Networks.
 	IngressVips []*IngressVip `json:"ingress_vips"`
 


### PR DESCRIPTION
## Summary
- Adds optional `ingress_domain` on cluster / `v2-cluster-update-params` so Day-2 flows can supply the live apps/ingress domain from `ingress.config.openshift.io/cluster`.
- Apps DNS probe and `apps-domain-name-resolved-correctly` use that value when set; otherwise keep deriving `apps.<name>.<base_dns_domain>` (no Day-1 regression).
- Agent-based installer import path reads `ingressDomain` from `import-cluster-config.json` and applies it via cluster update.

This is the assisted-service half of [OCPBUGS-88511](https://issues.redhat.com/browse/OCPBUGS-88511). A companion change in `openshift/installer` (node-joiner) is still required to read the live Ingress CR and populate `import-cluster-config.json`.

## Motivation
`oc adm node-image create` fails `apps-domain-name-resolved-correctly` when the cluster ingress domain was changed post-install, because assisted-service always validates `*.apps.<cluster>.<baseDomain>` from import-time metadata.

## Test plan
- [x] Unit tests for `GetClusterAppsDomain` / `GetAppsDomainProbeHost`
- [x] `domain_name_resolution_cmd` test: custom `ingress_domain` changes apps probe only
- [x] ABI import test: `ingressDomain` in JSON maps to update params
- [ ] CI unit tests / lint
- [ ] With companion installer PR: patch ingress domain, ensure default apps DNS is unresolved, run `oc adm node-image create` and confirm apps validation uses the custom domain


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom application ingress domain during cluster import and updates.
  * Custom ingress domains are now used for application DNS validation while API domains continue using the cluster’s standard domain.
  * Added API schema support for the optional ingress domain field.

* **Bug Fixes**
  * Improved handling of missing or invalid application domain information during DNS validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->