### PR TITLE
MGMT-24352: Reset finalizing timeout on transition from installing-pending-user-action

### DIFF
--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -884,6 +884,13 @@ func addExtraParams(cluster *common.Cluster, srcState string) ([]interface{}, er
 		if srcState == models.ClusterStatusPreparingForInstallation {
 			extra = append(extra, initProgressParamsInstallingStage()...)
 		}
+	case models.ClusterStatusFinalizing:
+		// Reset the finalizing stage timeout when returning from pending-user-action
+		// to give the cluster a fresh timeout window
+		if srcState == models.ClusterStatusInstallingPendingUserAction {
+			extra = append(extra, "progress_finalizing_stage_started_at", strfmt.DateTime(time.Now()))
+			extra = append(extra, "progress_finalizing_stage_timed_out", false)
+		}
 	}
 	return extra, nil
 }

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -5305,3 +5305,152 @@ func makeFreeNetworksAddressesStr(elems ...*models.FreeNetworkAddresses) string 
 	Expect(err).ToNot(HaveOccurred())
 	return string(b)
 }
+
+var _ = Describe("Finalizing stage timeout reset", func() {
+	var (
+		ctx          = context.Background()
+		db           *gorm.DB
+		clusterApi   *Manager
+		mockEvents   *eventsapi.MockHandler
+		mockHostAPI  *host.MockAPI
+		mockMetric   *metrics.MockAPI
+		mockS3Api    *s3wrapper.MockAPI
+		ctrl         *gomock.Controller
+		dbName       string
+		clusterId    strfmt.UUID
+		operatorsApi operators.API
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		ctrl = gomock.NewController(GinkgoT())
+		mockEvents = eventsapi.NewMockHandler(ctrl)
+		mockHostAPI = host.NewMockAPI(ctrl)
+		mockMetric = metrics.NewMockAPI(ctrl)
+		mockS3Api = s3wrapper.NewMockAPI(ctrl)
+		operatorsApi = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil)
+		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
+			commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, mockHostAPI, mockMetric, nil, nil,
+			operatorsApi, nil, mockS3Api, nil, nil, nil, false)
+		clusterId = strfmt.UUID(uuid.New().String())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("should reset finalizing stage fields on transition from InstallingPendingUserAction to Finalizing", func() {
+		oldTimestamp := time.Now().Add(-2 * time.Hour)
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID:               &clusterId,
+				Status:           swag.String(models.ClusterStatusInstallingPendingUserAction),
+				StatusInfo:       swag.String("Waiting for user action"),
+				BaseDNSDomain:    "test.com",
+				PullSecretSet:    true,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+				StatusUpdatedAt:  strfmt.DateTime(time.Now()),
+				InstallStartedAt: strfmt.DateTime(time.Now().Add(-1 * time.Hour)),
+				MachineNetworks:  common.TestIPv4Networking.MachineNetworks,
+				APIVips:          common.TestIPv4Networking.APIVips,
+				IngressVips:      common.TestIPv4Networking.IngressVips,
+			},
+		}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+		Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterId.String()).Updates(map[string]interface{}{
+			"progress_finalizing_stage_started_at": oldTimestamp,
+			"progress_finalizing_stage_timed_out":  true,
+		}).Error).ShouldNot(HaveOccurred())
+
+		hid1, hid2, hid3 := strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String())
+		hid4, hid5, hid6 := strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String())
+
+		hosts := []models.Host{
+			{ID: &hid1, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid2, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid3, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid4, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+			{ID: &hid5, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+			{ID: &hid6, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstallingInProgress), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+		}
+
+		for i := range hosts {
+			Expect(db.Create(&hosts[i]).Error).ShouldNot(HaveOccurred())
+		}
+
+		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
+			eventstest.WithClusterIdMatcher(clusterId.String()))).AnyTimes()
+
+		cluster = getClusterFromDB(clusterId, db)
+		clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clusterAfterRefresh).ToNot(BeNil())
+		Expect(swag.StringValue(clusterAfterRefresh.Status)).To(Equal(models.ClusterStatusFinalizing))
+
+		var progressStartedAt time.Time
+		var progressTimedOut bool
+		row := db.Raw("SELECT progress_finalizing_stage_started_at, progress_finalizing_stage_timed_out FROM clusters WHERE id = ?", clusterId.String()).Row()
+		Expect(row.Scan(&progressStartedAt, &progressTimedOut)).ShouldNot(HaveOccurred())
+
+		Expect(progressStartedAt).To(BeTemporally("~", time.Now(), 5*time.Second))
+		Expect(progressStartedAt).NotTo(BeTemporally("~", oldTimestamp, 1*time.Minute))
+		Expect(progressTimedOut).To(BeFalse())
+	})
+
+	It("should NOT reset finalizing stage fields on transition from Installing to Finalizing", func() {
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID:               &clusterId,
+				Status:           swag.String(models.ClusterStatusInstalling),
+				StatusInfo:       swag.String("Installing"),
+				BaseDNSDomain:    "test.com",
+				PullSecretSet:    true,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+				StatusUpdatedAt:  strfmt.DateTime(time.Now()),
+				InstallStartedAt: strfmt.DateTime(time.Now().Add(-1 * time.Hour)),
+				MachineNetworks:  common.TestIPv4Networking.MachineNetworks,
+				APIVips:          common.TestIPv4Networking.APIVips,
+				IngressVips:      common.TestIPv4Networking.IngressVips,
+			},
+		}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+		hid1, hid2, hid3 := strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String())
+		hid4, hid5 := strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String())
+
+		hosts := []models.Host{
+			{ID: &hid1, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid2, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid3, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+			{ID: &hid4, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+			{ID: &hid5, InfraEnvID: clusterId, ClusterID: &clusterId, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+		}
+
+		for i := range hosts {
+			Expect(db.Create(&hosts[i]).Error).ShouldNot(HaveOccurred())
+		}
+
+		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
+			eventstest.WithClusterIdMatcher(clusterId.String()))).AnyTimes()
+
+		cluster = getClusterFromDB(clusterId, db)
+		clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clusterAfterRefresh).ToNot(BeNil())
+		Expect(swag.StringValue(clusterAfterRefresh.Status)).To(Equal(models.ClusterStatusFinalizing))
+
+		var progressStartedAt *time.Time
+		var progressTimedOut *bool
+		row := db.Raw("SELECT progress_finalizing_stage_started_at, progress_finalizing_stage_timed_out FROM clusters WHERE id = ?", clusterId.String()).Row()
+		err = row.Scan(&progressStartedAt, &progressTimedOut)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		if progressStartedAt != nil {
+			Expect(*progressStartedAt).NotTo(BeTemporally("~", time.Now(), 5*time.Second))
+		}
+	})
+})


### PR DESCRIPTION
Replace https://github.com/openshift/assisted-service/pull/10753

Manual cherrypick of https://github.com/openshift/assisted-service/pull/10293

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
