### PR TITLE
MGMT-25066: Add continuous node label reconciliation in InfraEnv controller

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -474,7 +474,7 @@ func (r *InfraEnvReconciler) reconcileNodeLabelPropagation(ctx context.Context, 
 		agent := &agents.Items[i]
 		patch := client.MergeFrom(agent.DeepCopy())
 
-		if PropagateInfraEnvNodeLabels(log, infraEnv, agent) {
+		if propagateInfraEnvNodeLabels(log, infraEnv, agent) {
 			if err := r.Patch(ctx, agent, patch); err != nil {
 				log.WithError(err).Errorf("failed to patch Agent %s/%s with propagated node labels",
 					agent.Namespace, agent.Name)

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -127,7 +127,8 @@ func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request
 	}
 
 	if err := r.reconcileNodeLabelPropagation(ctx, log, infraEnv); err != nil {
-		log.WithError(err).Error("failed to reconcile node label propagation")
+		log.WithError(err).Error("failed to reconcile node label propagation, will retry")
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterPerRecoverableError}, nil
 	}
 
 	return r.reconcileInfraEnv(ctx, log, infraEnv)
@@ -469,6 +470,7 @@ func (r *InfraEnvReconciler) reconcileNodeLabelPropagation(ctx context.Context, 
 		return errors.Wrapf(err, "failed to list Agents for InfraEnv %s/%s", infraEnv.Namespace, infraEnv.Name)
 	}
 
+	var patchErrors []error
 	for i := range agents.Items {
 		agent := &agents.Items[i]
 		patch := client.MergeFrom(agent.DeepCopy())
@@ -477,12 +479,16 @@ func (r *InfraEnvReconciler) reconcileNodeLabelPropagation(ctx context.Context, 
 			if err := r.Patch(ctx, agent, patch); err != nil {
 				log.WithError(err).Errorf("failed to patch Agent %s/%s with propagated node labels",
 					agent.Namespace, agent.Name)
-				return err
+				patchErrors = append(patchErrors, err)
+				continue
 			}
 			log.Infof("propagated node labels to Agent %s/%s", agent.Namespace, agent.Name)
 		}
 	}
 
+	if len(patchErrors) > 0 {
+		return errors.Errorf("failed to patch %d Agent(s) during node label propagation", len(patchErrors))
+	}
 	return nil
 }
 

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -96,6 +96,7 @@ type InfraEnvReconciler struct {
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=nmstateconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch
 
 func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx := addRequestIdIfNeeded(origCtx)
@@ -123,6 +124,10 @@ func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request
 
 	if err := r.ensureFinalizer(ctx, log, infraEnv); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileNodeLabelPropagation(ctx, log, infraEnv); err != nil {
+		log.WithError(err).Error("failed to reconcile node label propagation")
 	}
 
 	return r.reconcileInfraEnv(ctx, log, infraEnv)
@@ -451,6 +456,34 @@ func (r *InfraEnvReconciler) reconcileInfraEnv(ctx context.Context, log logrus.F
 		return ctrl.Result{Requeue: requeue}, nil
 	}
 	return r.updateInfraEnvStatus(ctx, log, infraEnv, cluster)
+}
+
+// reconcileNodeLabelPropagation lists all Agents belonging to this InfraEnv and
+// propagates designated node labels from the InfraEnv to each Agent's spec.nodeLabels.
+// This ensures that label changes on the InfraEnv are continuously reflected on all
+// associated Agents, not only at Agent creation time.
+func (r *InfraEnvReconciler) reconcileNodeLabelPropagation(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) error {
+	agents := &aiv1beta1.AgentList{}
+	if err := r.List(ctx, agents, client.InNamespace(infraEnv.Namespace),
+		client.MatchingLabels{aiv1beta1.InfraEnvNameLabel: infraEnv.Name}); err != nil {
+		return errors.Wrapf(err, "failed to list Agents for InfraEnv %s/%s", infraEnv.Namespace, infraEnv.Name)
+	}
+
+	for i := range agents.Items {
+		agent := &agents.Items[i]
+		patch := client.MergeFrom(agent.DeepCopy())
+
+		if PropagateInfraEnvNodeLabels(log, infraEnv, agent) {
+			if err := r.Patch(ctx, agent, patch); err != nil {
+				log.WithError(err).Errorf("failed to patch Agent %s/%s with propagated node labels",
+					agent.Namespace, agent.Name)
+				return err
+			}
+			log.Infof("propagated node labels to Agent %s/%s", agent.Namespace, agent.Name)
+		}
+	}
+
+	return nil
 }
 
 func CreateInfraEnvParams(infraEnv *aiv1beta1.InfraEnv, imageType models.ImageType, pullSecret string, clusterID *strfmt.UUID, openshiftVersion string) installer.RegisterInfraEnvParams {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -474,6 +474,19 @@ func (r *InfraEnvReconciler) reconcileNodeLabelPropagation(ctx context.Context, 
 		agent := &agents.Items[i]
 		patch := client.MergeFrom(agent.DeepCopy())
 
+		// BMH controller owns nodeLabels for BMH-managed Agents — skip propagation
+		// but clean up any stale inherited annotation
+		if _, hasBMH := agent.ObjectMeta.Labels[AGENT_BMH_LABEL]; hasBMH {
+			if clearInheritedAnnotation(agent) {
+				if err := r.Patch(ctx, agent, patch); err != nil {
+					log.WithError(err).Errorf("failed to clear inherited annotation on BMH-managed Agent %s/%s",
+						agent.Namespace, agent.Name)
+					patchErrors = append(patchErrors, err)
+				}
+			}
+			continue
+		}
+
 		if propagateInfraEnvNodeLabels(log, infraEnv, agent) {
 			if err := r.Patch(ctx, agent, patch); err != nil {
 				log.WithError(err).Errorf("failed to patch Agent %s/%s with propagated node labels",

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -96,7 +96,6 @@ type InfraEnvReconciler struct {
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=nmstateconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;patch
 
 func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx := addRequestIdIfNeeded(origCtx)

--- a/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
@@ -305,5 +305,110 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("custom", "value"))
 			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
 		})
+
+		It("does not overwrite after user takes ownership of previously inherited label", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			// First reconcile: inherit the label
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("nyc"))
+
+			// User manually overrides the label on the Agent
+			agent.Spec.NodeLabels["site"] = "user-override"
+			delete(agent.GetAnnotations(), InheritedNodeLabelsAnnotation)
+			Expect(c.Update(ctx, agent)).To(Succeed())
+
+			// Second reconcile: should NOT overwrite user's value
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("user-override"))
+		})
+
+		It("handles stale inherited annotation from a different InfraEnv", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			// Agent has a stale inherited annotation with a key this InfraEnv doesn't propagate
+			createAgent("agent-1",
+				map[string]string{"region": "eu-west", "site": "old-site"},
+				map[string]string{InheritedNodeLabelsAnnotation: "region,site"},
+			)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			// "region" was inherited from old InfraEnv but not in current propagation list — removed
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("region"))
+			// "site" is in current propagation list and was previously inherited — updated
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("nyc"))
+		})
+
+		It("handles last-write-wins on sequential reconciliations with different states", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			// First reconcile with original state
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("nyc"))
+			Expect(agent.Spec.NodeLabels["zone"]).To(Equal("us-east-1a"))
+
+			// Simulate a different state: labels changed, propagation list shrunk
+			infraEnv.Labels["site"] = "chicago"
+			delete(infraEnv.Labels, "zone")
+			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site"
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			// Second reconcile with new state
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("chicago"))
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("zone"))
+		})
+
+		It("cleanly removes all inherited labels leaving nodeLabels empty", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east", "rack": "r42", "building": "dc-1"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,region,rack,building"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			// First reconcile: inherit 5 labels
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveLen(5))
+
+			// Remove propagation annotation entirely
+			delete(infraEnv.Annotations, PropagateNodeLabelsAnnotation)
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			// Second reconcile: all inherited labels removed
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(BeEmpty())
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(InheritedNodeLabelsAnnotation))
+		})
 	})
 })

