### PR TITLE
[release-ocm-2.13] ACM-40440: Bump Go toolchain to go1.25.11 to fix stdlib CVEs

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/api
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/itchyny/gojq v0.12.8

--- a/client/go.mod
+++ b/client/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/client
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/go-openapi/errors v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/IBM/netaddr v1.5.0

--- a/models/go.mod
+++ b/models/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/assisted-service/models
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/go-openapi/errors v0.22.0


### PR DESCRIPTION
Bump Go toolchain from go1.25.9 to go1.25.11 in all go.mod files.

### Fixed CVEs
- CVE-2026-39820 (stdlib, CVSS 7.5)
- CVE-2026-33814 (stdlib, CVSS 7.5)
- CVE-2026-33811 (stdlib, CVSS 7.5)
- CVE-2026-42499 (stdlib, CVSS 7.5)
- CVE-2026-27145 (stdlib, CVSS 7.5)
- CVE-2026-42504 (stdlib, CVSS 7.5)
- CVE-2026-39822 (stdlib, CVSS 7.5)