### PR TITLE
ACM-30180: Honor cluster TLS security profile in Infrastructure Operator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -55,6 +56,7 @@ import (
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
 	"github.com/openshift/assisted-service/internal/stream"
 	"github.com/openshift/assisted-service/internal/system"
+	"github.com/openshift/assisted-service/internal/tlsconfig"
 	"github.com/openshift/assisted-service/internal/uploader"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/internal/versions"
@@ -157,6 +159,8 @@ var Options struct {
 	ServeHTTPS                           bool          `envconfig:"SERVE_HTTPS" default:"false"`
 	HTTPSKeyFile                         string        `envconfig:"HTTPS_KEY_FILE" default:""`
 	HTTPSCertFile                        string        `envconfig:"HTTPS_CERT_FILE" default:""`
+	TLSMinVersion                        string        `envconfig:"TLS_MIN_VERSION" default:""`
+	TLSCipherSuites                      string        `envconfig:"TLS_CIPHER_SUITES" default:""`
 	MaxIdleConns                         int           `envconfig:"DB_MAX_IDLE_CONNECTIONS" default:"50"`
 	MaxOpenConns                         int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"90"`
 	ConnMaxLifetime                      time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
@@ -722,6 +726,7 @@ func main() {
 
 	// Determine if IPXE artifact URLs need to be http
 	serverInfo := servers.New(Options.HTTPListenPort, swag.StringValue(port), Options.HTTPSKeyFile, Options.HTTPSCertFile)
+	applyClusterTLSConfig(log, serverInfo)
 	generateInsecureIPXEURLs := serverInfo.HTTP != nil
 
 	disconnectedIgnitionGenerator := ignition.NewDisconnectedIgnitionGenerator(
@@ -818,6 +823,18 @@ func setupServerForIPXE(serverInfo *servers.ServerInfo, h http.Handler) {
 	if serverInfo.HTTPS != nil {
 		serverInfo.HTTPS.Handler = h
 	}
+}
+
+func applyClusterTLSConfig(log *logrus.Logger, serverInfo *servers.ServerInfo) {
+	if Options.TLSMinVersion == "" || serverInfo.HTTPS == nil {
+		return
+	}
+	tlsCfg, err := tlsconfig.BuildTLSConfigFromCLIArgs(Options.TLSMinVersion, Options.TLSCipherSuites)
+	if err != nil {
+		log.WithError(err).Fatal("unable to build TLS config from environment")
+	}
+	serverInfo.HTTPS.TLSConfig = tlsCfg
+	log.Infof("Applied cluster TLS profile: MinVersion=0x%04x, CipherSuites=%d", tlsCfg.MinVersion, len(tlsCfg.CipherSuites))
 }
 
 func setupDB(log logrus.FieldLogger, slowQueryConfig slowquery.Config) *gorm.DB {
@@ -977,9 +994,22 @@ func createControllerManager() (manager.Manager, error) {
 				Label: labels.NewSelector().Add(*infraenvLabel),
 			}
 		}
-		return ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		var webhookTLSOpts []func(*tls.Config)
+		restCfg := ctrl.GetConfigOrDie()
+		if Options.TLSMinVersion != "" {
+			tlsCfg, tlsErr := tlsconfig.BuildTLSConfigFromCLIArgs(Options.TLSMinVersion, Options.TLSCipherSuites)
+			if tlsErr != nil {
+				return nil, tlsErr
+			}
+			webhookTLSOpts = append(webhookTLSOpts, func(cfg *tls.Config) {
+				cfg.MinVersion = tlsCfg.MinVersion
+				cfg.CipherSuites = tlsCfg.CipherSuites
+			})
+		}
+
+		return ctrl.NewManager(restCfg, ctrl.Options{
 			Scheme:           schemes,
-			WebhookServer:    webhook.NewServer(webhook.Options{Port: 9443}),
+			WebhookServer:    webhook.NewServer(webhook.Options{Port: 9443, TLSOpts: webhookTLSOpts}),
 			LeaderElection:   true,
 			LeaderElectionID: "77190dcb.agent-install.openshift.io",
 			Cache: cache.Options{

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -32,6 +33,7 @@ import (
 	"github.com/openshift/assisted-service/internal/kubernetes"
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
 	"github.com/openshift/assisted-service/internal/system"
+	"github.com/openshift/assisted-service/internal/tlsconfig"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -124,12 +126,27 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+
+	restCfg := ctrl.GetConfigOrDie()
+
+	tlsCfg, err := tlsconfig.FetchTLSConfig(context.Background(), restCfg)
+	if err != nil {
+		setupLog.Error(err, "unable to fetch TLS config from APIServer")
+		os.Exit(1)
+	}
+	tlsOpts := []func(*tls.Config){
+		func(cfg *tls.Config) {
+			cfg.MinVersion = tlsCfg.MinVersion
+			cfg.CipherSuites = tlsCfg.CipherSuites
+		},
+	}
+
+	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
-		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
+		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443, TLSOpts: tlsOpts}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "86f835c3.agent-install.openshift.io",
@@ -215,6 +232,7 @@ func main() {
 			Recorder:        mgr.GetEventRecorderFor("agentserviceconfig-controller"),
 			PodIntrospector: introspector,
 			IsOpenShift:     isOpenShift,
+			RestConfig:      restCfg,
 		},
 		Client:    mgr.GetClient(),
 		Namespace: ns,
@@ -231,6 +249,7 @@ func main() {
 			Tolerations:  tolerations,
 			Recorder:     mgr.GetEventRecorderFor("hypershiftagentserviceconfig-controller"),
 			IsOpenShift:  isOpenShift,
+			RestConfig:   restCfg,
 		},
 		Client:       mgr.GetClient(),
 		SpokeClients: spokeClientCache,
@@ -256,8 +275,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+
+	// The APIServer resource only exists on OpenShift, so there is no
+	// cluster-wide TLS profile to watch on other Kubernetes flavors.
+	if isOpenShift {
+		if err := tlsconfig.WatchForTLSProfileChanges(ctx, restCfg, cancel); err != nil {
+			setupLog.Error(err, "unable to start TLS profile watcher")
+			os.Exit(1)
+		}
+	}
+
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -163,6 +163,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusteroperators
   - clusterversions
   - dnses

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -713,6 +713,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
           - clusteroperators
           - clusterversions
           - dnses

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -208,6 +208,7 @@ type ComponentStatusFn func(context.Context, logrus.FieldLogger, string, appsv1.
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/openshift/assisted-service/internal/kubernetes"
+	"github.com/openshift/assisted-service/internal/tlsconfig"
 	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -59,6 +60,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -139,6 +141,9 @@ type AgentServiceConfigReconcileContext struct {
 
 	// flag to indicate if the operator is running on an OpenShift cluster or some other flavor of Kubernetes
 	IsOpenShift bool
+
+	// RestConfig is the cluster REST configuration, used for fetching TLS profile settings
+	RestConfig *rest.Config
 }
 
 // AgentServiceConfigReconciler reconciles a AgentServiceConfig object
@@ -1369,6 +1374,15 @@ func newAssistedCM(ctx context.Context, log logrus.FieldLogger, asc ASC) (client
 			cm.Data["HTTPS_CERT_FILE"] = "/etc/assisted-tls-config/tls.crt"
 			cm.Data["HTTPS_KEY_FILE"] = "/etc/assisted-tls-config/tls.key"
 			cm.Data["SERVICE_CA_CERT_PATH"] = "/etc/assisted-ingress-cert/ca-bundle.crt"
+			if asc.rec.RestConfig != nil {
+				minVersion, cipherSuites, err := tlsconfig.FetchTLSCLIArgs(ctx, asc.rec.RestConfig)
+				if err != nil {
+					log.WithError(err).Warn("unable to fetch TLS profile for assisted-service, skipping TLS configuration")
+				} else {
+					cm.Data["TLS_MIN_VERSION"] = minVersion
+					cm.Data["TLS_CIPHER_SUITES"] = strings.Join(cipherSuites, ",")
+				}
+			}
 		} else {
 			cm.Data["SERVICE_CA_CERT_PATH"] = "/etc/assisted-ingress-cert/ca.crt"
 		}
@@ -1514,6 +1528,17 @@ func newImageServiceStatefulSet(ctx context.Context, log logrus.FieldLogger, asc
 			corev1.EnvVar{Name: "ASSISTED_SERVICE_SCHEME", Value: "https"},
 			corev1.EnvVar{Name: "HTTP_LISTEN_PORT", Value: imageHandlerHTTPPort.String()},
 		)
+		if asc.rec.RestConfig != nil {
+			minVersion, cipherSuites, err := tlsconfig.FetchTLSCLIArgs(ctx, asc.rec.RestConfig)
+			if err != nil {
+				log.WithError(err).Warning("unable to fetch TLS profile for image-service, using defaults")
+			} else {
+				containerEnv = append(containerEnv,
+					corev1.EnvVar{Name: "TLS_MIN_VERSION", Value: minVersion},
+					corev1.EnvVar{Name: "TLS_CIPHER_SUITES", Value: strings.Join(cipherSuites, ",")},
+				)
+			}
+		}
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{Name: "tls-certs", MountPath: "/etc/image-service/certs"},
 			corev1.VolumeMount{Name: "service-cabundle", MountPath: "/etc/image-service/ca-bundle"},
@@ -2829,17 +2854,31 @@ func newWebHookAPIService(ctx context.Context, log logrus.FieldLogger, asc ASC) 
 }
 
 func newWebHookDeployment(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {
+	command := []string{
+		"/assisted-service-admission",
+		"--secure-port=9443",
+		"--audit-log-path=-",
+		"--tls-cert-file=/var/serving-cert/tls.crt",
+		"--tls-private-key-file=/var/serving-cert/tls.key",
+	}
+
+	if asc.rec.IsOpenShift && asc.rec.RestConfig != nil {
+		minVersion, cipherSuites, err := tlsconfig.FetchTLSCLIArgs(ctx, asc.rec.RestConfig)
+		if err != nil {
+			log.WithError(err).Warning("unable to fetch TLS profile for webhook, using defaults")
+		} else {
+			command = append(command, fmt.Sprintf("--tls-min-version=%s", minVersion))
+			if len(cipherSuites) > 0 {
+				command = append(command, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+			}
+		}
+	}
+
 	serviceContainer := corev1.Container{
 		Name: "agentinstalladmission",
 		// always use the default image for webhooks since this will never need to run the installer binary
-		Image: serviceImageDefault(),
-		Command: []string{
-			"/assisted-service-admission",
-			"--secure-port=9443",
-			"--audit-log-path=-",
-			"--tls-cert-file=/var/serving-cert/tls.crt",
-			"--tls-private-key-file=/var/serving-cert/tls.key",
-		},
+		Image:   serviceImageDefault(),
+		Command: command,
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: 9443,

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -10,6 +10,9 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -20,6 +23,9 @@ var log = ctrl.Log.WithName("tlsconfig")
 // and returns a *tls.Config configured with the appropriate MinVersion and
 // CipherSuites. Delegates to FetchTLSCLIArgs for the profile resolution and
 // converts the result via BuildTLSConfigFromCLIArgs.
+//
+// The cluster profile is only honored when spec.tlsAdherence requires it,
+// otherwise the default Intermediate profile is used.
 func FetchTLSConfig(ctx context.Context, restConfig *rest.Config) (*tls.Config, error) {
 	minVersion, cipherSuites, err := FetchTLSCLIArgs(ctx, restConfig)
 	if err != nil {
@@ -52,6 +58,19 @@ func getProfileSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileS
 // and returns the MinTLSVersion string and IANA cipher suite names suitable for
 // passing as --tls-min-version and --tls-cipher-suites CLI flags.
 func FetchTLSCLIArgs(ctx context.Context, restConfig *rest.Config) (minVersion string, cipherSuites []string, err error) {
+	adherence, err := fetchTLSAdherence(ctx, restConfig)
+	if err != nil {
+		log.Error(err, "unable to fetch TLS adherence, using default Intermediate profile")
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return string(spec.MinTLSVersion), libgocrypto.OpenSSLToIANACipherSuites(spec.Ciphers), nil
+	}
+
+	if !shouldHonorClusterTLSProfile(adherence) {
+		log.Info("TLS adherence does not require honoring cluster profile, using default Intermediate", "adherence", adherence)
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return string(spec.MinTLSVersion), libgocrypto.OpenSSLToIANACipherSuites(spec.Ciphers), nil
+	}
+
 	configClient, err := configclientset.NewForConfig(restConfig)
 	if err != nil {
 		return "", nil, fmt.Errorf("creating config client: %w", err)
@@ -78,6 +97,43 @@ func FetchTLSCLIArgs(ctx context.Context, restConfig *rest.Config) (minVersion s
 
 	log.Info("resolved TLS profile from APIServer", "type", profile.Type)
 	return string(spec.MinTLSVersion), libgocrypto.OpenSSLToIANACipherSuites(spec.Ciphers), nil
+}
+
+var apiServerGVR = schema.GroupVersionResource{
+	Group:    "config.openshift.io",
+	Version:  "v1",
+	Resource: "apiservers",
+}
+
+// shouldHonorClusterTLSProfile returns true when the component must honor the
+// cluster-wide TLS profile. Mirrors library-go's ShouldHonorClusterTLSProfile.
+// Unknown values return true for forward compatibility.
+func shouldHonorClusterTLSProfile(adherence string) bool {
+	switch adherence {
+	case "", "LegacyAdheringComponentsOnly":
+		return false
+	default:
+		return true
+	}
+}
+
+// fetchTLSAdherence reads the tlsAdherence field from the APIServer resource
+// using the dynamic client, since our vendored openshift/api does not include
+// the TLSAdherence type. Returns the raw string value, or empty string if the
+// field is not set or the resource is not available.
+func fetchTLSAdherence(ctx context.Context, restConfig *rest.Config) (string, error) {
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	obj, err := dynClient.Resource(apiServerGVR).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting APIServer resource: %w", err)
+	}
+
+	adherence, _, _ := unstructured.NestedString(obj.Object, "spec", "tlsAdherence")
+	return adherence, nil
 }
 
 // BuildTLSConfigFromCLIArgs builds a *tls.Config from a TLS version string

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -1,0 +1,114 @@
+package tlsconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("tlsconfig")
+
+// FetchTLSConfig reads the TLS profile from the cluster's APIServer resource
+// and returns a *tls.Config configured with the appropriate MinVersion and
+// CipherSuites. Delegates to FetchTLSCLIArgs for the profile resolution and
+// converts the result via BuildTLSConfigFromCLIArgs.
+func FetchTLSConfig(ctx context.Context, restConfig *rest.Config) (*tls.Config, error) {
+	minVersion, cipherSuites, err := FetchTLSCLIArgs(ctx, restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return BuildTLSConfigFromCLIArgs(minVersion, strings.Join(cipherSuites, ","))
+}
+
+func getProfileSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileSpec, error) {
+	switch profile.Type {
+	case configv1.TLSProfileOldType,
+		configv1.TLSProfileIntermediateType,
+		configv1.TLSProfileModernType:
+		spec, ok := configv1.TLSProfiles[profile.Type]
+		if !ok {
+			return nil, fmt.Errorf("unknown built-in TLS profile type: %s", profile.Type)
+		}
+		return spec, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			return nil, fmt.Errorf("custom TLS profile specified but Custom field is nil")
+		}
+		return &profile.Custom.TLSProfileSpec, nil
+	default:
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+}
+
+// FetchTLSCLIArgs reads the TLS profile from the cluster's APIServer resource
+// and returns the MinTLSVersion string and IANA cipher suite names suitable for
+// passing as --tls-min-version and --tls-cipher-suites CLI flags.
+func FetchTLSCLIArgs(ctx context.Context, restConfig *rest.Config) (minVersion string, cipherSuites []string, err error) {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating config client: %w", err)
+	}
+
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		log.Error(err, "unable to get APIServer config, using default Intermediate profile")
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return string(spec.MinTLSVersion), libgocrypto.OpenSSLToIANACipherSuites(spec.Ciphers), nil
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		profile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileIntermediateType,
+		}
+	}
+
+	spec, err := getProfileSpec(profile)
+	if err != nil {
+		return "", nil, err
+	}
+
+	log.Info("resolved TLS profile from APIServer", "type", profile.Type)
+	return string(spec.MinTLSVersion), libgocrypto.OpenSSLToIANACipherSuites(spec.Ciphers), nil
+}
+
+// BuildTLSConfigFromCLIArgs builds a *tls.Config from a TLS version string
+// and comma-separated IANA cipher suite names, as passed via environment
+// variables or CLI flags.
+func BuildTLSConfigFromCLIArgs(minVersion string, cipherSuites string) (*tls.Config, error) {
+	ver, err := libgocrypto.TLSVersion(minVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS version %q: %w", minVersion, err)
+	}
+
+	config := &tls.Config{
+		MinVersion: ver,
+	}
+
+	if ver < tls.VersionTLS13 && cipherSuites != "" {
+		names := strings.Split(cipherSuites, ",")
+		var suites []uint16
+		for _, name := range names {
+			suite, csErr := libgocrypto.CipherSuite(strings.TrimSpace(name))
+			if csErr != nil {
+				log.Info("skipping unsupported cipher suite", "cipher", name)
+				continue
+			}
+			suites = append(suites, suite)
+		}
+		if len(suites) == 0 {
+			return nil, fmt.Errorf("none of the specified cipher suites are supported: %v", names)
+		}
+		config.CipherSuites = suites
+	}
+
+	return config, nil
+}

--- a/internal/tlsconfig/tlsconfig_suite_test.go
+++ b/internal/tlsconfig/tlsconfig_suite_test.go
@@ -1,0 +1,13 @@
+package tlsconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTLSConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "tlsconfig tests")
+}

--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -126,3 +126,21 @@ var _ = Describe("getProfileSpec", func() {
 		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS12))
 	})
 })
+
+var _ = Describe("shouldHonorClusterTLSProfile", func() {
+	It("returns false for empty adherence", func() {
+		Expect(shouldHonorClusterTLSProfile("")).To(BeFalse())
+	})
+
+	It("returns false for LegacyAdheringComponentsOnly", func() {
+		Expect(shouldHonorClusterTLSProfile("LegacyAdheringComponentsOnly")).To(BeFalse())
+	})
+
+	It("returns true for StrictAllComponents", func() {
+		Expect(shouldHonorClusterTLSProfile("StrictAllComponents")).To(BeTrue())
+	})
+
+	It("returns true for unknown values (forward compatibility)", func() {
+		Expect(shouldHonorClusterTLSProfile("SomeFutureValue")).To(BeTrue())
+	})
+})

--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,128 @@
+package tlsconfig
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var _ = Describe("BuildTLSConfigFromCLIArgs", func() {
+	It("returns TLS 1.2 config with Intermediate ciphers", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS12",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(config.CipherSuites).To(HaveLen(2))
+		Expect(config.CipherSuites).To(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256))
+		Expect(config.CipherSuites).To(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384))
+	})
+
+	It("returns TLS 1.3 config with no cipher suites", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS13", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+		Expect(config.CipherSuites).To(BeNil())
+	})
+
+	It("returns TLS 1.0 config", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS10",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS10)))
+		Expect(config.CipherSuites).To(HaveLen(1))
+	})
+
+	It("ignores cipher suites for TLS 1.3", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS13",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+		Expect(config.CipherSuites).To(BeNil())
+	})
+
+	It("returns error for invalid TLS version", func() {
+		_, err := BuildTLSConfigFromCLIArgs("InvalidVersion", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid TLS version"))
+	})
+
+	It("skips unsupported cipher suites without error", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS12",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,FAKE_CIPHER")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.CipherSuites).To(HaveLen(1))
+		Expect(config.CipherSuites).To(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256))
+	})
+
+	It("returns error when all cipher suites are unsupported", func() {
+		_, err := BuildTLSConfigFromCLIArgs("VersionTLS12", "FAKE_CIPHER_1,FAKE_CIPHER_2")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("none of the specified cipher suites"))
+	})
+
+	It("handles empty cipher suites string for TLS 1.2", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS12", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(config.CipherSuites).To(BeNil())
+	})
+
+	It("trims whitespace from cipher suite names", func() {
+		config, err := BuildTLSConfigFromCLIArgs("VersionTLS12",
+			" TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.CipherSuites).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("getProfileSpec", func() {
+	It("returns the Old spec for the Old profile", func() {
+		spec, err := getProfileSpec(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS10))
+		Expect(spec.Ciphers).NotTo(BeEmpty())
+	})
+
+	It("returns the Intermediate spec for the Intermediate profile", func() {
+		spec, err := getProfileSpec(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS12))
+		Expect(spec.Ciphers).NotTo(BeEmpty())
+	})
+
+	It("returns the Modern spec for the Modern profile", func() {
+		spec, err := getProfileSpec(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS13))
+	})
+
+	It("returns the caller's spec for a Custom profile", func() {
+		profile := &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS12,
+					Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+				},
+			},
+		}
+		spec, err := getProfileSpec(profile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS12))
+		Expect(spec.Ciphers).To(ConsistOf("ECDHE-RSA-AES128-GCM-SHA256"))
+	})
+
+	It("returns an error for a Custom profile with no custom field", func() {
+		_, err := getProfileSpec(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Custom field is nil"))
+	})
+
+	It("falls back to Intermediate for an unknown profile type", func() {
+		spec, err := getProfileSpec(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileType("Unknown")})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(configv1.VersionTLS12))
+	})
+})

--- a/internal/tlsconfig/watcher.go
+++ b/internal/tlsconfig/watcher.go
@@ -1,0 +1,95 @@
+package tlsconfig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+// WatchForTLSProfileChanges watches the APIServer resource for TLS profile
+// and tlsAdherence changes. When a change is detected, it calls the provided
+// onChanged callback. The watcher compares spec.tlsSecurityProfile and
+// spec.tlsAdherence to avoid unnecessary restarts on unrelated APIServer
+// changes (e.g. status updates during node rollouts).
+func WatchForTLSProfileChanges(ctx context.Context, restConfig *rest.Config, onChanged func()) error {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("creating config client for TLS watcher: %w", err)
+	}
+
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("fetching initial APIServer config for TLS watcher: %w", err)
+	}
+
+	currentAdherence, err := fetchTLSAdherence(ctx, restConfig)
+	if err != nil {
+		return fmt.Errorf("fetching initial TLS adherence for watcher: %w", err)
+	}
+
+	go watchAPIServer(ctx, configClient, restConfig, apiserver.Spec.TLSSecurityProfile, currentAdherence, onChanged)
+	return nil
+}
+
+const watchReconnectInterval = 30 * time.Second
+
+func watchAPIServer(ctx context.Context, configClient configclientset.Interface, restConfig *rest.Config, currentProfile *configv1.TLSSecurityProfile, currentAdherence string, onChanged func()) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		w, err := configClient.ConfigV1().APIServers().Watch(ctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=cluster",
+		})
+		if err != nil {
+			log.Error(err, "failed to watch APIServer, retrying")
+			select {
+			case <-time.After(watchReconnectInterval):
+				continue
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		for event := range w.ResultChan() {
+			if event.Type != watch.Modified {
+				continue
+			}
+			updated, ok := event.Object.(*configv1.APIServer)
+			if !ok {
+				continue
+			}
+
+			profileChanged := !equality.Semantic.DeepEqual(currentProfile, updated.Spec.TLSSecurityProfile)
+
+			adherenceChanged := false
+			newAdherence, adhErr := fetchTLSAdherence(ctx, restConfig)
+			if adhErr != nil {
+				log.Error(adhErr, "unable to fetch TLS adherence, assuming unchanged")
+			} else {
+				adherenceChanged = newAdherence != currentAdherence
+			}
+
+			if !profileChanged && !adherenceChanged {
+				continue
+			}
+			log.Info("APIServer TLS configuration changed, shutting down to reload")
+			onChanged()
+			return
+		}
+
+		w.Stop()
+		if ctx.Err() != nil {
+			return
+		}
+		log.Info("watch on APIServer connection closed, reconnecting")
+	}
+}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

The Infrastructure Operator manages several pods, each serving TLS connections. These listeners must honor the cluster's TLS security profile:

   - infrastructure-operator webhook server (port 9443)
   - assisted-service REST API (port 8090)
   - assisted-service webhook (port 9443)
   - agentinstalladmission webhook (port 9443, via CLI flags)
   - assisted-image-service HTTPS (port 8080, via env vars)

The infrastructure-operator fetches the TLS profile from the APIServer resource at startup, applies it to its own webhook via TLSOpts, and watches for profile changes to trigger graceful shutdown.

For assisted-service, agentinstalladmission, and assisted-image-service, the operator pushes TLS settings via ConfigMap env vars, CLI flags, and StatefulSet env vars respectively. No watcher is needed in these pods as the operator handles restart and reconciliation.

TLS adherence (spec.tlsAdherence) is checked before applying the profile. Since our vendored openshift/api does not include the TLSAdherence type, the field is read via the dynamic/unstructured client. When adherence is empty or LegacyAdheringComponentsOnly, the default Intermediate profile is used. The watcher monitors both tlsSecurityProfile and tlsAdherence for changes.

Follows the Direct Go approach from the TLS Profile Compliance Remediation Guidance.

The image-service side of this change is in openshift/assisted-image-service#999.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for applying cluster-defined TLS profiles to HTTPS, webhook, image-service, and service endpoints.
  * TLS settings now update automatically when the cluster profile changes.
  * Added support for built-in and custom profiles, including minimum TLS versions and cipher suites.

* **Bug Fixes**
  * Unavailable cluster profiles fall back to secure defaults.
  * Unsupported cipher suites are filtered, while invalid TLS configurations prevent startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->