### PR TITLE
MGMT-24903: Fall back to CoreOS image from worker ignition for day-2 persistent-boot

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1620,6 +1620,12 @@ func (b *bareMetalInventory) validateReleaseImageForDay2HostInstall(ctx context.
 
 	_, err = b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cpuArch, cluster.PullSecret)
 	if err != nil {
+		// For imported clusters with no ImageSetRef, the release image may not be
+		// available. The install command can use the CoreOS image from the worker
+		// ignition's encapsulated MachineConfig instead (MGMT-24903).
+		if hostutil.GetCoreOSImageFromIgnition(host) != "" {
+			return nil
+		}
 		return fmt.Errorf("no release image found for host: %w", err)
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -14103,6 +14103,29 @@ func verifyFeatureSupportApiErrorString(responder middleware.Responder, expected
 	ExpectWithOffset(1, concreteError.Error()).To(ContainSubstring(featuresupport.GetFeatureByID(featureB).GetName()))
 }
 
+func buildAPIVipConnectivityWithCoreOSImage(osImageURL string) string {
+	mcJSON := fmt.Sprintf(`{"apiVersion":"machineconfiguration.openshift.io/v1","kind":"MachineConfig","spec":{"osImageURL":"%s","config":{"ignition":{"version":"3.5.0"}}}}`, osImageURL)
+	source := "data:," + url.PathEscape(mcJSON)
+	ign := map[string]interface{}{
+		"ignition": map[string]interface{}{"version": "3.2.0"},
+		"storage": map[string]interface{}{
+			"files": []map[string]interface{}{
+				{
+					"path":     "/etc/ignition-machine-config-encapsulated.json",
+					"contents": map[string]interface{}{"source": source},
+				},
+			},
+		},
+	}
+	ignBytes, _ := json.Marshal(ign)
+	resp := models.APIVipConnectivityResponse{
+		IsSuccess: true,
+		Ignition:  string(ignBytes),
+	}
+	respBytes, _ := json.Marshal(resp)
+	return string(respBytes)
+}
+
 func addHost(hostId strfmt.UUID, role models.HostRole, state, kind string, infraEnvId, clusterId strfmt.UUID, inventory string, db *gorm.DB) models.Host {
 	host := models.Host{
 		ID:         &hostId,
@@ -14594,6 +14617,30 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(nil, fmt.Errorf("failed to find release image"))
 
 		Expect(bm.InstallSingleDay2HostInternal(ctx, clusterID, infraEnvID, hostId)).ToNot(Succeed())
+	})
+
+	It("succeeds when release image is unavailable but CoreOS image is in worker ignition for persistent-boot", func() {
+		hostId := strfmt.UUID(uuid.New().String())
+		inventory := `{"boot": {"device_type": "persistent"}}`
+		host := addHost(hostId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, infraEnvID, clusterID, inventory, db)
+
+		testCoreOSImage := "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
+		apiVipConnectivity := buildAPIVipConnectivityWithCoreOSImage(testCoreOSImage)
+		Expect(db.Model(&host).UpdateColumn("api_vip_connectivity", apiVipConnectivity).Error).ToNot(HaveOccurred())
+
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostInstallationStartedEventName),
+			eventstest.WithHostIdMatcher(hostId.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithClusterIdMatcher(clusterID.String())))
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(nil, fmt.Errorf("failed to find release image"))
+		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+
+		Expect(bm.InstallSingleDay2HostInternal(ctx, clusterID, infraEnvID, hostId)).To(Succeed())
 	})
 })
 

--- a/internal/common/ignition/ignition.go
+++ b/internal/common/ignition/ignition.go
@@ -144,6 +144,45 @@ func GetCACertInIgnition(contents string) (*string, error) {
 	return cert, nil
 }
 
