### PR TITLE
allow cluster-id to be empty

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6703,12 +6703,23 @@ func (b *bareMetalInventory) V2DownloadInfraEnvFiles(ctx context.Context, params
 	switch params.FileName {
 	case "discovery.ign":
 		if common.ImageTypeValue(infraEnv.Type) == models.ImageTypeDisconnectedIso {
-			cluster, clusterErr := common.GetClusterFromDB(b.db, infraEnv.ClusterID, common.SkipEagerLoading)
-			if clusterErr != nil {
-				b.log.WithError(clusterErr).Errorf("Failed to get cluster for disconnected ignition generation, infraEnv %s", infraEnv.ID)
-				return common.GenerateErrorResponder(clusterErr)
+			openshiftVersion := infraEnv.OpenshiftVersion
+			clusterName := swag.StringValue(infraEnv.Name)
+			if clusterName == "" {
+				clusterName = "disconnected-cluster"
 			}
-			content, err = b.disconnectedIgnitionGenerator.GenerateDisconnectedIgnition(ctx, infraEnv, cluster.OpenshiftVersion, cluster.Name)
+
+			if infraEnv.ClusterID != "" {
+				cluster, clusterErr := common.GetClusterFromDB(b.db, infraEnv.ClusterID, common.SkipEagerLoading)
+				if clusterErr != nil {
+					b.log.WithError(clusterErr).Errorf("Failed to get cluster for disconnected ignition generation, infraEnv %s", infraEnv.ID)
+					return common.GenerateErrorResponder(clusterErr)
+				}
+				openshiftVersion = cluster.OpenshiftVersion
+				clusterName = cluster.Name
+			}
+
+			content, err = b.disconnectedIgnitionGenerator.GenerateDisconnectedIgnition(ctx, infraEnv, openshiftVersion, clusterName)
 			if err != nil {
 				b.log.WithError(err).Error("Failed to generate disconnected ignition")
 				return common.GenerateErrorResponder(err)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13358,14 +13358,42 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 		Expect(ignition["version"]).To(Equal("3.2.0"))
 	})
 
-	It("returns error when infraEnv has disconnected-iso type but is not bound to a cluster", func() {
-		imageType := models.ImageTypeDisconnectedIso
-		err := db.Model(&common.InfraEnv{}).Where("id = ?", infraEnvID).Update("type", imageType).Error
+	It("returns OVE ignition for discovery.ign when InfraEnv has disconnected-iso type and is not bound to a cluster", func() {
+		var infraEnv common.InfraEnv
+		Expect(db.First(&infraEnv, "id = ?", infraEnvID).Error).To(Succeed())
+		infraEnv.Type = common.ImageTypePtr(models.ImageTypeDisconnectedIso)
+		infraEnv.ClusterID = ""
+		Expect(db.Save(&infraEnv).Error).To(Succeed())
+
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.DefaultCPUArchitecture),
+				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				URL:              swag.String("test-url"),
+				Version:          swag.String("4.16.0"),
+			}, nil)
+		mockInstallerCache.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(installercache.NewMockRelease("/tmp/test", mockEvents), nil)
+		mockEvents.EXPECT().V2AddMetricsEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockExecuter.EXPECT().Execute(gomock.Any(), "agent", "create", "unconfigured-ignition", gomock.Any(), gomock.Any()).
+			DoAndReturn(func(command string, args ...string) (string, string, int) {
+				tempDir := args[len(args)-1]
+				mockIgnition := `{"ignition": {"version": "3.2.0"},"storage":{"files":[]}}`
+				err := os.WriteFile(filepath.Join(tempDir, "unconfigured-agent.ign"),
+					[]byte(mockIgnition), 0600)
+				Expect(err).NotTo(HaveOccurred())
+				return "", "", 0
+			})
+
+		body := getResponseData("discovery.ign", false, nil, "", infraEnvID)
+
+		var ignitionConfig map[string]interface{}
+		err := json.Unmarshal(body, &ignitionConfig)
 		Expect(err).NotTo(HaveOccurred())
 
-		params := installer.V2DownloadInfraEnvFilesParams{InfraEnvID: infraEnvID, FileName: "discovery.ign"}
-		response := bm.V2DownloadInfraEnvFiles(ctx, params)
-		verifyApiError(response, http.StatusNotFound)
+		ignition, ok := ignitionConfig["ignition"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(ignition["version"]).To(Equal("3.2.0"))
 	})
 
 	It("returns not found with a non-existant InfraEnv", func() {

--- a/internal/ignition/disconnected.go
+++ b/internal/ignition/disconnected.go
@@ -64,11 +64,6 @@ func (g *DisconnectedIgnitionGenerator) GenerateDisconnectedIgnition(ctx context
 	log := logutil.FromContext(ctx, g.log)
 	log.Infof("GenerateDisconnectedIgnition called for infraEnv %s", *infraEnv.ID)
 
-	// For disconnected ISOs, we require the infraEnv to be bound to a cluster
-	if infraEnv.ClusterID == "" {
-		return "", errors.Errorf("InfraEnv %s is not bound to a cluster, which is required for disconnected ignition generation", *infraEnv.ID)
-	}
-
 	disconnectedManifestsDir, err := createDisconnectedManifestsDir(g.workDir, infraEnv)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create disconnected manifests directory")

--- a/internal/ignition/disconnected_test.go
+++ b/internal/ignition/disconnected_test.go
@@ -200,12 +200,38 @@ var _ = Describe("Disconnected Ignition", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should fail when ClusterID is empty", func() {
+		It("should succeed when ClusterID is empty", func() {
 			infraEnv.ClusterID = ""
 
+			releaseImage := &models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.DefaultCPUArchitecture),
+				OpenshiftVersion: swag.String("4.16.0"),
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64"),
+				Version:          swag.String("4.16.0"),
+			}
+
+			mockVersionsHandler.EXPECT().GetReleaseImage(ctx, clusterVersion, common.DefaultCPUArchitecture, infraEnv.PullSecret).Return(releaseImage, nil)
+
+			mockEvents.EXPECT().V2AddMetricsEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			mockInstallerCache.EXPECT().Get(ctx, *releaseImage.URL, "", infraEnv.PullSecret, gomock.Any(), clusterVersion, infraEnv.ClusterID).Return(mockRelease, nil)
+
+			mockExecuter.EXPECT().Execute(
+				mockRelease.Path,
+				"agent",
+				"create",
+				"unconfigured-ignition",
+				"--dir",
+				gomock.Any(),
+			).DoAndReturn(func(command string, args ...string) (string, string, int) {
+				oveDir := args[4]
+				ignitionContent := `{"ignition":{"version":"3.2.0"}}`
+				err := os.WriteFile(filepath.Join(oveDir, "unconfigured-agent.ign"), []byte(ignitionContent), 0600)
+				Expect(err).NotTo(HaveOccurred())
+				return "success", "", 0
+			})
+
 			_, err := generator.GenerateDisconnectedIgnition(ctx, infraEnv, cluster.OpenshiftVersion, cluster.Name)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("InfraEnv test-infra-env-id is not bound to a cluster, which is required for disconnected ignition generation"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fail when cluster version is empty", func() {

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -103,8 +103,12 @@ type Release struct {
 
 // Cleanup is called to signal that the caller has finished using the release and that resources may be released.
 func (rl *Release) Cleanup(ctx context.Context) error {
+	var clusterID *strfmt.UUID
+	if rl.clusterID != "" {
+		clusterID = &rl.clusterID
+	}
 	rl.eventsHandler.V2AddMetricsEvent(
-		ctx, &rl.clusterID, nil, nil, "", models.EventSeverityInfo,
+		ctx, clusterID, nil, nil, "", models.EventSeverityInfo,
 		metricEventInstallerCacheRelease,
 		time.Now(),
 		"release_id", rl.releaseID,


### PR DESCRIPTION
In case of downloading offline iso empty cluster-id shall be allowed, since only having an infra-env is mandatory

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disconnected ignition can now be generated for InfraEnvs without a bound cluster.
  * Uses the InfraEnv’s OpenShift version and name, with a fallback disconnected-cluster name.

* **Bug Fixes**
  * Prevented failures when generating disconnected ignition without a cluster association.
  * Improved cleanup metrics handling when no cluster is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->