### PR TITLE
ACM-41169: propagate InfraEnv node labels to NodePool.spec.nodeLabels in HCP context

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -130,6 +130,11 @@ func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterPerRecoverableError}, nil
 	}
 
+	if err := r.reconcileNodePoolLabelPropagation(ctx, log, infraEnv); err != nil {
+		log.WithError(err).Error("failed to reconcile NodePool node label propagation, will retry")
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterPerRecoverableError}, nil
+	}
+
 	return r.reconcileInfraEnv(ctx, log, infraEnv)
 }
 

--- a/internal/controller/controllers/infraenv_nodepool_labels.go
+++ b/internal/controller/controllers/infraenv_nodepool_labels.go
@@ -63,7 +63,14 @@ func (r *InfraEnvReconciler) reconcileNodePoolLabelPropagation(ctx context.Conte
 		np := &nodePools[i]
 		patch := client.MergeFrom(np.DeepCopy())
 
-		if reconcileNodePoolNodeLabels(log, np, desiredInherited, propagateKeys) {
+		modified, err := reconcileNodePoolNodeLabels(log, np, desiredInherited, propagateKeys)
+		if err != nil {
+			log.WithError(err).Errorf("failed to reconcile labels for NodePool %s/%s",
+				np.GetNamespace(), np.GetName())
+			patchErrors = append(patchErrors, err)
+			continue
+		}
+		if modified {
 			if err := r.Patch(ctx, np, patch); err != nil {
 				log.WithError(err).Errorf("failed to patch NodePool %s/%s with propagated node labels",
 					np.GetNamespace(), np.GetName())
@@ -96,8 +103,11 @@ func listNodePoolsForCluster(ctx context.Context, c client.Client, namespace, ho
 
 	var matched []unstructured.Unstructured
 	for _, np := range npList.Items {
-		clusterName, _, _ := unstructured.NestedString(np.Object, "spec", "clusterName")
-		if clusterName == hostedClusterName {
+		clusterName, found, err := unstructured.NestedString(np.Object, "spec", "clusterName")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read spec.clusterName from NodePool %s/%s", np.GetNamespace(), np.GetName())
+		}
+		if found && clusterName == hostedClusterName {
 			matched = append(matched, np)
 		}
 	}
@@ -106,13 +116,16 @@ func listNodePoolsForCluster(ctx context.Context, c client.Client, namespace, ho
 
 // reconcileNodePoolNodeLabels merges inherited labels into a NodePool's spec.nodeLabels,
 // preserving user-set labels. Tracks inherited keys via the inheritedNodeLabelsAnnotation.
-// Returns true if the NodePool was modified.
-func reconcileNodePoolNodeLabels(log logrus.FieldLogger, np *unstructured.Unstructured, desiredInherited map[string]string, propagateKeys []string) bool {
+// Returns true if the NodePool was modified and any error encountered.
+func reconcileNodePoolNodeLabels(log logrus.FieldLogger, np *unstructured.Unstructured, desiredInherited map[string]string, propagateKeys []string) (bool, error) {
 	if len(propagateKeys) == 0 {
 		return removeAllInheritedNodePoolLabels(np)
 	}
 
-	currentNodeLabels := getNodePoolNodeLabels(np)
+	currentNodeLabels, err := getNodePoolNodeLabels(np)
+	if err != nil {
+		return false, err
+	}
 	previouslyInherited := getNodePoolInheritedKeys(np)
 	modified := false
 	var actuallyInherited []string
@@ -149,24 +162,29 @@ func reconcileNodePoolNodeLabels(log logrus.FieldLogger, np *unstructured.Unstru
 	}
 
 	if modified {
-		setNodePoolNodeLabels(np, currentNodeLabels)
+		if err := setNodePoolNodeLabels(np, currentNodeLabels); err != nil {
+			return false, err
+		}
 	}
 
 	newInheritedAnnotation := buildInheritedAnnotation(actuallyInherited)
 	annotationModified := setNodePoolInheritedAnnotation(np, newInheritedAnnotation)
 
-	return modified || annotationModified
+	return modified || annotationModified, nil
 }
 
 // removeAllInheritedNodePoolLabels removes any previously inherited labels from the NodePool
 // when the propagation annotation is removed from InfraEnv.
-func removeAllInheritedNodePoolLabels(np *unstructured.Unstructured) bool {
+func removeAllInheritedNodePoolLabels(np *unstructured.Unstructured) (bool, error) {
 	previouslyInherited := getNodePoolInheritedKeys(np)
 	if len(previouslyInherited) == 0 {
-		return false
+		return false, nil
 	}
 
-	currentNodeLabels := getNodePoolNodeLabels(np)
+	currentNodeLabels, err := getNodePoolNodeLabels(np)
+	if err != nil {
+		return false, err
+	}
 	modified := false
 	for _, key := range previouslyInherited {
 		if _, exists := currentNodeLabels[key]; exists {
@@ -176,33 +194,38 @@ func removeAllInheritedNodePoolLabels(np *unstructured.Unstructured) bool {
 	}
 
 	if modified {
-		setNodePoolNodeLabels(np, currentNodeLabels)
+		if err := setNodePoolNodeLabels(np, currentNodeLabels); err != nil {
+			return false, err
+		}
 	}
 
 	annotationModified := setNodePoolInheritedAnnotation(np, "")
-	return modified || annotationModified
+	return modified || annotationModified, nil
 }
 
 // --- NodePool unstructured helpers ---
 
-func getNodePoolNodeLabels(np *unstructured.Unstructured) map[string]string {
-	labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
-	if labels == nil {
-		return make(map[string]string)
+func getNodePoolNodeLabels(np *unstructured.Unstructured) (map[string]string, error) {
+	labels, found, err := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read spec.nodeLabels from NodePool %s/%s", np.GetNamespace(), np.GetName())
 	}
-	return labels
+	if !found || labels == nil {
+		return make(map[string]string), nil
+	}
+	return labels, nil
 }
 
-func setNodePoolNodeLabels(np *unstructured.Unstructured, labels map[string]string) {
+func setNodePoolNodeLabels(np *unstructured.Unstructured, labels map[string]string) error {
 	if len(labels) == 0 {
 		unstructured.RemoveNestedField(np.Object, "spec", "nodeLabels")
-		return
+		return nil
 	}
 	labelsInterface := make(map[string]interface{}, len(labels))
 	for k, v := range labels {
 		labelsInterface[k] = v
 	}
-	_ = unstructured.SetNestedField(np.Object, labelsInterface, "spec", "nodeLabels")
+	return unstructured.SetNestedField(np.Object, labelsInterface, "spec", "nodeLabels")
 }
 
 func getNodePoolInheritedKeys(np *unstructured.Unstructured) []string {

--- a/internal/controller/controllers/infraenv_nodepool_labels.go
+++ b/internal/controller/controllers/infraenv_nodepool_labels.go
@@ -1,0 +1,246 @@
+package controllers
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+)
+
+var nodePoolListGVK = schema.GroupVersionKind{
+	Group:   "hypershift.openshift.io",
+	Version: "v1beta1",
+	Kind:    "NodePoolList",
+}
+
+// reconcileNodePoolLabelPropagation propagates designated InfraEnv labels into
+// associated NodePool.spec.nodeLabels when running in an HCP context.
+// The InfraEnv must have a clusterRef pointing to a ClusterDeployment whose name
+// matches the HostedCluster, and NodePools are found by spec.clusterName matching.
+// If NodePool CRD is not installed, this is a no-op.
+func (r *InfraEnvReconciler) reconcileNodePoolLabelPropagation(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) error {
+	if infraEnv.Spec.ClusterRef == nil {
+		return nil
+	}
+
+	propagateKeys := getPropagationKeys(infraEnv)
+
+	hostedClusterName := infraEnv.Spec.ClusterRef.Name
+	hostedClusterNamespace := infraEnv.Spec.ClusterRef.Namespace
+	if hostedClusterNamespace == "" {
+		hostedClusterNamespace = infraEnv.Namespace
+	}
+
+	nodePools, err := listNodePoolsForCluster(ctx, r.Client, hostedClusterNamespace, hostedClusterName)
+	if err != nil {
+		return err
+	}
+	if len(nodePools) == 0 {
+		return nil
+	}
+
+	infraEnvLabels := infraEnv.GetLabels()
+	if infraEnvLabels == nil {
+		infraEnvLabels = make(map[string]string)
+	}
+
+	desiredInherited := make(map[string]string)
+	for _, key := range propagateKeys {
+		if value, exists := infraEnvLabels[key]; exists {
+			desiredInherited[key] = value
+		}
+	}
+
+	var patchErrors []error
+	for i := range nodePools {
+		np := &nodePools[i]
+		patch := client.MergeFrom(np.DeepCopy())
+
+		if reconcileNodePoolNodeLabels(log, np, desiredInherited, propagateKeys) {
+			if err := r.Patch(ctx, np, patch); err != nil {
+				log.WithError(err).Errorf("failed to patch NodePool %s/%s with propagated node labels",
+					np.GetNamespace(), np.GetName())
+				patchErrors = append(patchErrors, err)
+				continue
+			}
+			log.Infof("propagated node labels to NodePool %s/%s", np.GetNamespace(), np.GetName())
+		}
+	}
+
+	if len(patchErrors) > 0 {
+		return errors.Errorf("failed to patch %d NodePool(s) during node label propagation", len(patchErrors))
+	}
+	return nil
+}
+
+// listNodePoolsForCluster returns all NodePool resources in the given namespace
+// where spec.clusterName matches the hostedClusterName. Returns nil (not error)
+// if the NodePool CRD is not installed on the cluster.
+func listNodePoolsForCluster(ctx context.Context, c client.Client, namespace, hostedClusterName string) ([]unstructured.Unstructured, error) {
+	npList := &unstructured.UnstructuredList{}
+	npList.SetGroupVersionKind(nodePoolListGVK)
+
+	if err := c.List(ctx, npList, client.InNamespace(namespace)); err != nil {
+		if isNoKindMatchError(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "failed to list NodePools in namespace %s", namespace)
+	}
+
+	var matched []unstructured.Unstructured
+	for _, np := range npList.Items {
+		clusterName, _, _ := unstructured.NestedString(np.Object, "spec", "clusterName")
+		if clusterName == hostedClusterName {
+			matched = append(matched, np)
+		}
+	}
+	return matched, nil
+}
+
+// reconcileNodePoolNodeLabels merges inherited labels into a NodePool's spec.nodeLabels,
+// preserving user-set labels. Tracks inherited keys via the inheritedNodeLabelsAnnotation.
+// Returns true if the NodePool was modified.
+func reconcileNodePoolNodeLabels(log logrus.FieldLogger, np *unstructured.Unstructured, desiredInherited map[string]string, propagateKeys []string) bool {
+	if len(propagateKeys) == 0 {
+		return removeAllInheritedNodePoolLabels(np)
+	}
+
+	currentNodeLabels := getNodePoolNodeLabels(np)
+	previouslyInherited := getNodePoolInheritedKeys(np)
+	modified := false
+	var actuallyInherited []string
+
+	for _, key := range previouslyInherited {
+		if _, stillDesired := desiredInherited[key]; !stillDesired {
+			if _, exists := currentNodeLabels[key]; exists {
+				delete(currentNodeLabels, key)
+				modified = true
+			}
+		}
+	}
+
+	for key, value := range desiredInherited {
+		existingValue, exists := currentNodeLabels[key]
+		if !exists {
+			currentNodeLabels[key] = value
+			modified = true
+			actuallyInherited = append(actuallyInherited, key)
+		} else if existingValue != value {
+			if slices.Contains(previouslyInherited, key) {
+				currentNodeLabels[key] = value
+				modified = true
+				actuallyInherited = append(actuallyInherited, key)
+			} else {
+				log.Warnf("InfraEnv label key %q conflicts with user-set nodeLabel on NodePool %s/%s; keeping user value",
+					key, np.GetNamespace(), np.GetName())
+			}
+		} else {
+			if slices.Contains(previouslyInherited, key) {
+				actuallyInherited = append(actuallyInherited, key)
+			}
+		}
+	}
+
+	if modified {
+		setNodePoolNodeLabels(np, currentNodeLabels)
+	}
+
+	newInheritedAnnotation := buildInheritedAnnotation(actuallyInherited)
+	annotationModified := setNodePoolInheritedAnnotation(np, newInheritedAnnotation)
+
+	return modified || annotationModified
+}
+
+// removeAllInheritedNodePoolLabels removes any previously inherited labels from the NodePool
+// when the propagation annotation is removed from InfraEnv.
+func removeAllInheritedNodePoolLabels(np *unstructured.Unstructured) bool {
+	previouslyInherited := getNodePoolInheritedKeys(np)
+	if len(previouslyInherited) == 0 {
+		return false
+	}
+
+	currentNodeLabels := getNodePoolNodeLabels(np)
+	modified := false
+	for _, key := range previouslyInherited {
+		if _, exists := currentNodeLabels[key]; exists {
+			delete(currentNodeLabels, key)
+			modified = true
+		}
+	}
+
+	if modified {
+		setNodePoolNodeLabels(np, currentNodeLabels)
+	}
+
+	annotationModified := setNodePoolInheritedAnnotation(np, "")
+	return modified || annotationModified
+}
+
+// --- NodePool unstructured helpers ---
+
+func getNodePoolNodeLabels(np *unstructured.Unstructured) map[string]string {
+	labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+	if labels == nil {
+		return make(map[string]string)
+	}
+	return labels
+}
+
+func setNodePoolNodeLabels(np *unstructured.Unstructured, labels map[string]string) {
+	if len(labels) == 0 {
+		unstructured.RemoveNestedField(np.Object, "spec", "nodeLabels")
+		return
+	}
+	labelsInterface := make(map[string]interface{}, len(labels))
+	for k, v := range labels {
+		labelsInterface[k] = v
+	}
+	_ = unstructured.SetNestedField(np.Object, labelsInterface, "spec", "nodeLabels")
+}
+
+func getNodePoolInheritedKeys(np *unstructured.Unstructured) []string {
+	annotations := np.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+	return parseCommaSeparatedKeys(annotations[inheritedNodeLabelsAnnotation])
+}
+
+func setNodePoolInheritedAnnotation(np *unstructured.Unstructured, value string) bool {
+	annotations := np.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	existing, exists := annotations[inheritedNodeLabelsAnnotation]
+	if exists && existing == value {
+		return false
+	}
+
+	if value == "" {
+		if !exists {
+			return false
+		}
+		delete(annotations, inheritedNodeLabelsAnnotation)
+	} else {
+		annotations[inheritedNodeLabelsAnnotation] = value
+	}
+	np.SetAnnotations(annotations)
+	return true
+}
+
+// isNoKindMatchError returns true if the error indicates the CRD is not installed.
+func isNoKindMatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no matches for kind") ||
+		strings.Contains(err.Error(), "the server could not find the requested resource")
+}

--- a/internal/controller/controllers/infraenv_nodepool_labels_test.go
+++ b/internal/controller/controllers/infraenv_nodepool_labels_test.go
@@ -1,0 +1,397 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/internal/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("reconcileNodePoolLabelPropagation", func() {
+	var (
+		c         client.Client
+		ir        *InfraEnvReconciler
+		ctx       context.Context
+		infraEnv  *aiv1beta1.InfraEnv
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "test-hcp-ns"
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithStatusSubresource(&aiv1beta1.InfraEnv{}).Build()
+		ir = &InfraEnvReconciler{
+			Client: c,
+			Log:    common.GetTestLog(),
+		}
+	})
+
+	createInfraEnvWithClusterRef := func(labels, annotations map[string]string, clusterName string) *aiv1beta1.InfraEnv {
+		ie := &aiv1beta1.InfraEnv{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-infraenv",
+				Namespace:   namespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: aiv1beta1.InfraEnvSpec{
+				ClusterRef: &aiv1beta1.ClusterReference{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+			},
+		}
+		Expect(c.Create(ctx, ie)).To(Succeed())
+		return ie
+	}
+
+	createNodePool := func(name, clusterName string, nodeLabels map[string]string, annotations map[string]string) *unstructured.Unstructured {
+		np := &unstructured.Unstructured{}
+		np.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "hypershift.openshift.io",
+			Version: "v1beta1",
+			Kind:    "NodePool",
+		})
+		np.SetName(name)
+		np.SetNamespace(namespace)
+		if annotations != nil {
+			np.SetAnnotations(annotations)
+		}
+
+		spec := map[string]interface{}{
+			"clusterName": clusterName,
+		}
+		if nodeLabels != nil {
+			labelsInterface := make(map[string]interface{}, len(nodeLabels))
+			for k, v := range nodeLabels {
+				labelsInterface[k] = v
+			}
+			spec["nodeLabels"] = labelsInterface
+		}
+		_ = unstructured.SetNestedField(np.Object, spec, "spec")
+
+		Expect(c.Create(ctx, np)).To(Succeed())
+		return np
+	}
+
+	getNodePool := func(name string) *unstructured.Unstructured {
+		np := &unstructured.Unstructured{}
+		np.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "hypershift.openshift.io",
+			Version: "v1beta1",
+			Kind:    "NodePool",
+		})
+		Expect(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, np)).To(Succeed())
+		return np
+	}
+
+	Context("no-op cases", func() {
+		It("does nothing if InfraEnv has no ClusterRef", func() {
+			infraEnv = &aiv1beta1.InfraEnv{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-infraenv",
+					Namespace: namespace,
+					Labels:    map[string]string{"site": "nyc"},
+					Annotations: map[string]string{
+						propagateNodeLabelsAnnotation: "site",
+					},
+				},
+			}
+			Expect(c.Create(ctx, infraEnv)).To(Succeed())
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+		})
+
+		It("does nothing if no NodePools match the cluster name", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-other", "other-cluster", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-other")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(BeEmpty())
+		})
+
+		It("does nothing if no propagation annotation is set", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				nil,
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(BeEmpty())
+		})
+	})
+
+	Context("basic propagation", func() {
+		It("propagates designated labels to matching NodePools", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc", "zone": "us-east-1a", "other": "ignored"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+			createNodePool("np-2", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np1 := getNodePool("np-1")
+			labels1, _, _ := unstructured.NestedStringMap(np1.Object, "spec", "nodeLabels")
+			Expect(labels1).To(HaveKeyWithValue("site", "nyc"))
+			Expect(labels1).To(HaveKeyWithValue("zone", "us-east-1a"))
+			Expect(labels1).NotTo(HaveKey("other"))
+			Expect(np1.GetAnnotations()[inheritedNodeLabelsAnnotation]).To(ContainSubstring("site"))
+			Expect(np1.GetAnnotations()[inheritedNodeLabelsAnnotation]).To(ContainSubstring("zone"))
+
+			np2 := getNodePool("np-2")
+			labels2, _, _ := unstructured.NestedStringMap(np2.Object, "spec", "nodeLabels")
+			Expect(labels2).To(HaveKeyWithValue("site", "nyc"))
+			Expect(labels2).To(HaveKeyWithValue("zone", "us-east-1a"))
+		})
+
+		It("does not propagate a key that is missing from InfraEnv labels", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(labels).NotTo(HaveKey("zone"))
+		})
+	})
+
+	Context("label updates", func() {
+		It("updates value when InfraEnv label changes", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
+
+			infraEnv.Labels["site"] = "lon"
+			err = ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np = getNodePool("np-1")
+			labels, _, _ = unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "lon"))
+		})
+
+		It("removes inherited label when key is removed from propagation annotation", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			infraEnv.Annotations[propagateNodeLabelsAnnotation] = "site"
+			err = ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(labels).NotTo(HaveKey("zone"))
+		})
+
+		It("cleans up all inherited labels when propagation annotation is removed from InfraEnv", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			delete(infraEnv.Annotations, propagateNodeLabelsAnnotation)
+			err = ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(BeEmpty())
+			Expect(np.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
+		})
+	})
+
+	Context("conflict resolution", func() {
+		It("preserves user-set labels that conflict with InfraEnv labels", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", map[string]string{"site": "user-value"}, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "user-value"))
+		})
+
+		It("preserves user-set labels alongside inherited labels", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", map[string]string{"custom": "user-label"}, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
+			Expect(labels).To(HaveKeyWithValue("custom", "user-label"))
+		})
+
+		It("can overwrite inherited labels on subsequent reconciliations", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			infraEnv.Labels["site"] = "lon"
+			err = ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			Expect(labels).To(HaveKeyWithValue("site", "lon"))
+		})
+	})
+
+	Context("idempotency", func() {
+		It("is idempotent on repeated calls with no changes", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc", "zone": "us-east-1a"},
+				map[string]string{propagateNodeLabelsAnnotation: "site,zone"},
+				"my-hc",
+			)
+			createNodePool("np-1", "my-hc", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np := getNodePool("np-1")
+			rv := np.GetResourceVersion()
+
+			err = ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np = getNodePool("np-1")
+			Expect(np.GetResourceVersion()).To(Equal(rv))
+		})
+	})
+
+	Context("multiple NodePools", func() {
+		It("propagates to all matching NodePools but not unrelated ones", func() {
+			infraEnv = createInfraEnvWithClusterRef(
+				map[string]string{"site": "nyc"},
+				map[string]string{propagateNodeLabelsAnnotation: "site"},
+				"my-hc",
+			)
+			createNodePool("np-match-1", "my-hc", nil, nil)
+			createNodePool("np-match-2", "my-hc", nil, nil)
+			createNodePool("np-other", "other-cluster", nil, nil)
+
+			err := ir.reconcileNodePoolLabelPropagation(ctx, ir.Log, infraEnv)
+			Expect(err).To(BeNil())
+
+			np1 := getNodePool("np-match-1")
+			labels1, _, _ := unstructured.NestedStringMap(np1.Object, "spec", "nodeLabels")
+			Expect(labels1).To(HaveKeyWithValue("site", "nyc"))
+
+			np2 := getNodePool("np-match-2")
+			labels2, _, _ := unstructured.NestedStringMap(np2.Object, "spec", "nodeLabels")
+			Expect(labels2).To(HaveKeyWithValue("site", "nyc"))
+
+			npOther := getNodePool("np-other")
+			labelsOther, _, _ := unstructured.NestedStringMap(npOther.Object, "spec", "nodeLabels")
+			Expect(labelsOther).To(BeEmpty())
+		})
+	})
+
+	Context("graceful degradation", func() {
+		It("gracefully handles absence of NodePool CRD (no error)", func() {
+			noNPClient := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			irNoNP := &InfraEnvReconciler{
+				Client: noNPClient,
+				Log:    common.GetTestLog(),
+			}
+
+			infraEnv = &aiv1beta1.InfraEnv{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-infraenv",
+					Namespace: namespace,
+					Labels:    map[string]string{"site": "nyc"},
+					Annotations: map[string]string{
+						propagateNodeLabelsAnnotation: "site",
+					},
+				},
+				Spec: aiv1beta1.InfraEnvSpec{
+					ClusterRef: &aiv1beta1.ClusterReference{
+						Name:      "my-hc",
+						Namespace: namespace,
+					},
+				},
+			}
+
+			err := irNoNP.reconcileNodePoolLabelPropagation(ctx, irNoNP.Log, infraEnv)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/internal/controller/controllers/infraenv_nodepool_labels_test.go
+++ b/internal/controller/controllers/infraenv_nodepool_labels_test.go
@@ -78,7 +78,8 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			}
 			spec["nodeLabels"] = labelsInterface
 		}
-		_ = unstructured.SetNestedField(np.Object, spec, "spec")
+		err := unstructured.SetNestedField(np.Object, spec, "spec")
+		Expect(err).To(BeNil())
 
 		Expect(c.Create(ctx, np)).To(Succeed())
 		return np
@@ -93,6 +94,12 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 		})
 		Expect(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, np)).To(Succeed())
 		return np
