### PR TITLE
MGMT-24877: Improve sensitive credential redaction

### DIFF
--- a/internal/controller/controllers/pullsecret_handler.go
+++ b/internal/controller/controllers/pullsecret_handler.go
@@ -41,7 +41,7 @@ func (ps *pullSecretManager) GetValidPullSecret(ctx context.Context, key types.N
 
 	err = ps.Installer.ValidatePullSecret(make([]string, 0), pullSecret, "", "")
 	if err != nil {
-		return "", errors.Wrap(err, fmt.Sprintf("invalid pull secret data in secret %s %s", key.Name, pullSecret))
+		return "", errors.Wrap(err, fmt.Sprintf("invalid pull secret data in secret %s/%s", key.Namespace, key.Name))
 	}
 	return pullSecret, nil
 }


### PR DESCRIPTION
Improve sensitive credential redaction

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid pull-secret error messages by identifying the affected secret with its namespace and name.
  * Removed secret contents from the error message to avoid exposing sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->