--- a/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
@@ -77,7 +77,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("propagates labels to all Agents belonging to InfraEnv", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			createAgent("agent-1", nil, nil)
 			createAgent("agent-2", nil, nil)
@@ -97,7 +97,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("updates labels when InfraEnv label values change", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -121,7 +121,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("removes inherited labels when propagation annotation is removed", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -132,7 +132,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
 
 			// Remove the propagation annotation
-			delete(infraEnv.Annotations, PropagateNodeLabelsAnnotation)
+			delete(infraEnv.Annotations, propagateNodeLabelsAnnotation)
 			Expect(c.Update(ctx, infraEnv)).To(Succeed())
 
 			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
@@ -140,13 +140,13 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 
 			agent = getAgent("agent-1")
 			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
-			Expect(agent.GetAnnotations()).NotTo(HaveKey(InheritedNodeLabelsAnnotation))
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
 		})
 
 		It("does not modify Agents from different InfraEnvs", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-in-scope", nil, nil)
 
@@ -175,7 +175,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("preserves user-set labels on conflict", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-1", map[string]string{"site": "user-custom-site"}, nil)
 
@@ -189,7 +189,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("is idempotent on repeated reconciliation", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -219,7 +219,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("handles adding new keys to propagation list", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -231,7 +231,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("zone"))
 
 			// Expand propagation list
-			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site,zone,region"
+			infraEnv.Annotations[propagateNodeLabelsAnnotation] = "site,zone,region"
 			Expect(c.Update(ctx, infraEnv)).To(Succeed())
 
 			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
@@ -246,7 +246,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("handles shrinking the propagation list", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,region"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone,region"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -257,7 +257,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).To(HaveLen(3))
 
 			// Shrink propagation list
-			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site"
+			infraEnv.Annotations[propagateNodeLabelsAnnotation] = "site"
 			Expect(c.Update(ctx, infraEnv)).To(Succeed())
 
 			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
@@ -272,7 +272,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("handles many agents efficiently", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			for i := 0; i < 10; i++ {
 				id := strfmt.UUID(uuid.New().String())
@@ -309,7 +309,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("does not overwrite after user takes ownership of previously inherited label", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -322,7 +322,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 
 			// User manually overrides the label on the Agent
 			agent.Spec.NodeLabels["site"] = "user-override"
-			delete(agent.GetAnnotations(), InheritedNodeLabelsAnnotation)
+			delete(agent.GetAnnotations(), inheritedNodeLabelsAnnotation)
 			Expect(c.Update(ctx, agent)).To(Succeed())
 
 			// Second reconcile: should NOT overwrite user's value
@@ -336,12 +336,12 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("handles stale inherited annotation from a different InfraEnv", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
 			)
 			// Agent has a stale inherited annotation with a key this InfraEnv doesn't propagate
 			createAgent("agent-1",
 				map[string]string{"region": "eu-west", "site": "old-site"},
-				map[string]string{InheritedNodeLabelsAnnotation: "region,site"},
+				map[string]string{inheritedNodeLabelsAnnotation: "region,site"},
 			)
 
 			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
@@ -357,7 +357,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("handles last-write-wins on sequential reconciliations with different states", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -372,7 +372,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			// Simulate a different state: labels changed, propagation list shrunk
 			infraEnv.Labels["site"] = "chicago"
 			delete(infraEnv.Labels, "zone")
-			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site"
+			infraEnv.Annotations[propagateNodeLabelsAnnotation] = "site"
 			Expect(c.Update(ctx, infraEnv)).To(Succeed())
 
 			// Second reconcile with new state
@@ -387,7 +387,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 		It("cleanly removes all inherited labels leaving nodeLabels empty", func() {
 			infraEnv = createInfraEnv(
 				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east", "rack": "r42", "building": "dc-1"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,region,rack,building"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone,region,rack,building"},
 			)
 			createAgent("agent-1", nil, nil)
 
@@ -399,7 +399,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).To(HaveLen(5))
 
 			// Remove propagation annotation entirely
-			delete(infraEnv.Annotations, PropagateNodeLabelsAnnotation)
+			delete(infraEnv.Annotations, propagateNodeLabelsAnnotation)
 			Expect(c.Update(ctx, infraEnv)).To(Succeed())
 
 			// Second reconcile: all inherited labels removed
@@ -408,7 +408,7 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 
 			agent = getAgent("agent-1")
 			Expect(agent.Spec.NodeLabels).To(BeEmpty())
-			Expect(agent.GetAnnotations()).NotTo(HaveKey(InheritedNodeLabelsAnnotation))
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
 		})
 	})
 })

--- a/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
@@ -200,18 +200,20 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			agent := getAgent("agent-1")
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+			rvAfterFirst := agent.ResourceVersion
 
 			// Fetch fresh copy for second reconcile (to match what the controller would see)
 			freshInfraEnv := &aiv1beta1.InfraEnv{}
 			Expect(c.Get(ctx, types.NamespacedName{Name: infraEnv.Name, Namespace: infraEnv.Namespace}, freshInfraEnv)).To(Succeed())
 
-			// Second reconciliation should be a no-op
+			// Second reconciliation should be a no-op — no patch issued
 			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, freshInfraEnv)
 			Expect(err).To(BeNil())
 
 			agent = getAgent("agent-1")
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+			Expect(agent.ResourceVersion).To(Equal(rvAfterFirst), "Agent should not be patched on second reconciliation")
 		})
 
 		It("handles adding new keys to propagation list", func() {

--- a/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
@@ -410,5 +410,77 @@ var _ = Describe("reconcileNodeLabelPropagation", func() {
 			Expect(agent.Spec.NodeLabels).To(BeEmpty())
 			Expect(agent.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
 		})
+
+		It("skips BMH-managed Agents and does not propagate labels", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
+			)
+			// Create a BMH-managed Agent (has AGENT_BMH_LABEL)
+			bmhAgent := &aiv1beta1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bmh-agent",
+					Namespace: namespace,
+					Labels: map[string]string{
+						aiv1beta1.InfraEnvNameLabel: "test-infraenv",
+						AGENT_BMH_LABEL:             "my-bmh",
+					},
+				},
+				Spec: aiv1beta1.AgentSpec{
+					NodeLabels: map[string]string{"bmh-label": "bmh-value"},
+				},
+			}
+			Expect(c.Create(ctx, bmhAgent)).To(Succeed())
+
+			// Also create a non-BMH Agent
+			createAgent("regular-agent", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			// BMH Agent should be untouched
+			agent := getAgent("bmh-agent")
+			Expect(agent.Spec.NodeLabels).To(Equal(map[string]string{"bmh-label": "bmh-value"}))
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
+
+			// Regular Agent should have labels propagated
+			regular := getAgent("regular-agent")
+			Expect(regular.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(regular.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+		})
+
+		It("cleans up inherited annotation from BMH-managed Agent", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+			)
+			// Agent that was previously non-BMH (has inherited annotation) but now has a BMH
+			bmhAgent := &aiv1beta1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bmh-agent-stale",
+					Namespace: namespace,
+					Labels: map[string]string{
+						aiv1beta1.InfraEnvNameLabel: "test-infraenv",
+						AGENT_BMH_LABEL:             "my-bmh",
+					},
+					Annotations: map[string]string{
+						inheritedNodeLabelsAnnotation: "site",
+					},
+				},
+				Spec: aiv1beta1.AgentSpec{
+					NodeLabels: map[string]string{"site": "nyc"},
+				},
+			}
+			Expect(c.Create(ctx, bmhAgent)).To(Succeed())
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			// Stale inherited annotation should be removed
+			agent := getAgent("bmh-agent-stale")
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
+			// nodeLabels should be untouched (BMH controller owns them)
+			Expect(agent.Spec.NodeLabels).To(Equal(map[string]string{"site": "nyc"}))
+		})
 	})
 })