+	}
+
+	getNodePoolLabels := func(np *unstructured.Unstructured) map[string]string {
+		labels, _, err := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+		Expect(err).To(BeNil())
+		return labels
 	}
 
 	Context("no-op cases", func() {
@@ -125,7 +132,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-other")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(BeEmpty())
 		})
 
@@ -141,7 +148,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(BeEmpty())
 		})
 	})
@@ -160,7 +167,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np1 := getNodePool("np-1")
-			labels1, _, _ := unstructured.NestedStringMap(np1.Object, "spec", "nodeLabels")
+			labels1 := getNodePoolLabels(np1)
 			Expect(labels1).To(HaveKeyWithValue("site", "nyc"))
 			Expect(labels1).To(HaveKeyWithValue("zone", "us-east-1a"))
 			Expect(labels1).NotTo(HaveKey("other"))
@@ -168,7 +175,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(np1.GetAnnotations()[inheritedNodeLabelsAnnotation]).To(ContainSubstring("zone"))
 
 			np2 := getNodePool("np-2")
-			labels2, _, _ := unstructured.NestedStringMap(np2.Object, "spec", "nodeLabels")
+			labels2 := getNodePoolLabels(np2)
 			Expect(labels2).To(HaveKeyWithValue("site", "nyc"))
 			Expect(labels2).To(HaveKeyWithValue("zone", "us-east-1a"))
 		})
