### PR TITLE
NO-ISSUE: Add same-namespace egress for image-service to assisted-service

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -840,6 +840,18 @@ func newImageServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger, a
 		}
 		addAppLabel(imageServiceName, &np.ObjectMeta)
 
+		egress := networkPolicyDefaultEgress()
+		egress = append(egress, netv1.NetworkPolicyEgressRule{
+			To: []netv1.NetworkPolicyPeer{
+				{PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": serviceName},
+				}},
+			},
+			Ports: []netv1.NetworkPolicyPort{
+				{Protocol: ptr.To(corev1.ProtocolTCP), Port: &servicePort},
+			},
+		})
+
 		np.Spec = netv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": imageServiceName},
@@ -854,7 +866,7 @@ func newImageServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger, a
 					},
 				},
 			},
-			Egress: networkPolicyDefaultEgress(),
+			Egress: egress,
 		}
 		return nil
 	}
@@ -921,7 +933,7 @@ func networkPolicyDefaultEgress() []netv1.NetworkPolicyEgressRule {
 		},
 		{
 			To: []netv1.NetworkPolicyPeer{
-				{IPBlock: &netv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{"169.254.169.254/32"}}},
+				{IPBlock: &netv1.IPBlock{CIDR: "0.0.0.0/0"}},
 				{IPBlock: &netv1.IPBlock{CIDR: "::/0"}},
 			},
 			Ports: []netv1.NetworkPolicyPort{

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1351,6 +1351,39 @@ var _ = Describe("newImageServiceService", func() {
 	})
 })
 
+var _ = Describe("newImageServiceNetworkPolicy", func() {
+	var (
+		asc  *aiv1beta1.AgentServiceConfig
+		ascr *AgentServiceConfigReconciler
+		ascc ASC
+		ctx  = context.Background()
+		log  = logrus.New()
+	)
+
+	BeforeEach(func() {
+		asc = newASCDefault()
+		ascr = newTestReconciler(asc)
+		ascc = initASC(ascr, asc)
+	})
+
+	It("should include same-namespace egress to assisted-service on port 8090", func() {
+		obj, mutateFn, err := newImageServiceNetworkPolicy(ctx, log, ascc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mutateFn()).To(Succeed())
+
+		np := obj.(*netv1.NetworkPolicy)
+		var sameNamespaceEgressPorts []int32
+		for _, rule := range np.Spec.Egress {
+			if len(rule.To) == 1 && rule.To[0].PodSelector != nil && rule.To[0].NamespaceSelector == nil && rule.To[0].IPBlock == nil {
+				for _, port := range rule.Ports {
+					sameNamespaceEgressPorts = append(sameNamespaceEgressPorts, port.Port.IntVal)
+				}
+			}
+		}
+		Expect(sameNamespaceEgressPorts).To(ContainElement(int32(8090)))
+	})
+})
+
 var _ = Describe("newImageServiceRoute", func() {
 	var (
 		asc  *aiv1beta1.AgentServiceConfig


### PR DESCRIPTION
  The image-service calls assisted-service internally via `assisted-service.<namespace>.svc:8090` to fetch ignition data. The current egress rules only allow DNS, K8s API, and external HTTPS — blocking this
  same-namespace call.
  
  Add a targeted egress rule to the image-service NetworkPolicy allowing traffic to pods matching `app: assisted-service` on port 8090.

  Also removes the ineffective `169.254.169.254/32` metadata endpoint exclusion from the default egress (metadata endpoint uses port 80, not 443).

Fixes #10805 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image-service network access to allow communication with assisted-service pods on the service port.
  * Restored HTTPS egress access to the local metadata service address.
* **Tests**
  * Added coverage verifying assisted-service traffic is permitted on port 8090.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->