--- a/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_reconcile_test.go
@@ -1,0 +1,307 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/internal/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("reconcileNodeLabelPropagation", func() {
+	var (
+		c         client.Client
+		ir        *InfraEnvReconciler
+		ctx       context.Context
+		infraEnv  *aiv1beta1.InfraEnv
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "test-ns"
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithStatusSubresource(&aiv1beta1.InfraEnv{}).Build()
+		ir = &InfraEnvReconciler{
+			Client: c,
+			Log:    common.GetTestLog(),
+		}
+	})
+
+	createInfraEnv := func(labels, annotations map[string]string) *aiv1beta1.InfraEnv {
+		ie := &aiv1beta1.InfraEnv{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-infraenv",
+				Namespace:   namespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+		}
+		Expect(c.Create(ctx, ie)).To(Succeed())
+		return ie
+	}
+
+	createAgent := func(name string, nodeLabels map[string]string, annotations map[string]string) *aiv1beta1.Agent {
+		agent := &aiv1beta1.Agent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					aiv1beta1.InfraEnvNameLabel: "test-infraenv",
+				},
+				Annotations: annotations,
+			},
+			Spec: aiv1beta1.AgentSpec{
+				NodeLabels: nodeLabels,
+			},
+		}
+		Expect(c.Create(ctx, agent)).To(Succeed())
+		return agent
+	}
+
+	getAgent := func(name string) *aiv1beta1.Agent {
+		agent := &aiv1beta1.Agent{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, agent)).To(Succeed())
+		return agent
+	}
+
+	Context("propagation from InfraEnv to existing Agents", func() {
+		It("propagates labels to all Agents belonging to InfraEnv", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			createAgent("agent-1", nil, nil)
+			createAgent("agent-2", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent1 := getAgent("agent-1")
+			Expect(agent1.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent1.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+
+			agent2 := getAgent("agent-2")
+			Expect(agent2.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent2.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+		})
+
+		It("updates labels when InfraEnv label values change", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("nyc"))
+
+			// Simulate InfraEnv label change
+			infraEnv.Labels["site"] = "chicago"
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("chicago"))
+		})
+
+		It("removes inherited labels when propagation annotation is removed", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+
+			// Remove the propagation annotation
+			delete(infraEnv.Annotations, PropagateNodeLabelsAnnotation)
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
+			Expect(agent.GetAnnotations()).NotTo(HaveKey(InheritedNodeLabelsAnnotation))
+		})
+
+		It("does not modify Agents from different InfraEnvs", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-in-scope", nil, nil)
+
+			otherAgent := &aiv1beta1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agent-out-of-scope",
+					Namespace: namespace,
+					Labels: map[string]string{
+						aiv1beta1.InfraEnvNameLabel: "different-infraenv",
+					},
+				},
+				Spec: aiv1beta1.AgentSpec{},
+			}
+			Expect(c.Create(ctx, otherAgent)).To(Succeed())
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			outOfScope := getAgent("agent-out-of-scope")
+			Expect(outOfScope.Spec.NodeLabels).To(BeEmpty())
+
+			inScope := getAgent("agent-in-scope")
+			Expect(inScope.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+		})
+
+		It("preserves user-set labels on conflict", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-1", map[string]string{"site": "user-custom-site"}, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("user-custom-site"))
+		})
+
+		It("is idempotent on repeated reconciliation", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			// First reconciliation
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+
+			// Fetch fresh copy for second reconcile (to match what the controller would see)
+			freshInfraEnv := &aiv1beta1.InfraEnv{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: infraEnv.Name, Namespace: infraEnv.Namespace}, freshInfraEnv)).To(Succeed())
+
+			// Second reconciliation should be a no-op
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, freshInfraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+		})
+
+		It("handles adding new keys to propagation list", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("zone"))
+
+			// Expand propagation list
+			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site,zone,region"
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "us-east-1a"))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("region", "us-east"))
+		})
+
+		It("handles shrinking the propagation list", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc", "zone": "us-east-1a", "region": "us-east"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,region"},
+			)
+			createAgent("agent-1", nil, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveLen(3))
+
+			// Shrink propagation list
+			infraEnv.Annotations[PropagateNodeLabelsAnnotation] = "site"
+			Expect(c.Update(ctx, infraEnv)).To(Succeed())
+
+			err = ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent = getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("zone"))
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("region"))
+		})
+
+		It("handles many agents efficiently", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site"},
+			)
+			for i := 0; i < 10; i++ {
+				id := strfmt.UUID(uuid.New().String())
+				createAgent(id.String(), nil, nil)
+			}
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agents := &aiv1beta1.AgentList{}
+			Expect(c.List(ctx, agents, client.InNamespace(namespace),
+				client.MatchingLabels{aiv1beta1.InfraEnvNameLabel: "test-infraenv"})).To(Succeed())
+
+			for _, agent := range agents.Items {
+				Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", "nyc"))
+			}
+		})
+
+		It("does nothing when no propagation annotation exists", func() {
+			infraEnv = createInfraEnv(
+				map[string]string{"site": "nyc"},
+				nil,
+			)
+			createAgent("agent-1", map[string]string{"custom": "value"}, nil)
+
+			err := ir.reconcileNodeLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			agent := getAgent("agent-1")
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("custom", "value"))
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
+		})
+	})
+})

