### PR TITLE
MGMT-21334: Don't check ImageSetRef for installed clusters

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1719,13 +1719,12 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 }
 
 func (r *ClusterDeploymentsReconciler) ensureClusterImageSetRef(ctx context.Context, log logrus.FieldLogger, clusterDeployment *hivev1.ClusterDeployment, clusterInstall *hiveext.AgentClusterInstall) (*hivev1.ClusterImageSet, error) {
+	if isInstalled(clusterDeployment, clusterInstall) {
+		return nil, nil
+	}
+
 	// Make sure that the ImageSetRef is set before continuing
 	if clusterInstall.Spec.ImageSetRef == nil {
-		// ImageSetRef is not required for already installed clusters
-		// however we should still try to pull and cache it if it is specified
-		if isInstalled(clusterDeployment, clusterInstall) {
-			return nil, nil
-		}
 		return nil, newInputError("ClusterImageSet must be specified in AgentClusterInstall.Spec.ImageSetRef for cluster that is not installed")
 	}
 

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1094,6 +1094,29 @@ var _ = Describe("cluster reconcile", func() {
 				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 0}))
 			})
 
+			It("stale ClusterImageSet reference when adding nodes to an installed cluster should succeed", func() {
+				// Regression test: an installed cluster may reference a ClusterImageSet that no longer
+				// exists (e.g. deleted after the cluster was installed, or never synced to this hub).
+				// Adding Day-2 workers must not fail with "ClusterImageSet not found".
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
+				cluster := newClusterDeployment(clusterName, testNamespace,
+					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, ""))
+				cluster.Spec.Installed = true
+				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+				mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+
+				aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, getDefaultSNOAgentClusterInstallSpec(clusterName), cluster)
+				// ImageSetRef points to a ClusterImageSet that does not exist in Kubernetes
+				aci.Spec.ImageSetRef = &hivev1.ClusterImageSetReference{Name: "stale-imageset-that-does-not-exist"}
+				Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+				request := newClusterDeploymentRequest(cluster)
+				result, err := cr.Reconcile(ctx, request)
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 0}))
+			})
+
 			It("fail to get openshift version when trying to create a cluster", func() {
 				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some-error"))
@@ -4440,8 +4463,6 @@ var _ = Describe("cluster reconcile", func() {
 		BeforeEach(func() {
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
-			imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
-			Expect(c.Create(ctx, imageSet)).To(BeNil())
 			cluster = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			cluster.Spec.Installed = true
 			Expect(c.Create(ctx, cluster)).To(BeNil())
@@ -4451,7 +4472,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
 			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
-			mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 		})
 
 		It("success", func() {
@@ -4474,7 +4494,9 @@ var _ = Describe("cluster reconcile", func() {
 			V2ImportClusterInternal := func(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID,
 				params installer.V2ImportClusterParams) (*common.Cluster, error) {
 				Expect(string(*params.NewImportClusterParams.OpenshiftClusterID)).To(Equal(cid))
-				Expect(params.NewImportClusterParams.OpenshiftVersion).To(Equal(ocpVersion))
+				// OpenshiftVersion is not populated for installed clusters since ClusterImageSet
+				// resolution is skipped (the ImageSetRef may reference a stale/deleted ClusterImageSet)
+				Expect(params.NewImportClusterParams.OpenshiftVersion).To(Equal(""))
 				return clusterReply, nil
 			}
 			mockInstallerInternal.EXPECT().
@@ -4534,8 +4556,6 @@ var _ = Describe("cluster reconcile", func() {
 
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
-			imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
-			Expect(c.Create(ctx, imageSet)).To(BeNil())
 			clusterDeployment = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			clusterDeployment.Spec.Installed = true
 			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
@@ -5418,8 +5438,6 @@ var _ = Describe("day2 cluster", func() {
 	var (
 		c                              client.Client
 		ctx                            = context.Background()
-		imageSetName                   = "openshift-v4.8.0"
-		releaseImageUrl                = "quay.io/openshift-release-dev/ocp-release:4.8.0-x86_64"
 		clusterKey                     types.NamespacedName
 		clusterName                    = "test-cluster"
 		agentClusterInstallName        = "test-cluster-aci"
@@ -5432,14 +5450,6 @@ var _ = Describe("day2 cluster", func() {
 		mockVersions                   *versions.MockHandler
 		dbCluster                      *common.Cluster
 		mockMirrorRegistries           *mirrorregistries.MockServiceMirrorRegistriesConfigBuilder
-		ocpReleaseVersion              = "4.8.0"
-		ocpVersion                     = "4.8"
-		releaseImage                   = &models.ReleaseImage{
-			CPUArchitecture:  &common.TestDefaultConfig.CPUArchitecture,
-			OpenshiftVersion: &ocpVersion,
-			URL:              &releaseImageUrl,
-			Version:          &ocpReleaseVersion,
-		}
 	)
 
 	BeforeEach(func() {
@@ -5469,9 +5479,6 @@ var _ = Describe("day2 cluster", func() {
 
 		pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 		Expect(c.Create(ctx, pullSecret)).To(BeNil())
-
-		imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
-		Expect(c.Create(ctx, imageSet)).To(BeNil())
 
 		secretName := fmt.Sprintf(adminKubeConfigStringTemplate, clusterName)
 		adminKubeconfigSecret := &corev1.Secret{
@@ -5532,7 +5539,6 @@ var _ = Describe("day2 cluster", func() {
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
 		mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil).AnyTimes()
 
 		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any(), gomock.Any()).Return(dbCluster, nil)
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Day-2 worker additions for installed clusters when their referenced ClusterImageSet is stale or has been deleted.
  * Installed clusters can now proceed without resolving an unnecessary image-set reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->