### PR TITLE
OCPBUGS-29975: Allow multiple machine networks for UMN clusters

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -672,7 +672,9 @@ func (b *bareMetalInventory) validateRegisterClusterInternalPreDefaultValuesSet(
 	if err := validations.ValidateNetworkCIDRs(params.NewClusterParams.MachineNetworks, params.NewClusterParams.ServiceNetworks, params.NewClusterParams.ClusterNetworks); err != nil {
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
-	if err := validations.ValidateDualStackNetworks(params.NewClusterParams, false, false, swag.StringValue(params.NewClusterParams.OpenshiftVersion)); err != nil {
+	createParams := params.NewClusterParams
+	targetLBType := network.TargetLoadBalancerType(nil, createParams)
+	if err := validations.ValidateDualStackNetworks(createParams, false, targetLBType, swag.StringValue(createParams.OpenshiftVersion)); err != nil {
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
 	return nil
@@ -2258,9 +2260,9 @@ func (b *bareMetalInventory) validateUpdateCluster(
 		return params, common.NewApiError(http.StatusBadRequest, err)
 	}
 	alreadyDualStack := network.CheckIfClusterIsDualStack(cluster)
-	alreadyUserManagedLoadBalancer := network.IsLoadBalancerUserManaged(cluster)
+	targetLBType := network.TargetLoadBalancerType(cluster, params.ClusterUpdateParams)
 
-	if err = validations.ValidateDualStackNetworks(params.ClusterUpdateParams, alreadyDualStack, alreadyUserManagedLoadBalancer, cluster.OpenshiftVersion); err != nil {
+	if err = validations.ValidateDualStackNetworks(params.ClusterUpdateParams, alreadyDualStack, targetLBType, cluster.OpenshiftVersion); err != nil {
 		return params, common.NewApiError(http.StatusBadRequest, err)
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5255,7 +5255,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{Cidr: "15.15.0.0/21"}, {Cidr: "16.16.0.0/21"}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Single-stack cluster cannot contain multiple Machine Networks")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Single-stack cluster with managed load balancer cannot contain multiple Machine Networks")
 				})
 
 				It("Multiple machine networks allowed for single-stack cluster with user-managed networking", func() {
@@ -17847,7 +17847,7 @@ var _ = Describe("RegisterCluster", func() {
 				verifyApiErrorString(
 					reply,
 					http.StatusBadRequest,
-					"Single-stack cluster cannot contain multiple Machine Networks",
+					"Single-stack cluster with managed load balancer cannot contain multiple Machine Networks",
 				)
 			})
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5258,6 +5258,21 @@ var _ = Describe("cluster", func() {
 					verifyApiErrorString(reply, http.StatusBadRequest, "Single-stack cluster cannot contain multiple Machine Networks")
 				})
 
+				It("Multiple machine networks allowed for single-stack cluster with user-managed networking", func() {
+					Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterID).Updates(map[string]interface{}{
+						"user_managed_networking": true,
+						"platform_type":           models.PlatformTypeNone,
+					}).Error).ShouldNot(HaveOccurred())
+					mockSuccess(1)
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "15.15.0.0/21"}, {Cidr: "16.16.0.0/21"}},
+						},
+					})
+					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+				})
+
 				It("Override networks - additional cluster subnet", func() {
 					mockSuccess(1)
 					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -17671,6 +17686,26 @@ var _ = Describe("RegisterCluster", func() {
 
 				Expect(responseCluster.APIVips).To(ContainElement(apiVips[0]))
 				Expect(responseCluster.IngressVips).To(ContainElement(ingressVIPs[0]))
+			})
+
+			It("when registering cluster with user-managed networking and multiple machine networks", func() {
+				reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
+					NewClusterParams: &models.ClusterCreateParams{
+						OpenshiftVersion:      swag.String(common.MinimumVersionForUserManagedLoadBalancerFeature),
+						CPUArchitecture:       common.X86CPUArchitecture,
+						UserManagedNetworking: swag.Bool(true),
+						Platform: &models.Platform{
+							Type: models.PlatformTypeNone.Pointer(),
+						},
+						MachineNetworks: []*models.MachineNetwork{
+							{Cidr: "192.168.127.0/24"},
+							{Cidr: "192.168.128.0/24"},
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
+				actual := reply.(*installer.V2RegisterClusterCreated)
+				Expect(actual.Payload.MachineNetworks).To(HaveLen(2))
 			})
 		})
 

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -226,7 +226,8 @@ func ValidateClusterCreateIPAddresses(ipV6Supported bool, clusterId strfmt.UUID,
 	targetConfiguration.LoadBalancer = params.LoadBalancer
 	targetConfiguration.OpenshiftVersion = swag.StringValue(params.OpenshiftVersion)
 	targetConfiguration.PrimaryIPStack = primaryIPStack
-	return validateVIPAddresses(ipV6Supported, targetConfiguration)
+	targetLBType := network.TargetLoadBalancerType(&targetConfiguration, nil)
+	return validateVIPAddresses(ipV6Supported, targetConfiguration, targetLBType)
 }
 
 func validateVIPsWithUMA(cluster *common.Cluster, params *models.V2ClusterUpdateParams, vipDhcpAllocation bool) error {
@@ -341,7 +342,8 @@ func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Clust
 	}
 
 	targetConfiguration.PrimaryIPStack = primaryIPStack
-	return validateVIPAddresses(ipV6Supported, targetConfiguration)
+	targetLBType := network.TargetLoadBalancerType(cluster, params)
+	return validateVIPAddresses(ipV6Supported, targetConfiguration, targetLBType)
 }
 
 func validateVIPIP(ip, vipType string, index int) error {
@@ -552,7 +554,7 @@ func validateVIPAddressFamily(ipV6Supported bool, targetConfiguration common.Clu
 	return allAddresses, nil
 }
 
-func validateVIPAddresses(ipV6Supported bool, targetConfiguration common.Cluster) error {
+func validateVIPAddresses(ipV6Supported bool, targetConfiguration common.Cluster, targetLBType string) error {
 	var allAddresses []*string
 	var multiErr error
 	var err error
@@ -581,7 +583,7 @@ func validateVIPAddresses(ipV6Supported bool, targetConfiguration common.Cluster
 		return err
 	}
 
-	err = ValidateDualStackNetworks(targetConfiguration, false, false, targetConfiguration.OpenshiftVersion)
+	err = ValidateDualStackNetworks(targetConfiguration, false, targetLBType, targetConfiguration.OpenshiftVersion)
 	if err != nil {
 		return err
 	}
@@ -669,11 +671,10 @@ func ValidateVIPsWereNotSetDhcpMode(apiVips []*models.APIVip, ingressVips []*mod
 	return nil
 }
 
-func ValidateDualStackNetworks(clusterParams interface{}, alreadyDualStack bool, alreadyUserManagedLoadBalancer bool, openshiftVersion string) error {
+func ValidateDualStackNetworks(clusterParams interface{}, alreadyDualStack bool, targetLoadBalancerType string, openshiftVersion string) error {
 	var machineNetworks []*models.MachineNetwork
 	var serviceNetworks []*models.ServiceNetwork
 	var clusterNetworks []*models.ClusterNetwork
-	var clusterLoadBalancer *models.LoadBalancer
 	var err error
 	var ipv4, ipv6 bool
 	reqDualStack := false
@@ -681,16 +682,6 @@ func ValidateDualStackNetworks(clusterParams interface{}, alreadyDualStack bool,
 	machineNetworks = network.DerefMachineNetworks(funk.Get(clusterParams, "MachineNetworks"))
 	serviceNetworks = network.DerefServiceNetworks(funk.Get(clusterParams, "ServiceNetworks"))
 	clusterNetworks = network.DerefClusterNetworks(funk.Get(clusterParams, "ClusterNetworks"))
-	clusterLoadBalancer = network.DerefClusterLoadBalancer(funk.Get(clusterParams, "LoadBalancer"))
-
-	// Extract OpenShift version for version-aware validation
-	var targetLoadBalancerType string = models.LoadBalancerTypeClusterManaged
-	if alreadyUserManagedLoadBalancer {
-		targetLoadBalancerType = models.LoadBalancerTypeUserManaged
-	}
-	if clusterLoadBalancer != nil {
-		targetLoadBalancerType = clusterLoadBalancer.Type
-	}
 
 	ipv4, ipv6, err = network.GetAddressFamilies(machineNetworks)
 	if err != nil {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -732,7 +732,7 @@ func ValidateDualStackNetworks(clusterParams interface{}, alreadyDualStack bool,
 		}
 	} else {
 		if len(machineNetworks) > 1 && targetLoadBalancerType == models.LoadBalancerTypeClusterManaged {
-			err := errors.Errorf("Single-stack cluster cannot contain multiple Machine Networks")
+			err := errors.Errorf("Single-stack cluster with managed load balancer cannot contain multiple Machine Networks")
 			return err
 		}
 	}

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -4153,7 +4153,7 @@ var _ = Describe("Refresh Host", func() {
 					HasCPUCoresForRole:   {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role master"},
 					HasMemoryForRole:     {status: ValidationSuccess, messagePattern: "Sufficient RAM for role master"},
 					IsHostnameUnique:     {status: ValidationSuccess, messagePattern: " is unique in cluster"},
-					BelongsToMachineCidr: {status: ValidationFailure, messagePattern: "Host does not belong to machine network CIDRs."},
+					BelongsToMachineCidr: {status: ValidationFailure, messagePattern: "Host does not belong to any machine network CIDR"},
 					IsHostnameValid:      {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
 					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
 					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationSuccess, messagePattern: "Speed of installation disk has not yet been measured"},

--- a/internal/ignition/installmanifests.go
+++ b/internal/ignition/installmanifests.go
@@ -149,7 +149,7 @@ func (g *installerGenerator) patchInternalReleaseManifests(ctx context.Context, 
 }
 
 func (g *installerGenerator) allocateNodeIpsIfNeeded(log logrus.FieldLogger) {
-	if common.IsMultiNodeNonePlatformCluster(g.cluster) || network.IsLoadBalancerUserManaged(g.cluster) {
+	if network.IsLoadBalancerUserManaged(g.cluster) {
 		nodeIpAllocations, err := network.GenerateNonePlatformAddressAllocation(g.cluster, log)
 		if err != nil {
 			log.WithError(err).Warnf("failed to generate ip address allocation for cluster %s", *g.cluster.ID)
@@ -352,7 +352,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 func (g *installerGenerator) addBootstrapKubeletIpIfRequired(log logrus.FieldLogger, envVars []string) ([]string, error) {
 	// setting bootstrap kubelet node ip
 	log.Debugf("Adding bootstrap ip to env vars")
-	if !common.IsMultiNodeNonePlatformCluster(g.cluster) && !network.IsLoadBalancerUserManaged(g.cluster) {
+	if !network.IsLoadBalancerUserManaged(g.cluster) {
 		bootstrapIp, err := network.GetPrimaryMachineCIDRIP(common.GetBootstrapHost(g.cluster), g.cluster)
 		if err != nil {
 			log.WithError(err).Warn("Failed to get bootstrap primary ip for kubelet service update.")
@@ -1176,7 +1176,7 @@ func (g *installerGenerator) writeSingleHostFile(host *models.Host, baseFile str
 			return errors.Wrapf(errP, "Failed to parse machine cidr for node ip hint content")
 		}
 		ignitioncommon.SetFileInIgnition(config, nodeIpHintFile, fmt.Sprintf("data:,KUBELET_NODEIP_HINT=%s", ip), false, 420, true)
-	} else if g.nodeIpAllocations != nil && (common.IsMultiNodeNonePlatformCluster(g.cluster) || network.IsLoadBalancerUserManaged(g.cluster)) {
+	} else if g.nodeIpAllocations != nil && network.IsLoadBalancerUserManaged(g.cluster) {
 		allocation, ok := g.nodeIpAllocations[lo.FromPtr(host.ID)]
 		if ok {
 			ignitioncommon.SetFileInIgnition(config, nodeIpHintFile, fmt.Sprintf("data:,KUBELET_NODEIP_HINT=%s", allocation.HintIp), false, 420, true)

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"github.com/thoas/go-funk"
 	"golang.org/x/sys/unix"
 	"gorm.io/gorm"
 )
@@ -671,6 +672,22 @@ func FindInterfaceByIPString(ipAddress string, interfaces []*models.Interface) (
 
 func IsLoadBalancerUserManaged(c *common.Cluster) bool {
 	return c != nil && c.LoadBalancer != nil && c.LoadBalancer.Type == models.LoadBalancerTypeUserManaged
+}
+
+// TargetLoadBalancerType computes the effective load balancer type for validation
+// purposes, given the existing cluster state and what is being requested in params.
+// cluster may be nil when there is no existing cluster (e.g. during registration).
+// clusterParams is the create or update params struct, from which the LoadBalancer
+// field is read if present; it may be nil.
+func TargetLoadBalancerType(cluster *common.Cluster, clusterParams interface{}) string {
+	result := models.LoadBalancerTypeClusterManaged
+	if IsLoadBalancerUserManaged(cluster) {
+		result = models.LoadBalancerTypeUserManaged
+	}
+	if lb := DerefClusterLoadBalancer(funk.Get(clusterParams, "LoadBalancer")); lb != nil {
+		result = lb.Type
+	}
+	return result
 }
 
 // IsNicBelongsAnyMachineNetwork is a helper function to find a nic within the machine networks.

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -671,14 +671,15 @@ func FindInterfaceByIPString(ipAddress string, interfaces []*models.Interface) (
 }
 
 func IsLoadBalancerUserManaged(c *common.Cluster) bool {
-	return c != nil && c.LoadBalancer != nil && c.LoadBalancer.Type == models.LoadBalancerTypeUserManaged
+	return c != nil && (common.IsMultiNodeNonePlatformCluster(c) ||
+		(c.LoadBalancer != nil && c.LoadBalancer.Type == models.LoadBalancerTypeUserManaged))
 }
 
 // TargetLoadBalancerType computes the effective load balancer type for validation
 // purposes, given the existing cluster state and what is being requested in params.
 // cluster may be nil when there is no existing cluster (e.g. during registration).
-// clusterParams is the create or update params struct, from which the LoadBalancer
-// field is read if present; it may be nil.
+// clusterParams is the create or update params struct; it may be nil, in which
+// case only the existing cluster state is considered.
 func TargetLoadBalancerType(cluster *common.Cluster, clusterParams interface{}) string {
 	result := models.LoadBalancerTypeClusterManaged
 	if IsLoadBalancerUserManaged(cluster) {
@@ -686,6 +687,19 @@ func TargetLoadBalancerType(cluster *common.Cluster, clusterParams interface{}) 
 	}
 	if lb := DerefClusterLoadBalancer(funk.Get(clusterParams, "LoadBalancer")); lb != nil {
 		result = lb.Type
+	} else {
+		umnRaw := funk.Get(clusterParams, "UserManagedNetworking")
+		if umnPtr, ok := umnRaw.(*bool); ok && swag.BoolValue(umnPtr) {
+			isSNO := false
+			if cluster != nil {
+				isSNO = common.IsSingleNodeCluster(cluster)
+			} else if haModePtr, ok := funk.Get(clusterParams, "HighAvailabilityMode").(*string); ok {
+				isSNO = swag.StringValue(haModePtr) == models.ClusterCreateParamsHighAvailabilityModeNone
+			}
+			if !isSNO {
+				result = models.LoadBalancerTypeUserManaged
+			}
+		}
 	}
 	return result
 }


### PR DESCRIPTION
In [MGMT-19590](https://redhat.atlassian.net/browse/MGMT-19590) (#7187) we started allowing clusters with Cluster-Managed Networking but User-Managed Load Balancers to be allowed to have multiple machine networks.

This PR extends the same support to multi-node clusters with User-Managed Networking (which by definition also have User-Managed Load Balancers).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [OCPBUGS-29975](https://redhat.atlassian.net/browse/OCPBUGS-29975)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dual-stack network validation during cluster creation and updates.
  * Correctly determines load-balancer settings from current and requested configurations.
  * Supports multiple machine networks for single-stack clusters using user-managed networking.
  * Improved cluster registration with multiple machine networks.
  * Ensures node IP allocation and bootstrap hints are applied correctly for user-managed load balancers.
  * Updated validation messaging for insufficient user-managed network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->