### PR TITLE
ACM-40510: Fix infrastructure-operator NetworkPolicy egress to kubernetes API

### DIFF
--- a/config/manager/infrastructure-operator-networkpolicy.yaml
+++ b/config/manager/infrastructure-operator-networkpolicy.yaml
@@ -40,10 +40,10 @@ spec:
           port: 5353
     # Kubernetes API
     - to:
-        - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              component: apiserver
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 6443
@@ -51,8 +51,6 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
-            except:
-              - 169.254.169.254/32
         - ipBlock:
             cidr: ::/0
       ports:

--- a/deploy/olm-catalog/manifests/infrastructure-operator-networkpolicy.yaml
+++ b/deploy/olm-catalog/manifests/infrastructure-operator-networkpolicy.yaml
@@ -40,10 +40,10 @@ spec:
           port: 5353
     # Kubernetes API
     - to:
-        - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              component: apiserver
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 6443
@@ -51,8 +51,6 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
-            except:
-              - 169.254.169.254/32
         - ipBlock:
             cidr: ::/0
       ports:


### PR DESCRIPTION
## Summary

Fix infrastructure-operator CrashLoopBackOff on OCP 5.0 caused by NetworkPolicy egress rule using `component: apiserver` podSelector that doesn't match OCP 5.0 kube-apiserver pods.

**Root cause:** The egress rule targeted pods with label `component: apiserver`, but OCP 5.0 kube-apiserver uses `apiserver=true, app=openshift-kube-apiserver` instead. Additionally, OVN-Kubernetes evaluates NetworkPolicy after DNAT, so connecting to `kubernetes.default.svc:443` gets translated to port 6443 - the existing port 443 rule didn't cover it.

**Fix:** Replace the `podSelector` rule with a broad `ipBlock: 0.0.0.0/0` on port 6443, matching the pattern already used by the other NetworkPolicies (assisted-service, image-service, webhook) created in operator code. Also removed the ineffective `169.254.169.254/32` metadata endpoint exclusion (metadata uses port 80, not 443).


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow Kubernetes API traffic over TCP port 6443 across IPv4 and IPv6 addresses.
  * Restored HTTPS access to the metadata service address `169.254.169.254`.
  * Applied the same networking updates across deployment configurations for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->