### PR TITLE
OCPBUGS-112813: Handle dns-change event in forcedns dispatcher script

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -136,7 +136,7 @@ BASE_DOMAIN=${SNO_BASE_DOMAIN_OVERRIDE:-"{{.DNS_DOMAIN}}"}
 CLUSTER_FULL_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
 
 export BASE_RESOLV_CONF=/run/NetworkManager/resolv.conf
-if [ "$2" = "dhcp4-change" ] || [ "$2" = "dhcp6-change" ] || [ "$2" = "up" ] || [ "$2" = "connectivity-change" ]; then
+if [ "$2" = "dhcp4-change" ] || [ "$2" = "dhcp6-change" ] || [ "$2" = "up" ] || [ "$2" = "connectivity-change" ] || [ "$2" = "dns-change" ]; then
 	export TMP_FILE=$(mktemp /etc/forcedns_resolv.conf.XXXXXX)
 	cp  $BASE_RESOLV_CONF $TMP_FILE
 	chmod --reference=$BASE_RESOLV_CONF $TMP_FILE


### PR DESCRIPTION
## What I did

Added `dns-change` to the list of NetworkManager dispatcher actions handled by the `forcedns` script in `internal/network/manifests_generator.go`.

## Why

The `forcedns` dispatcher script on Assisted SNO clusters does not handle the `dns-change` action. When DNS configuration is changed via `nmstate` / `NodeNetworkConfigurationPolicy` (NNCP), NetworkManager emits a `dns-change` event and updates `/run/NetworkManager/resolv.conf`, but `forcedns` ignores it, leaving `/etc/resolv.conf` stale with the old nameservers.

The current `if` statement only handles: `dhcp4-change`, `dhcp6-change`, `up`, `connectivity-change`.

This means any post-install DNS change via NNCP on Assisted SNO requires a manual `NetworkManager` restart or node reboot to take effect — which defeats the purpose of using nmstate for non-disruptive DNS changes.

## Context

- The `dns-change` dispatcher action was added to NetworkManager in RHEL 9.2 (NM 1.42.2-11, [RHEL-14888](https://redhat.atlassian.net/browse/RHEL-14888)) and is available on all RHCOS versions shipped with OCP 4.14+.
- The bootstrap node's `local-dns-prepender` dispatcher in `openshift/installer` already handles `dns-change` ([installer PR #8430](https://github.com/openshift/installer/pull/8430)).
- The on-prem IPI path is not affected because it uses `on-prem-resolv-prepender.service` with a systemd `.path` watcher on `/run/NetworkManager/resolv.conf`.
- This was reproduced and validated on a fresh Assisted Installer SNO cluster (vSphere, `platform: None`, OCP 4.16). After patching `forcedns` to include `dns-change`, subsequent NNCP DNS changes correctly updated `/etc/resolv.conf` automatically.

## How to verify it

1. Install SNO cluster using Assisted Installer
2. Install `kubernetes-nmstate` operator
3. Apply an NNCP that changes `dns-resolver.config.server`
4. Verify `/etc/resolv.conf` is automatically updated with the new nameservers

## List all the issues related to this PR

- [x] Bug fix

Jira: [OCPBUGS-112813](https://redhat.atlassian.net/browse/OCPBUGS-112813)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forced DNS settings now refresh when NetworkManager reports a DNS configuration change, helping keep name resolution current after network updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->