### PR TITLE
MGMT-24831: Add ntpSources field to InfraEnv and AgentClusterInstall CRDs

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -140,6 +140,11 @@ type AgentClusterInstallSpec struct {
 	// +optional
 	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 
+	// NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+	// configuration for the cluster hosts. Mutually exclusive with the InfraEnv's AdditionalNTPSources.
+	// +optional
+	NTPSources []string `json:"ntpSources,omitempty"`
+
 	// ProvisionRequirements defines configuration for when the installation is ready to be launched automatically.
 	ProvisionRequirements ProvisionRequirements `json:"provisionRequirements"`
 

--- a/api/hiveextension/v1beta1/zz_generated.deepcopy.go
+++ b/api/hiveextension/v1beta1/zz_generated.deepcopy.go
@@ -111,6 +111,11 @@ func (in *AgentClusterInstallSpec) DeepCopyInto(out *AgentClusterInstallSpec) {
 		copy(*out, *in)
 	}
 	in.Networking.DeepCopyInto(&out.Networking)
+	if in.NTPSources != nil {
+		in, out := &in.NTPSources, &out.NTPSources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.ProvisionRequirements = in.ProvisionRequirements
 	if in.ControlPlane != nil {
 		in, out := &in.ControlPlane, &out.ControlPlane

--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -66,6 +66,11 @@ type InfraEnvSpec struct {
 	// +optional
 	AdditionalNTPSources []string `json:"additionalNTPSources,omitempty"`
 
+	// NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+	// configuration for hosts in this InfraEnv. Mutually exclusive with AdditionalNTPSources.
+	// +optional
+	NTPSources []string `json:"ntpSources,omitempty"`
+
 	// SSHAuthorizedKey is a SSH public keys that will be added to all agents for use in debugging.
 	// +optional
 	SSHAuthorizedKey string `json:"sshAuthorizedKey,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -981,6 +981,11 @@ func (in *InfraEnvSpec) DeepCopyInto(out *InfraEnvSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NTPSources != nil {
+		in, out := &in.NTPSources, &out.NTPSources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PullSecretRef != nil {
 		in, out := &in.PullSecretRef, &out.PullSecretRef
 		*out = new(corev1.LocalObjectReference)

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -240,6 +240,13 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for hosts in this InfraEnv. Mutually exclusive with AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               osImageVersion:
                 description: |-
                   OSImageVersion is the version of OS image to use when generating the InfraEnv.

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -533,6 +533,13 @@ spec:
                       For single-node installations (none or external platform), set to true or leave empty.
                     type: boolean
                 type: object
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for the cluster hosts. Mutually exclusive with the InfraEnv's AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               platformType:
                 description: PlatformType is the name for the specific platform upon
                   which to perform the installation.

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -648,6 +648,13 @@ spec:
                       For single-node installations (none or external platform), set to true or leave empty.
                     type: boolean
                 type: object
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for the cluster hosts. Mutually exclusive with the InfraEnv's AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               platformType:
                 description: PlatformType is the name for the specific platform upon
                   which to perform the installation.
@@ -3415,6 +3422,13 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for hosts in this InfraEnv. Mutually exclusive with AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               osImageVersion:
                 description: |-
                   OSImageVersion is the version of OS image to use when generating the InfraEnv.

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
@@ -250,6 +250,13 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for hosts in this InfraEnv. Mutually exclusive with AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               osImageVersion:
                 description: |-
                   OSImageVersion is the version of OS image to use when generating the InfraEnv.

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -533,6 +533,13 @@ spec:
                       For single-node installations (none or external platform), set to true or leave empty.
                     type: boolean
                 type: object
+              ntpSources:
+                description: |-
+                  NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+                  configuration for the cluster hosts. Mutually exclusive with the InfraEnv's AdditionalNTPSources.
+                items:
+                  type: string
+                type: array
               platformType:
                 description: PlatformType is the name for the specific platform upon
                   which to perform the installation.

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1117,6 +1117,11 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(
 	sshPublicKey := strings.TrimSpace(clusterInstall.Spec.SSHPublicKey)
 	updateString(sshPublicKey, cluster.SSHPublicKey, &params.SSHPublicKey)
 
+	if len(clusterInstall.Spec.NTPSources) > 0 {
+		ntpSources := strings.Join(clusterInstall.Spec.NTPSources, ",")
+		updateString(ntpSources, cluster.NtpSources, &params.NtpSources)
+	}
+
 	// Update ignition endpoint if needed
 	shouldUpdate, err := r.updateIgnitionInUpdateParams(ctx, log, clusterInstall, cluster, params)
 	if err != nil {
@@ -1578,6 +1583,10 @@ func CreateClusterParams(clusterDeployment *hivev1.ClusterDeployment, clusterIns
 	if clusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents == 1 &&
 		clusterInstall.Spec.ProvisionRequirements.WorkerAgents == 0 {
 		clusterParams.HighAvailabilityMode = swag.String(HighAvailabilityModeNone)
+	}
+
+	if len(clusterInstall.Spec.NTPSources) > 0 {
+		clusterParams.NtpSources = swag.String(strings.Join(clusterInstall.Spec.NTPSources, ","))
 	}
 
 	if hyperthreadingInSpec(clusterInstall) {

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -788,6 +788,22 @@ var _ = Describe("cluster reconcile", func() {
 				validateCreation(cluster)
 			})
 
+			It("create new cluster with exclusive ntpSources", func() {
+				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Do(func(arg1, arg2, arg3 interface{}, params installer.V2RegisterClusterParams) {
+						Expect(swag.StringValue(params.NewClusterParams.NtpSources)).To(Equal("ntp1.example.com,ntp2.example.com"))
+					}).Return(clusterReply, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
+
+				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+				defaultAgentClusterInstallSpec.NTPSources = []string{"ntp1.example.com", "ntp2.example.com"}
+				aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cluster)
+				Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+				validateCreation(cluster)
+			})
+
 			It("create new cluster with IgnitionEndpoint CaCertificate", func() {
 				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -3566,6 +3582,45 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Reason).To(Equal(hiveext.ClusterNotReadyReason))
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Message).To(Equal(hiveext.ClusterNotReadyMsg))
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionFalse))
+		})
+
+		It("update cluster with exclusive ntpSources", func() {
+			backEndCluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:               &sId,
+					Name:             clusterName,
+					OpenshiftVersion: "4.8",
+					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:           swag.String(models.ClusterStatusInsufficient),
+					IngressVips:      common.TestIPv4Networking.IngressVips,
+					APIVips:          common.TestIPv4Networking.APIVips,
+					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
+					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
+				},
+				PullSecret: testPullSecretVal,
+			}
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
+
+			updateReply := getDefaultTestCluster()
+
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, param installer.V2UpdateClusterParams, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
+					Expect(swag.StringValue(param.ClusterUpdateParams.NtpSources)).To(Equal("ntp1.example.com,ntp2.example.com"))
+				}).Return(updateReply, nil)
+
+			aci.Spec.NTPSources = []string{"ntp1.example.com", "ntp2.example.com"}
+			Expect(c.Update(ctx, aci)).Should(BeNil())
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			aci = getTestClusterInstall()
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterSyncedOkReason))
 		})
 
 		It("update disk encryption configuration", func() {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -184,6 +184,9 @@ func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.Fiel
 	if len(infraEnv.Spec.AdditionalNTPSources) > 0 {
 		updateParams.InfraEnvUpdateParams.AdditionalNtpSources = swag.String(strings.Join(infraEnv.Spec.AdditionalNTPSources[:], ","))
 	}
+	if len(infraEnv.Spec.NTPSources) > 0 {
+		updateParams.InfraEnvUpdateParams.NtpSources = swag.String(strings.Join(infraEnv.Spec.NTPSources[:], ","))
+	}
 	imageType := infraenv.GetInfraEnvIsoImageType(log, infraEnv.Spec.CpuArchitecture, infraEnv.Spec.ImageType, r.Config.ImageType)
 	if imageType != common.ImageTypeValue(internalInfraEnv.Type) {
 		updateParams.InfraEnvUpdateParams.ImageType = imageType
@@ -474,6 +477,9 @@ func CreateInfraEnvParams(infraEnv *aiv1beta1.InfraEnv, imageType models.ImageTy
 
 	if len(infraEnv.Spec.AdditionalNTPSources) > 0 {
 		createParams.InfraenvCreateParams.AdditionalNtpSources = swag.String(strings.Join(infraEnv.Spec.AdditionalNTPSources[:], ","))
+	}
+	if len(infraEnv.Spec.NTPSources) > 0 {
+		createParams.InfraenvCreateParams.NtpSources = swag.String(strings.Join(infraEnv.Spec.NTPSources[:], ","))
 	}
 
 	if len(infraEnv.Spec.KernelArguments) > 0 {

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -928,6 +928,59 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(res).To(Equal(ctrl.Result{Requeue: false}))
 	})
 
+	It("create image with exclusive ntpSources", func() {
+		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace,
+			aiv1beta1.InfraEnvSpec{
+				NTPSources: []string{"ntp1.example.com", "ntp2.example.com"},
+				ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+				PullSecretRef: &corev1.LocalObjectReference{
+					Name: "pull-secret",
+				},
+			})
+		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
+
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), nil, nil).
+			Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration) {
+				Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
+				Expect(swag.StringValue(params.InfraEnvUpdateParams.NtpSources)).To(Equal("ntp1.example.com,ntp2.example.com"))
+			}).Return(&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}}, nil).Times(1)
+
+		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{Requeue: false}))
+	})
+
+	It("register new infraEnv with exclusive ntpSources", func() {
+		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		mockInstallerInternal.EXPECT().RegisterInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, kubeKey *types.NamespacedName, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration, params installer.RegisterInfraEnvParams) {
+				Expect(swag.StringValue(params.InfraenvCreateParams.NtpSources)).To(Equal("ntp1.example.com,ntp2.example.com"))
+			}).Return(backendInfraEnv, nil)
+
+		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
+			NTPSources: []string{"ntp1.example.com", "ntp2.example.com"},
+			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+			PullSecretRef: &corev1.LocalObjectReference{
+				Name: "pull-secret",
+			},
+		})
+		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
+
+		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{}))
+	})
+
 	It("create image with ignition config override", func() {
 		ignitionConfigOverride := `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -140,6 +140,11 @@ type AgentClusterInstallSpec struct {
 	// +optional
 	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 
+	// NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+	// configuration for the cluster hosts. Mutually exclusive with the InfraEnv's AdditionalNTPSources.
+	// +optional
+	NTPSources []string `json:"ntpSources,omitempty"`
+
 	// ProvisionRequirements defines configuration for when the installation is ready to be launched automatically.
 	ProvisionRequirements ProvisionRequirements `json:"provisionRequirements"`
 

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/zz_generated.deepcopy.go
@@ -111,6 +111,11 @@ func (in *AgentClusterInstallSpec) DeepCopyInto(out *AgentClusterInstallSpec) {
 		copy(*out, *in)
 	}
 	in.Networking.DeepCopyInto(&out.Networking)
+	if in.NTPSources != nil {
+		in, out := &in.NTPSources, &out.NTPSources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.ProvisionRequirements = in.ProvisionRequirements
 	if in.ControlPlane != nil {
 		in, out := &in.ControlPlane, &out.ControlPlane

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -66,6 +66,11 @@ type InfraEnvSpec struct {
 	// +optional
 	AdditionalNTPSources []string `json:"additionalNTPSources,omitempty"`
 
+	// NTPSources is a list of NTP sources (hostname or IP) to be used as the exclusive NTP
+	// configuration for hosts in this InfraEnv. Mutually exclusive with AdditionalNTPSources.
+	// +optional
+	NTPSources []string `json:"ntpSources,omitempty"`
+
 	// SSHAuthorizedKey is a SSH public keys that will be added to all agents for use in debugging.
 	// +optional
 	SSHAuthorizedKey string `json:"sshAuthorizedKey,omitempty"`

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/zz_generated.deepcopy.go
@@ -981,6 +981,11 @@ func (in *InfraEnvSpec) DeepCopyInto(out *InfraEnvSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NTPSources != nil {
+		in, out := &in.NTPSources, &out.NTPSources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PullSecretRef != nil {
 		in, out := &in.PullSecretRef, &out.PullSecretRef
 		*out = new(corev1.LocalObjectReference)


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Adds a new ntpSources field to the InfraEnv and AgentClusterInstall CRDs, bringing the exclusive NTP feature (already available in the SaaS REST API via PR #10408) to the ACM/Kube-API flow.

When ntpSources is set, hosts use only the specified NTP servers instead of the default pool, in both the discovery and installation phases.

The field is mutually exclusive with additionalNTPSources.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring exclusive NTP sources for cluster and infrastructure hosts.
  - NTP sources can be specified using hostnames or IP addresses.
  - Configured sources are applied during creation, registration, and updates.
  - Exclusive NTP settings cannot be combined with additional NTP source configuration.

- **Tests**
  - Added coverage for NTP source propagation during creation, registration, and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->