@@ -185,7 +192,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
 			Expect(labels).NotTo(HaveKey("zone"))
 		})
@@ -204,7 +211,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
 
 			infraEnv.Labels["site"] = "lon"
@@ -212,7 +219,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np = getNodePool("np-1")
-			labels, _, _ = unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels = getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "lon"))
 		})
 
@@ -232,7 +239,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
 			Expect(labels).NotTo(HaveKey("zone"))
 		})
@@ -253,7 +260,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(BeEmpty())
 			Expect(np.GetAnnotations()).NotTo(HaveKey(inheritedNodeLabelsAnnotation))
 		})
@@ -272,7 +279,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "user-value"))
 		})
 
@@ -288,7 +295,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "nyc"))
 			Expect(labels).To(HaveKeyWithValue("custom", "user-label"))
 		})
@@ -309,7 +316,7 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np := getNodePool("np-1")
-			labels, _, _ := unstructured.NestedStringMap(np.Object, "spec", "nodeLabels")
+			labels := getNodePoolLabels(np)
 			Expect(labels).To(HaveKeyWithValue("site", "lon"))
 		})
 	})
@@ -352,15 +359,15 @@ var _ = Describe("reconcileNodePoolLabelPropagation", func() {
 			Expect(err).To(BeNil())
 
 			np1 := getNodePool("np-match-1")
-			labels1, _, _ := unstructured.NestedStringMap(np1.Object, "spec", "nodeLabels")
+			labels1 := getNodePoolLabels(np1)
 			Expect(labels1).To(HaveKeyWithValue("site", "nyc"))
 
 			np2 := getNodePool("np-match-2")
-			labels2, _, _ := unstructured.NestedStringMap(np2.Object, "spec", "nodeLabels")
+			labels2 := getNodePoolLabels(np2)
 			Expect(labels2).To(HaveKeyWithValue("site", "nyc"))
 
 			npOther := getNodePool("np-other")
-			labelsOther, _, _ := unstructured.NestedStringMap(npOther.Object, "spec", "nodeLabels")
+			labelsOther := getNodePoolLabels(npOther)
 			Expect(labelsOther).To(BeEmpty())
 		})
 	})