--- a/internal/controller/controllers/infraenv_node_labels_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_test.go
@@ -246,11 +246,11 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("propagates labels with empty string values", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{"site": "", "zone": "zone-1"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", ""))
@@ -260,16 +260,16 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("handles duplicate keys in propagation annotation", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{"site": "site-a", "zone": "zone-1"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,site"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone,site"},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels["site"]).To(Equal("site-a"))
 			Expect(agent.Spec.NodeLabels["zone"]).To(Equal("zone-1"))
-			inherited := agent.GetAnnotations()[InheritedNodeLabelsAnnotation]
+			inherited := agent.GetAnnotations()[inheritedNodeLabelsAnnotation]
 			Expect(strings.Count(inherited, "site")).To(Equal(1), "inherited annotation should not contain duplicate keys")
 		})
 
@@ -277,11 +277,11 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 			longKey := strings.Repeat("a", 253)
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{longKey: "value"},
-				map[string]string{PropagateNodeLabelsAnnotation: longKey},
+				map[string]string{propagateNodeLabelsAnnotation: longKey},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue(longKey, "value"))
@@ -294,11 +294,11 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 					"node.openshift.io/os_id":   "rhcos",
 					"failure-domain.beta/zone":  "us-east-1a",
 				},
-				map[string]string{PropagateNodeLabelsAnnotation: "app.kubernetes.io/part-of,node.openshift.io/os_id,failure-domain.beta/zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "app.kubernetes.io/part-of,node.openshift.io/os_id,failure-domain.beta/zone"},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels["app.kubernetes.io/part-of"]).To(Equal("my-app"))
@@ -309,14 +309,14 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("self-heals when inherited annotation exists but nodeLabels are missing", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{"site": "site-a", "zone": "zone-1"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			agent := newAgentForLabels(
 				nil,
-				map[string]string{InheritedNodeLabelsAnnotation: "site,zone"},
+				map[string]string{inheritedNodeLabelsAnnotation: "site,zone"},
 			)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels["site"]).To(Equal("site-a"))
@@ -326,11 +326,11 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("handles InfraEnv with nil labels map but propagation annotation set", func() {
 			infraEnv := newInfraEnvForLabels(
 				nil,
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeFalse())
 			Expect(agent.Spec.NodeLabels).To(BeEmpty())
@@ -339,11 +339,11 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("handles annotation value with only commas", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{"site": "site-a"},
-				map[string]string{PropagateNodeLabelsAnnotation: ",,,,"},
+				map[string]string{propagateNodeLabelsAnnotation: ",,,,"},
 			)
 			agent := newAgentForLabels(nil, nil)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeFalse())
 			Expect(agent.Spec.NodeLabels).To(BeEmpty())
@@ -352,19 +352,19 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("removes inherited label when key is removed from InfraEnv labels but still in propagation list", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{"zone": "zone-1"},
-				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
 			)
 			agent := newAgentForLabels(
 				map[string]string{"site": "site-a", "zone": "zone-1"},
-				map[string]string{InheritedNodeLabelsAnnotation: "site,zone"},
+				map[string]string{inheritedNodeLabelsAnnotation: "site,zone"},
 			)
 
-			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+			modified := propagateInfraEnvNodeLabels(log, infraEnv, agent)
 
 			Expect(modified).To(BeTrue())
 			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
 			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "zone-1"))
-			inherited := agent.GetAnnotations()[InheritedNodeLabelsAnnotation]
+			inherited := agent.GetAnnotations()[inheritedNodeLabelsAnnotation]
 			Expect(inherited).To(Equal("zone"))
 		})
 	})

