### PR TITLE
ACM-42573: Assisted services' networkpolicy doesn't work for external image service and local image registry in disconnected environment

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -807,7 +807,7 @@ func newAssistedServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": serviceName},
 			},
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
 			Ingress: []netv1.NetworkPolicyIngressRule{
 				{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}},
 				{
@@ -818,7 +818,6 @@ func newAssistedServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger
 					},
 				},
 			},
-			Egress: networkPolicyDefaultEgress(),
 		}
 		return nil
 	}
@@ -840,23 +839,11 @@ func newImageServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger, a
 		}
 		addAppLabel(imageServiceName, &np.ObjectMeta)
 
-		egress := networkPolicyDefaultEgress()
-		egress = append(egress, netv1.NetworkPolicyEgressRule{
-			To: []netv1.NetworkPolicyPeer{
-				{PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": serviceName},
-				}},
-			},
-			Ports: []netv1.NetworkPolicyPort{
-				{Protocol: ptr.To(corev1.ProtocolTCP), Port: &servicePort},
-			},
-		})
-
 		np.Spec = netv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": imageServiceName},
 			},
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
 			Ingress: []netv1.NetworkPolicyIngressRule{
 				{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}},
 				{
@@ -866,7 +853,6 @@ func newImageServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger, a
 					},
 				},
 			},
-			Egress: egress,
 		}
 		return nil
 	}

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1351,6 +1351,32 @@ var _ = Describe("newImageServiceService", func() {
 	})
 })
 
+var _ = Describe("newAssistedServiceNetworkPolicy", func() {
+	var (
+		asc  *aiv1beta1.AgentServiceConfig
+		ascr *AgentServiceConfigReconciler
+		ascc ASC
+		ctx  = context.Background()
+		log  = logrus.New()
+	)
+
+	BeforeEach(func() {
+		asc = newASCDefault()
+		ascr = newTestReconciler(asc)
+		ascc = initASC(ascr, asc)
+	})
+
+	It("should not restrict egress traffic", func() {
+		obj, mutateFn, err := newAssistedServiceNetworkPolicy(ctx, log, ascc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mutateFn()).To(Succeed())
+
+		np := obj.(*netv1.NetworkPolicy)
+		Expect(np.Spec.PolicyTypes).To(Equal([]netv1.PolicyType{netv1.PolicyTypeIngress}))
+		Expect(np.Spec.Egress).To(BeEmpty())
+	})
+})
+
 var _ = Describe("newImageServiceNetworkPolicy", func() {
 	var (
 		asc  *aiv1beta1.AgentServiceConfig
@@ -1366,21 +1392,14 @@ var _ = Describe("newImageServiceNetworkPolicy", func() {
 		ascc = initASC(ascr, asc)
 	})
 
-	It("should include same-namespace egress to assisted-service on port 8090", func() {
+	It("should not restrict egress traffic", func() {
 		obj, mutateFn, err := newImageServiceNetworkPolicy(ctx, log, ascc)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mutateFn()).To(Succeed())
 
 		np := obj.(*netv1.NetworkPolicy)
-		var sameNamespaceEgressPorts []int32
-		for _, rule := range np.Spec.Egress {
-			if len(rule.To) == 1 && rule.To[0].PodSelector != nil && rule.To[0].NamespaceSelector == nil && rule.To[0].IPBlock == nil {
-				for _, port := range rule.Ports {
-					sameNamespaceEgressPorts = append(sameNamespaceEgressPorts, port.Port.IntVal)
-				}
-			}
-		}
-		Expect(sameNamespaceEgressPorts).To(ContainElement(int32(8090)))
+		Expect(np.Spec.PolicyTypes).To(Equal([]netv1.PolicyType{netv1.PolicyTypeIngress}))
+		Expect(np.Spec.Egress).To(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
## Summary

- Add unrestricted external TCP egress to the `assisted-service` and `assisted-image-service` NetworkPolicies
- In disconnected environments, OS image mirrors and container registries run on non-standard ports (80, 5000, 8080, 8081, 9080, etc.) which were blocked by the current egress rules (only 443/6443/5353 allowed)
- The `infrastructure-operator` NetworkPolicy is unchanged and remains port-restricted
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated assisted service and image service network policies to restrict traffic to inbound connections only.
  * Removed previously permitted outbound access to external endpoints and between the assisted and image services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->