+const encapsulatedMachineConfigPath = "/etc/ignition-machine-config-encapsulated.json"
+
+// GetOSImageURL extracts spec.osImageURL from the encapsulated MachineConfig
+// (/etc/ignition-machine-config-encapsulated.json) embedded in an ignition config.
+// Returns empty string if the file is not present or cannot be parsed.
+func GetOSImageURL(ignitionJSON string) string {
+	if ignitionJSON == "" {
+		return ""
+	}
+
+	config, err := ParseToLatest([]byte(ignitionJSON))
+	if err != nil {
+		return ""
+	}
+
+	for _, file := range config.Storage.Files {
+		if file.Path != encapsulatedMachineConfigPath {
+			continue
+		}
+		if file.Contents.Source == nil {
+			return ""
+		}
+		decoded, err := dataurl.DecodeString(*file.Contents.Source)
+		if err != nil {
+			return ""
+		}
+		var mc struct {
+			Spec struct {
+				OSImageURL string `json:"osImageURL"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(decoded.Data, &mc); err != nil {
+			return ""
+		}
+		return mc.Spec.OSImageURL
+	}
+	return ""
+}
+
 func extractCerts(ignition config_latest_types.Ignition) (*string, error) {
 	if len(ignition.Security.TLS.CertificateAuthorities) == 0 {
 		return nil, nil

--- a/internal/common/ignition/ignition_test.go
+++ b/internal/common/ignition/ignition_test.go
@@ -1,0 +1,60 @@
+package ignition
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIgnition(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ignition Suite")
+}
+
+var _ = Describe("GetOSImageURL", func() {
+	const testOSImageURL = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
+
+	buildIgnitionWithMC := func(osImageURL string) string {
+		mcJSON := `{"apiVersion":"machineconfiguration.openshift.io/v1","kind":"MachineConfig","spec":{"osImageURL":"` + osImageURL + `","config":{"ignition":{"version":"3.5.0"}}}}`
+		source := "data:," + url.PathEscape(mcJSON)
+		ign := map[string]interface{}{
+			"ignition": map[string]interface{}{"version": "3.2.0"},
+			"storage": map[string]interface{}{
+				"files": []map[string]interface{}{
+					{
+						"path":     "/etc/ignition-machine-config-encapsulated.json",
+						"contents": map[string]interface{}{"source": source},
+					},
+				},
+			},
+		}
+		b, _ := json.Marshal(ign)
+		return string(b)
+	}
+
+	It("extracts osImageURL from encapsulated MachineConfig", func() {
+		result := GetOSImageURL(buildIgnitionWithMC(testOSImageURL))
+		Expect(result).To(Equal(testOSImageURL))
+	})
+
+	It("returns empty string for ignition without encapsulated MC", func() {
+		ign := `{"ignition":{"version":"3.2.0"},"storage":{"files":[]}}`
+		Expect(GetOSImageURL(ign)).To(BeEmpty())
+	})
+
+	It("returns empty string for empty input", func() {
+		Expect(GetOSImageURL("")).To(BeEmpty())
+	})
+
+	It("returns empty string for invalid JSON", func() {
+		Expect(GetOSImageURL("not json")).To(BeEmpty())
+	})
+
+	It("returns empty string when osImageURL is empty", func() {
+		result := GetOSImageURL(buildIgnitionWithMC(""))
+		Expect(result).To(BeEmpty())
+	})
+})

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -153,20 +153,31 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 	}
 
 	installToDisk := inventory != nil && inventory.Boot != nil && inventory.Boot.DeviceType == models.BootDeviceTypePersistent
+	isDay2 := swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster
 
 	// Get release image for host only if it's either not a day-2 host or it's installing to disk
 	var releaseImage *models.ReleaseImage
-	if installToDisk || swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
+	if installToDisk || !isDay2 {
 		releaseImage, err = i.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cpuArch, cluster.PullSecret)
-		if err != nil {
+		if err != nil && !isDay2 {
 			return "", err
 		}
 	}
 
 	if installToDisk {
-		request.CoreosImage, err = i.ocRelease.GetCoreOSImage(i.log, *releaseImage.URL, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
-		if err != nil {
-			return "", err
+		if releaseImage != nil {
+			request.CoreosImage, err = i.ocRelease.GetCoreOSImage(i.log, *releaseImage.URL, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			// Day-2 persistent-boot: release image unavailable (e.g. imported cluster
+			// with no ImageSetRef). Use the CoreOS image from the worker ignition's
+			// encapsulated MachineConfig instead (MGMT-24903).
+			request.CoreosImage = hostutil.GetCoreOSImageFromIgnition(host)
+			if request.CoreosImage == "" {
+				return "", errors.Errorf("cannot determine CoreOS image for persistent-boot day-2 host %s: release image not available and worker ignition does not contain a CoreOS image reference", host.ID)
+			}
 		}
 		i.log.Infof("installing to disk with CoreOS image %s", request.CoreosImage)
 	}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/go-openapi/strfmt"
@@ -566,6 +567,47 @@ var _ = Describe("installcmd arguments", func() {
 			Expect(stepReply).NotTo(BeNil())
 			request := generateRequestForStep(stepReply[0])
 			Expect(request.CoreosImage).To(Equal(testCoreOSImage))
+		})
+
+	})
+
+	Context("day2 persistent-boot without release image", func() {
+		var (
+			noReleaseVersions *versions.MockHandler
+			noReleaseMock     *oc.MockRelease
+		)
+
+		BeforeEach(func() {
+			noReleaseMock = oc.NewMockRelease(ctrl)
+			noReleaseVersions = versions.NewMockHandler(ctrl)
+			noReleaseVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("release image not found")).AnyTimes()
+
+			var inventory models.Inventory
+			Expect(json.Unmarshal([]byte(host.Inventory), &inventory)).ToNot(HaveOccurred())
+			inventory.Boot = &models.Boot{DeviceType: models.BootDeviceTypePersistent}
+			newInventoryBytes, err := json.Marshal(inventory)
+			Expect(err).ToNot(HaveOccurred())
+			host.Inventory = string(newInventoryBytes)
+			Expect(db.Model(cluster).UpdateColumn("kind", models.ClusterKindAddHostsCluster).Error).ToNot(HaveOccurred())
+		})
+
+		It("falls back to CoreOS image from worker ignition", func() {
+			testCoreOSImage := "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
+			host.APIVipConnectivity = buildAPIVipConnectivityWithCoreOSImage(testCoreOSImage)
+
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, noReleaseMock, InstructionConfig{}, mockEvents, noReleaseVersions, true, true)
+			stepReply, err := installCmd.GetSteps(ctx, &host)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stepReply).NotTo(BeNil())
+			request := generateRequestForStep(stepReply[0])
+			Expect(request.CoreosImage).To(Equal(testCoreOSImage))
+		})
+
+		It("fails when worker ignition has no CoreOS image", func() {
+			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, noReleaseMock, InstructionConfig{}, mockEvents, noReleaseVersions, true, true)
+			_, err := installCmd.GetSteps(ctx, &host)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot determine CoreOS image"))
 		})
 	})
 
@@ -2076,6 +2118,29 @@ func postvalidation(isstepreplynil bool, issteperrnil bool, expectedstepreply *m
 		ExpectWithOffset(1, expectedstepreply.StepType).To(Equal(models.StepTypeInstall))
 		ExpectWithOffset(1, strings.Contains(expectedstepreply.Args[0], string(expectedrole))).To(Equal(true))
 	}
+}
+
+func buildAPIVipConnectivityWithCoreOSImage(osImageURL string) string {
+	mcJSON := fmt.Sprintf(`{"apiVersion":"machineconfiguration.openshift.io/v1","kind":"MachineConfig","spec":{"osImageURL":"%s","config":{"ignition":{"version":"3.5.0"}}}}`, osImageURL)
+	source := "data:," + url.PathEscape(mcJSON)
+	ign := map[string]interface{}{
+		"ignition": map[string]interface{}{"version": "3.2.0"},
+		"storage": map[string]interface{}{
+			"files": []map[string]interface{}{
+				{
+					"path":     "/etc/ignition-machine-config-encapsulated.json",
+					"contents": map[string]interface{}{"source": source},
+				},
+			},
+		},
+	}
+	ignBytes, _ := json.Marshal(ign)
+	resp := models.APIVipConnectivityResponse{
+		IsSuccess: true,
+		Ignition:  string(ignBytes),
+	}
+	respBytes, _ := json.Marshal(resp)
+	return string(respBytes)
 }
 
 func validateInstallCommand(installCmd *installCmd, reply *models.Step, role models.HostRole, infraEnvId, clusterId, hostId strfmt.UUID,

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -331,6 +331,21 @@ func GetDiskEncryptionForDay2(log logrus.FieldLogger, host *models.Host) (*ignit
 	return &config.Storage.Luks[0], nil
 }
 
+// GetCoreOSImageFromIgnition extracts the CoreOS image (spec.osImageURL) from the
+// encapsulated MachineConfig in the host's API VIP connectivity response. Returns
+// empty string if the response is missing, the ignition doesn't contain the
+// encapsulated MachineConfig, or the MachineConfig has no osImageURL.
+func GetCoreOSImageFromIgnition(host *models.Host) string {
+	if host.APIVipConnectivity == "" {
+		return ""
+	}
+	var response models.APIVipConnectivityResponse
+	if err := json.Unmarshal([]byte(host.APIVipConnectivity), &response); err != nil {
+		return ""
+	}
+	return ignition.GetOSImageURL(response.Ignition)
+}
+
 func GetIgnitionEndpointAndCert(cluster *common.Cluster, host *models.Host, logger logrus.FieldLogger) (string, *string, error) {
 	poolName := string(common.GetEffectiveRole(host))
 

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -820,6 +820,58 @@ var _ = Describe("GetHostInstallationDisk", func() {
 	})
 })
 
+var _ = Describe("GetCoreOSImageFromIgnition", func() {
+	const testOSImageURL = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
+
+	buildConnectivityResponse := func(osImageURL string) string {
+		mcJSON := fmt.Sprintf(`{"apiVersion":"machineconfiguration.openshift.io/v1","kind":"MachineConfig","spec":{"osImageURL":"%s","config":{"ignition":{"version":"3.5.0"}}}}`, osImageURL)
+		source := dataurl.EncodeBytes([]byte(mcJSON))
+		ign := map[string]interface{}{
+			"ignition": map[string]interface{}{"version": "3.2.0"},
+			"storage": map[string]interface{}{
+				"files": []map[string]interface{}{
+					{
+						"path":     "/etc/ignition-machine-config-encapsulated.json",
+						"contents": map[string]interface{}{"source": source},
+					},
+				},
+			},
+		}
+		ignBytes, _ := json.Marshal(ign)
+		resp := models.APIVipConnectivityResponse{
+			IsSuccess: true,
+			Ignition:  string(ignBytes),
+		}
+		respBytes, _ := json.Marshal(resp)
+		return string(respBytes)
+	}
+
+	It("extracts CoreOS image from host connectivity response", func() {
+		host := &models.Host{
+			APIVipConnectivity: buildConnectivityResponse(testOSImageURL),
+		}
+		Expect(GetCoreOSImageFromIgnition(host)).To(Equal(testOSImageURL))
+	})
+
+	It("returns empty string when APIVipConnectivity is empty", func() {
+		host := &models.Host{}
+		Expect(GetCoreOSImageFromIgnition(host)).To(BeEmpty())
+	})
+
+	It("returns empty string when ignition has no encapsulated MC", func() {
+		ign := `{"ignition":{"version":"3.2.0"},"storage":{"files":[]}}`
+		resp := models.APIVipConnectivityResponse{IsSuccess: true, Ignition: ign}
+		respBytes, _ := json.Marshal(resp)
+		host := &models.Host{APIVipConnectivity: string(respBytes)}
+		Expect(GetCoreOSImageFromIgnition(host)).To(BeEmpty())
+	})
+
+	It("returns empty string when APIVipConnectivity is invalid JSON", func() {
+		host := &models.Host{APIVipConnectivity: "not json"}
+		Expect(GetCoreOSImageFromIgnition(host)).To(BeEmpty())
+	})
+})
+
 func TestHostUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HostUtil Tests")


### PR DESCRIPTION
## Summary

- For day-2 persistent-boot hosts, fall back to the CoreOS image from the worker ignition's encapsulated MachineConfig when `GetReleaseImage` fails (e.g. imported clusters with empty `OpenshiftVersion`)
- Add `ignition.GetOSImageURL` to extract `spec.osImageURL` from the encapsulated MachineConfig in an ignition config
- Add `hostutil.GetCoreOSImageFromIgnition` to extract the CoreOS image from a host's API VIP connectivity response
- Update `validateReleaseImageForDay2HostInstall` to accept the ignition-sourced CoreOS image

## Background

The Agent CAPI provider (`cluster-api-provider-agent`) creates `AgentClusterInstall` without setting `Spec.ImageSetRef`. For day-2 hosts with persistent boot, this leaves `cluster.OpenshiftVersion` empty, causing `GetReleaseImage` and `GetCoreOSImage` to fail. The host stays stuck in `known` state.

The worker ignition from the cluster's MCS contains `/etc/ignition-machine-config-encapsulated.json` — a ~1 KB MachineConfig with `spec.osImageURL` pointing to the current CoreOS image. The MCO maintains this field across cluster upgrades, making it more reliable than the immutable `ImageSetRef`.

Depends on openshift/assisted-installer-agent#1568 (preserves the encapsulated MC in the filtered ignition). The service-side change is backward-compatible — if the agent hasn't been updated, the fallback returns the original error.

## Test plan

- [x] `internal/common/ignition/ignition_test.go`: 5 new tests for `GetOSImageURL` (happy path, missing file, empty input, invalid JSON, empty URL)
- [x] `internal/host/hostutil/host_utils_test.go`: 4 new tests for `GetCoreOSImageFromIgnition` (happy path, empty connectivity, missing MC, invalid JSON)
- [x] `internal/host/hostcommands/install_cmd_test.go`: 2 new tests (fallback succeeds, fallback unavailable)
- [x] `internal/bminventory/inventory_test.go`: 1 new test (validation passes with ignition fallback)
- [x] All locally-runnable tests pass; DB-dependent tests compile clean

Resolves https://issues.redhat.com/browse/MGMT-24903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Day-2 persistent-boot host installations now continue when the release image is unavailable, as long as a CoreOS image can be determined from existing host ignition data.
  - Added a clearer error message when no usable CoreOS image can be determined.
  - Improved robustness when ignition data is missing or malformed during image resolution.

- **Tests**
  - Added coverage for the successful fallback behavior and for failure when CoreOS image resolution is not possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->