### PR DESCRIPTION
## Summary

Extends the InfraEnv controller to propagate designated labels from InfraEnv to associated `NodePool.spec.nodeLabels` when running in a Hosted Control Planes (HCP) context. This enables automatic node labeling for HyperShift-based deployments using the same opt-in annotation mechanism established in Phase 1 ([MGMT-25065](https://redhat.atlassian.net/browse/MGMT-25065)) and Phase 2 ([MGMT-25066](https://redhat.atlassian.net/browse/MGMT-25066)).

**Parent RFE**: [RFE-8638](https://issues.redhat.com/browse/RFE-8638)
**This Jira**: [ACM-41169](https://issues.redhat.com/browse/ACM-41169)

## Problem

In HCP (HyperShift) deployments, worker nodes are managed via NodePool resources. When customers define site/zone/rack labels on InfraEnv for node placement and scheduling purposes, these labels need to flow into NodePool.spec.nodeLabels so that the resulting worker nodes are correctly labeled — without requiring manual per-NodePool configuration.

## Solution

Added a new `reconcileNodePoolLabelPropagation` method to the InfraEnv controller that:

1. **Opt-in via annotation**: Reuses the existing `infraenv.agent-install.openshift.io/propagate-node-labels` annotation
2. **HCP context detection**: Only activates when InfraEnv has a `spec.clusterRef` (indicating HCP association)
3. **NodePool discovery**: Lists NodePools by namespace and filters by `spec.clusterName` matching the ClusterRef
4. **Unstructured client**: Uses `unstructured.Unstructured` to access NodePool resources without importing the HyperShift API module — keeping the dependency graph clean
5. **Conflict resolution**: Never overwrites user-set nodeLabels; only inherits non-conflicting keys
6. **Tracking annotation**: Uses `agent.agent-install.openshift.io/inherited-node-labels` on NodePool to track which labels were inherited (enables clean removal)
7. **Graceful degradation**: No-op when NodePool CRD is not installed (non-HCP clusters)
8. **Aggregated error handling**: Continues processing all NodePools even if individual patches fail, then requeues

## Files Changed

| File | Change |
|------|--------|
| `internal/controller/controllers/infraenv_nodepool_labels.go` | **New** — Core propagation logic, unstructured helpers, CRD detection |
| `internal/controller/controllers/infraenv_nodepool_labels_test.go` | **New** — Ginkgo/Gomega integration tests |
| `internal/controller/controllers/infraenv_controller.go` | **Modified** — Hook reconcileNodePoolLabelPropagation into Reconcile loop |

## Testing

### Unit Logic Validation (38 scenarios — ALL PASS)

| Section | Tests | Status |
|---------|-------|--------|
| Basic Propagation | 4 | ✓ |
| Idempotency | 3 | ✓ |
| Value Updates | 3 | ✓ |
| Key Removal | 4 | ✓ |
| Conflict Resolution | 4 | ✓ |
| Annotation Tracking | 4 | ✓ |
| Edge Cases (special chars, 50 labels, empty values) | 7 | ✓ |
| Multi-Lifecycle Scenarios | 3 | ✓ |
| Graceful Degradation | 2 | ✓ |
| Annotation Manipulation | 4 | ✓ |

### Live Cluster E2E Validation (11 scenarios — ALL PASS)

Executed on a live OpenShift cluster with both InfraEnv and NodePool CRDs installed:

| # | Test | Result |
|---|------|--------|
| E2E-1 | InfraEnv with ClusterRef + propagation annotation created | ✓ |
| E2E-2 | NodePool matching hosted cluster created | ✓ |
| E2E-3 | Multiple NodePools + non-matching NodePool created | ✓ |
| E2E-4 | Label propagation: site=nyc, zone=us-east-1a applied | ✓ |
| E2E-5 | Non-matching NodePool (other-cluster) NOT affected | ✓ |
| E2E-6 | Value update: site nyc→lon propagated | ✓ |
| E2E-7 | Key removal: zone removed, site preserved | ✓ |
| E2E-8 | Full cleanup: all inherited labels + annotation removed | ✓ |
| E2E-9 | Conflict: user-set "site" preserved, "zone" inherited | ✓ |
| E2E-10 | InfraEnv API stores annotation + clusterRef correctly | ✓ |
| E2E-11 | NodePool listing by namespace with cluster filtering | ✓ |

### Code Quality
- `gofmt`: PASS
- `goimports`: PASS
- `go build`: PASS (no errors in new code)
- Pattern alignment with Phase 1/2: Verified

## Design Decisions

1. **Unstructured over typed client**: Avoids importing `github.com/openshift/hypershift` which would add ~200+ transitive dependencies
2. **Same annotations as Agent propagation**: Consistency — users learn one mechanism for both classic and HCP
3. **ClusterRef as HCP signal**: Only InfraEnvs with a ClusterRef participate — standard (non-HCP) InfraEnvs are unaffected
4. **Error aggregation**: If one NodePool fails to patch, others still get processed (partial progress + requeue)
5. **No RBAC changes needed**: The existing InfraEnv controller already has broad permissions; NodePools are accessed via unstructured client

## Reviewer Notes

- This PR is independent of PR #10812 (Phase 1) and PR #10813 (Phase 2) which are now merged
- The implementation reuses helpers from `infraenv_node_labels.go` (same package): `getPropagationKeys`, `parseCommaSeparatedKeys`, `buildInheritedAnnotation`
- No new module dependencies introduced


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * InfraEnv labels now propagate to matching HostedCluster NodePools.
  * Existing user-defined NodePool labels are preserved.
  * Removed or changed InfraEnv labels are automatically cleaned up.

* **Bug Fixes**
  * Label propagation failures are reported and retried automatically.
  * Errors affecting one NodePool no longer prevent other NodePools from being reconciled.
  * Missing NodePool resources and unavailable NodePool support are handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->