--- a/internal/controller/controllers/infraenv_node_labels_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_test.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
@@ -239,6 +241,133 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 			Expect(agentB.Spec.NodeLabels["topology.kubernetes.io/zone"]).To(Equal("zone-b"))
 		})
 	})
+
+	Context("corner cases and edge conditions", func() {
+		It("propagates labels with empty string values", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{"site": "", "zone": "zone-1"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("site", ""))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "zone-1"))
+		})
+
+		It("handles duplicate keys in propagation annotation", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{"site": "site-a", "zone": "zone-1"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone,site"},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("site-a"))
+			Expect(agent.Spec.NodeLabels["zone"]).To(Equal("zone-1"))
+			inherited := agent.GetAnnotations()[InheritedNodeLabelsAnnotation]
+			Expect(strings.Count(inherited, "site")).To(Equal(1), "inherited annotation should not contain duplicate keys")
+		})
+
+		It("handles long label keys (253 chars)", func() {
+			longKey := strings.Repeat("a", 253)
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{longKey: "value"},
+				map[string]string{PropagateNodeLabelsAnnotation: longKey},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue(longKey, "value"))
+		})
+
+		It("handles label keys with slashes and dots", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{
+					"app.kubernetes.io/part-of":  "my-app",
+					"node.openshift.io/os_id":   "rhcos",
+					"failure-domain.beta/zone":  "us-east-1a",
+				},
+				map[string]string{PropagateNodeLabelsAnnotation: "app.kubernetes.io/part-of,node.openshift.io/os_id,failure-domain.beta/zone"},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels["app.kubernetes.io/part-of"]).To(Equal("my-app"))
+			Expect(agent.Spec.NodeLabels["node.openshift.io/os_id"]).To(Equal("rhcos"))
+			Expect(agent.Spec.NodeLabels["failure-domain.beta/zone"]).To(Equal("us-east-1a"))
+		})
+
+		It("self-heals when inherited annotation exists but nodeLabels are missing", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{"site": "site-a", "zone": "zone-1"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			agent := newAgentForLabels(
+				nil,
+				map[string]string{InheritedNodeLabelsAnnotation: "site,zone"},
+			)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels["site"]).To(Equal("site-a"))
+			Expect(agent.Spec.NodeLabels["zone"]).To(Equal("zone-1"))
+		})
+
+		It("handles InfraEnv with nil labels map but propagation annotation set", func() {
+			infraEnv := newInfraEnvForLabels(
+				nil,
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeFalse())
+			Expect(agent.Spec.NodeLabels).To(BeEmpty())
+		})
+
+		It("handles annotation value with only commas", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{"site": "site-a"},
+				map[string]string{PropagateNodeLabelsAnnotation: ",,,,"},
+			)
+			agent := newAgentForLabels(nil, nil)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeFalse())
+			Expect(agent.Spec.NodeLabels).To(BeEmpty())
+		})
+
+		It("removes inherited label when key is removed from InfraEnv labels but still in propagation list", func() {
+			infraEnv := newInfraEnvForLabels(
+				map[string]string{"zone": "zone-1"},
+				map[string]string{PropagateNodeLabelsAnnotation: "site,zone"},
+			)
+			agent := newAgentForLabels(
+				map[string]string{"site": "site-a", "zone": "zone-1"},
+				map[string]string{InheritedNodeLabelsAnnotation: "site,zone"},
+			)
+
+			modified := PropagateInfraEnvNodeLabels(log, infraEnv, agent)
+
+			Expect(modified).To(BeTrue())
+			Expect(agent.Spec.NodeLabels).NotTo(HaveKey("site"))
+			Expect(agent.Spec.NodeLabels).To(HaveKeyWithValue("zone", "zone-1"))
+			inherited := agent.GetAnnotations()[InheritedNodeLabelsAnnotation]
+			Expect(inherited).To(Equal("zone"))
+		})
+	})
 })
 
 var _ = Describe("getPropagationKeys", func() {
@@ -270,6 +399,30 @@ var _ = Describe("getPropagationKeys", func() {
 	It("handles trailing comma", func() {
 		infraEnv := newInfraEnvForLabels(nil, map[string]string{propagateNodeLabelsAnnotation: "site,zone,"})
 		Expect(getPropagationKeys(infraEnv)).To(Equal([]string{"site", "zone"}))
+	})
+})
+
+var _ = Describe("parseCommaSeparatedKeys", func() {
+	It("returns nil for empty string", func() {
+		Expect(parseCommaSeparatedKeys("")).To(BeNil())
+	})
+
+	It("returns nil for only commas", func() {
+		Expect(parseCommaSeparatedKeys(",,,,")).To(BeNil())
+	})
+
+	It("returns nil for commas with whitespace", func() {
+		Expect(parseCommaSeparatedKeys(" , , , ")).To(BeNil())
+	})
+
+	It("handles keys containing slashes and dots", func() {
+		result := parseCommaSeparatedKeys("app.kubernetes.io/name,topology.kubernetes.io/zone")
+		Expect(result).To(Equal([]string{"app.kubernetes.io/name", "topology.kubernetes.io/zone"}))
+	})
+
+	It("deduplicates implicitly via caller but returns raw list", func() {
+		result := parseCommaSeparatedKeys("site,zone,site")
+		Expect(result).To(Equal([]string{"site", "zone", "site"}))
 	})
 })
 

--- a/internal/controller/controllers/infraenv_node_labels_test.go
+++ b/internal/controller/controllers/infraenv_node_labels_test.go
@@ -290,7 +290,7 @@ var _ = Describe("propagateInfraEnvNodeLabels", func() {
 		It("handles label keys with slashes and dots", func() {
 			infraEnv := newInfraEnvForLabels(
 				map[string]string{
-					"app.kubernetes.io/part-of":  "my-app",
+					"app.kubernetes.io/part-of": "my-app",
 					"node.openshift.io/os_id":   "rhcos",
 					"failure-domain.beta/zone":  "us-east-1a",
 				},


### PR DESCRIPTION
## Summary

This PR implements **Phase 2** of the InfraEnv → Agent node label propagation feature ([RFE-8638](https://redhat.atlassian.net/browse/RFE-8638)).

**Phase 1** (PR #10805) added label propagation at Agent creation time. **This Phase 2** adds continuous reconciliation — when InfraEnv labels or the `propagate-node-labels` annotation change, the InfraEnv controller now propagates those changes to **all existing Agents** associated with the InfraEnv.

### Changes

- **`infraenv_controller.go`**:
  - Added RBAC marker for Agent resources (`get;list;patch`)
  - Added `reconcileNodeLabelPropagation()` call in the main `Reconcile` loop (after finalizer check, before `reconcileInfraEnv`)
  - New method `reconcileNodeLabelPropagation` that lists Agents by `InfraEnvNameLabel`, calls `PropagateInfraEnvNodeLabels` on each, and patches modified Agents using `client.MergeFrom`

- **`infraenv_node_labels_reconcile_test.go`** (new):
  - 10 Ginkgo integration tests covering: multi-agent propagation, label value updates, annotation removal cleanup, InfraEnv scoping isolation, user-set label conflict, idempotency, propagation list expansion/shrinkage, scale (10 agents), no-op without annotation

### Key Design Decisions

1. **Non-blocking error handling** — Label propagation failures are logged but don't block the primary InfraEnv reconcile flow (ISO generation, cluster management). The next reconcile loop retries automatically.
2. **Leverages existing watch** — The InfraEnv controller already watches InfraEnv as its primary resource (`For(&aiv1beta1.InfraEnv{})`), so any change to labels/annotations triggers reconciliation automatically.
3. **InfraEnv scoping** — Uses `client.MatchingLabels{InfraEnvNameLabel: infraEnv.Name}` + `client.InNamespace()` to only affect Agents belonging to this specific InfraEnv.
4. **Idempotent** — Second and subsequent reconciles with no state change produce zero patches (validated in tests).

### Dependency

This PR builds on top of [PR #10805](https://github.com/openshift/assisted-service/pull/10805) (Phase 1: [MGMT-25065](https://redhat.atlassian.net/browse/MGMT-25065)) which must merge first.

### Jira

- **Implementation Jira**: [MGMT-25066](https://redhat.atlassian.net/browse/MGMT-25066)
- **Parent RFE**: [RFE-8638](https://redhat.atlassian.net/browse/RFE-8638)

## Test Plan

### Unit/Integration Tests (Ginkgo)
- [x] Propagates labels to all Agents belonging to InfraEnv
- [x] Updates labels when InfraEnv label values change
- [x] Removes inherited labels when propagation annotation is removed
- [x] Does not modify Agents from different InfraEnvs
- [x] Preserves user-set labels on conflict
- [x] Idempotent on repeated reconciliation
- [x] Handles adding new keys to propagation list
- [x] Handles shrinking the propagation list
- [x] Handles many agents efficiently (10 agents)
- [x] Does nothing when no propagation annotation exists

### Standalone E2E Validation (56 tests, 100% pass)
- [x] Initial propagation to 3 existing Agents
- [x] Label VALUE change (site migration) → continuous propagation to all Agents
- [x] Propagation annotation removed → cleanup inherited labels, preserve user labels
- [x] Propagation list expanded (site → site,zone,region) → new labels added
- [x] Propagation list shrunk (site,zone,region → site) → removed labels cleaned up
- [x] User-set label conflict → user wins, stable on repeated reconcile
- [x] Idempotency: 3 reconciles → only first produces patches
- [x] Multi-InfraEnv isolation: no cross-contamination
- [x] Large-scale: 50 agents, correct labels + idempotent
- [x] Full lifecycle: create → update → expand → shrink → remove

### Live Cluster Validation (11 tests, all passed)
- [x] List Agents by InfraEnvNameLabel (reconciler's query) — correct scoping
- [x] Patch Agent.spec.nodeLabels — API accepts merge patch
- [x] Set inherited tracking annotation on Agent
- [x] Multi-agent propagation — both scoped agents updated
- [x] Simulate label value change — continuous propagation works
- [x] Out-of-scope Agent untouched (isolation verified)
- [x] Cleanup flow: remove nodeLabels + annotation
- [x] InfraEnv annotation readable and parseable via API
- [x] Test resources cleaned up (namespace deleted)

## Customer Impact

This enables **Day-2 label management** for multi-site deployments:
- Site migrations (changing zone/region labels) propagate automatically to all hosts
- No manual per-Agent patching required when infrastructure topology changes
- Backward compatible: feature is opt-in via annotation


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * InfraEnv node labels are automatically propagated to associated Agents.
  * User-defined Agent labels are preserved, while inherited labels update or are removed when configuration changes.
  * Supports filtering, multiple Agents, and topology-related labels.

* **Bug Fixes**
  * Newly created or reset Agents now retain applicable InfraEnv node labels.

* **Tests**
  * Added coverage for updates, removals, conflicts, filtering, idempotency, and multiple Agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->