### PR TITLE
ACM-39262: chain PostgreSQL hops for EUS skip-upgrades

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,12 @@ spec:
             value: quay.io/edge-infrastructure/assisted-image-service:latest
           - name: DATABASE_IMAGE
             value: quay.io/sclorg/postgresql-16-c9s:latest
+          - name: DATABASE_IMAGE_VERSION
+            value: "16"
+          - name: DATABASE_IMAGE_PG13
+            value: quay.io/sclorg/postgresql-13-c9s:latest
+          - name: DATABASE_IMAGE_PG15
+            value: quay.io/sclorg/postgresql-15-c9s:latest
           - name: AGENT_IMAGE
             value: quay.io/edge-infrastructure/assisted-installer-agent:latest
           - name: CONTROLLER_IMAGE

--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -199,6 +199,10 @@ spec:
     name: image-service
   - image: quay.io/sclorg/postgresql-16-c9s:latest
     name: postgresql
+  - image: quay.io/sclorg/postgresql-13-c9s:latest
+    name: postgresql-13
+  - image: quay.io/sclorg/postgresql-15-c9s:latest
+    name: postgresql-15
   - image: quay.io/edge-infrastructure/assisted-installer:latest
     name: installer
   - image: quay.io/edge-infrastructure/assisted-installer-agent:latest

--- a/config/manifests/bundle-overrides/related-images-patch.yaml
+++ b/config/manifests/bundle-overrides/related-images-patch.yaml
@@ -12,6 +12,10 @@ spec:
       image: quay.io/edge-infrastructure/assisted-image-service:latest
     - name: postgresql
       image: quay.io/sclorg/postgresql-16-c9s:latest
+    - name: postgresql-13
+      image: quay.io/sclorg/postgresql-13-c9s:latest
+    - name: postgresql-15
+      image: quay.io/sclorg/postgresql-15-c9s:latest
     - name: installer
       image: quay.io/edge-infrastructure/assisted-installer:latest
     - name: agent

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -924,6 +924,12 @@ spec:
                   value: quay.io/edge-infrastructure/assisted-image-service:latest
                 - name: DATABASE_IMAGE
                   value: quay.io/sclorg/postgresql-16-c9s:latest
+                - name: DATABASE_IMAGE_VERSION
+                  value: "16"
+                - name: DATABASE_IMAGE_PG13
+                  value: quay.io/sclorg/postgresql-13-c9s:latest
+                - name: DATABASE_IMAGE_PG15
+                  value: quay.io/sclorg/postgresql-15-c9s:latest
                 - name: AGENT_IMAGE
                   value: quay.io/edge-infrastructure/assisted-installer-agent:latest
                 - name: CONTROLLER_IMAGE
@@ -1064,6 +1070,10 @@ spec:
     name: image-service
   - image: quay.io/sclorg/postgresql-16-c9s:latest
     name: postgresql
+  - image: quay.io/sclorg/postgresql-13-c9s:latest
+    name: postgresql-13
+  - image: quay.io/sclorg/postgresql-15-c9s:latest
+    name: postgresql-15
   - image: quay.io/edge-infrastructure/assisted-installer:latest
     name: installer
   - image: quay.io/edge-infrastructure/assisted-installer-agent:latest

--- a/docs/dev/postgresql-upgrade.md
+++ b/docs/dev/postgresql-upgrade.md
@@ -154,10 +154,12 @@ To upgrade to a new PostgreSQL version:
 
 1. Update `internal/controller/controllers/images.go` with the new image
 2. Add the previous image as a hop in `postgres_upgrade.go` (`postgresUpgradePath`) if customers can skip to the new version from an older EUS
-3. Update `deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml`:
-   - Update `DATABASE_IMAGE` env var
-   - Add `DATABASE_IMAGE_PG<prev>` env vars for intermediate hops
-   - Update `relatedImages` section (current image plus every hop image)
+3. Update operator packaging so `hack/generate.sh generate_bundle` keeps the hop images:
+   - `config/manager/manager.yaml`: `DATABASE_IMAGE` plus `DATABASE_IMAGE_PG<prev>` env vars
+   - `config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml`: same env vars and `relatedImages`
+   - `config/manifests/bundle-overrides/related-images-patch.yaml`: current image plus every hop image
+     (operator-sdk drops `relatedImages`; this patch is what verify-generated-code checks)
+   - Then regenerate the catalog CSV (`deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml`)
 4. Update backplane-operator:
    - `hack/bundle-automation/config.yaml` - image mapping
    - `pkg/templates/charts/toggle/assisted-service/values.yaml`

--- a/docs/dev/postgresql-upgrade.md
+++ b/docs/dev/postgresql-upgrade.md
@@ -181,7 +181,7 @@ This ensures the old pod releases the PVC before the new pod starts, preventing 
 
 The sclorg container still validates that each hop's source data matches `POSTGRESQL_PREV_VERSION`. If data is older than the first hop we ship (currently PG12 via `postgresql-13-c9s`), the hop init container fails with:
 
-```
+```text
 this hop image can only upgrade from 12, not '<version>'.
 An earlier hop init container is missing from the upgrade path.
 ```

--- a/docs/dev/postgresql-upgrade.md
+++ b/docs/dev/postgresql-upgrade.md
@@ -21,9 +21,34 @@ The script:
 4. Calls `run-postgresql` to start the database
 
 This handles all scenarios correctly:
-- **Fresh install**: No data → normal initialization
-- **Restart (same version)**: Versions match → normal startup
-- **Upgrade (version mismatch)**: Versions differ → enables pg_upgrade
+- **Fresh install**: No data → hop init containers no-op, main container initializes
+- **Restart (same version)**: Versions match → hop init containers no-op, normal startup
+- **Adjacent upgrade (version mismatch of one hop)**: Main container enables pg_upgrade
+- **EUS skip-upgrade (for example PG12 → PG15 or PG12 → PG16)**: Init containers walk the sclorg hop chain, then the main container starts
+
+## EUS skip-upgrades (ACM-39262)
+
+Each sclorg image can only upgrade from `POSTGRESQL_PREV_VERSION`. ACM EUS skips more than one PostgreSQL major version:
+
+| ACM upgrade | Data version | Target image | Required hops |
+|-------------|--------------|--------------|---------------|
+| 2.15 → 2.16 | PG12 | PG13 | 12 → 13 |
+| 2.16 → 2.17 | PG13 | PG15 | 13 → 15 |
+| 2.15 → 2.17 | PG12 | PG15 | 12 → 13 → 15 |
+| 2.16 → 2.18 | PG13 | PG16 | 13 → 15 → 16 |
+| 2.15 → 2.18 | PG12 | PG16 | 12 → 13 → 15 → 16 |
+
+The operator therefore adds **init containers** for every hop strictly older than `DATABASE_IMAGE`:
+
+1. `postgres-upgrade-to-13` uses `DATABASE_IMAGE_PG13` (`postgresql-13-c9s`) and runs `postgres_hop.sh`
+2. `postgres-upgrade-to-15` uses `DATABASE_IMAGE_PG15` (`postgresql-15-c9s`) and runs `postgres_hop.sh`
+3. The main `postgres` container uses `DATABASE_IMAGE` and `postgres_startup.sh`
+
+`postgres_hop.sh` only reads `PG_VERSION` to decide whether to run. If data is already at or newer than that hop, it exits 0 without starting PostgreSQL (an older image cannot open a newer data directory). If data matches `POSTGRESQL_PREV_VERSION`, it sets `POSTGRESQL_UPGRADE=hardlink`, calls sclorg `try_pgupgrade`, and exits so the next container can run.
+
+These intermediate images **must** be in the operator CSV `relatedImages` and operator env (`DATABASE_IMAGE_PG13`, `DATABASE_IMAGE_PG15`) so disconnected / oc-mirror payloads include them.
+
+If the target image reference has no `postgresql-N` token (bare digest), set `DATABASE_IMAGE_VERSION` to the major version (for example `16`) so the operator still emits the correct hops. When the image name already contains `postgresql-N`, that token wins over `DATABASE_IMAGE_VERSION`.
 
 ## How pg_upgrade Works
 
@@ -128,15 +153,17 @@ Note: There is no `postgresql-14-c9s` image. RHEL 9 module streams skip PG14, so
 To upgrade to a new PostgreSQL version:
 
 1. Update `internal/controller/controllers/images.go` with the new image
-2. Update `deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml`:
+2. Add the previous image as a hop in `postgres_upgrade.go` (`postgresUpgradePath`) if customers can skip to the new version from an older EUS
+3. Update `deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml`:
    - Update `DATABASE_IMAGE` env var
-   - Update `relatedImages` section
-3. Update backplane-operator:
+   - Add `DATABASE_IMAGE_PG<prev>` env vars for intermediate hops
+   - Update `relatedImages` section (current image plus every hop image)
+4. Update backplane-operator:
    - `hack/bundle-automation/config.yaml` - image mapping
    - `pkg/templates/charts/toggle/assisted-service/values.yaml`
    - `pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml`
 
-The wrapper script automatically detects version mismatches and triggers `pg_upgrade` when needed.
+Hop init containers plus the wrapper script automatically walk the sclorg path and trigger `pg_upgrade` when needed.
 
 ## Deployment Strategy
 
@@ -148,15 +175,13 @@ deploymentStrategy := appsv1.DeploymentStrategy{
 }
 ```
 
-This ensures the old pod releases the PVC before the new pod starts, preventing deadlocks.
+This ensures the old pod releases the PVC before the new pod starts, preventing deadlocks. Hop init containers run in that new pod, sequentially, on the same PVC.
 
-## Version Skip Protection
+## Unsupported source versions
 
-The sclorg container validates that the source data version matches `POSTGRESQL_PREV_VERSION`. If a customer tries to skip versions (e.g., PG12 → PG15), the container fails with a clear error:
+The sclorg container still validates that each hop's source data matches `POSTGRESQL_PREV_VERSION`. If data is older than the first hop we ship (currently PG12 via `postgresql-13-c9s`), the hop init container fails with:
 
 ```
-With this container image you can only upgrade from data directory
-of version '13', not '12'.
+this hop image can only upgrade from 12, not '<version>'.
+An earlier hop init container is missing from the upgrade path.
 ```
-
-This prevents accidental data corruption from unsupported upgrade paths.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -181,6 +181,12 @@ spec:
         value: ${SERVICE_IMAGE}
       - name: DATABASE_IMAGE
         value: ${DATABASE_IMAGE}
+      - name: DATABASE_IMAGE_VERSION
+        value: ${DATABASE_IMAGE_VERSION}
+      - name: DATABASE_IMAGE_PG13
+        value: ${DATABASE_IMAGE_PG13}
+      - name: DATABASE_IMAGE_PG15
+        value: ${DATABASE_IMAGE_PG15}
       - name: AGENT_IMAGE
         value: ${AGENT_IMAGE}
       - name: CONTROLLER_IMAGE

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -2236,12 +2236,31 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 		},
 	}
 
+	postgresEnv := []corev1.EnvVar{
+		newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_DATABASE", "db.name", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_USER", "db.user", databaseName),
+		newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_PASSWORD", "db.password", databaseName),
+	}
+	postgresVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "postgresdb",
+			MountPath: "/var/lib/pgsql/data",
+		},
+	}
+	postgresResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+	}
+
 	postgresContainer := corev1.Container{
 		Name:  databaseName,
 		Image: DatabaseImage(),
 		// Use a wrapper script that conditionally enables pg_upgrade only when a version
 		// mismatch is detected. This allows automatic upgrades while avoiding failures
-		// on normal restarts. See docs/dev/postgresql-upgrade.md for details.
+		// on normal restarts. EUS skip-upgrades (PG12 → PG15) are handled by hop init
+		// containers. See docs/dev/postgresql-upgrade.md for details.
 		Command: []string{"/bin/bash", "-c"},
 		Args:    []string{PostgresStartupScript},
 		Ports: []corev1.ContainerPort{
@@ -2251,23 +2270,9 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env: []corev1.EnvVar{
-			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_DATABASE", "db.name", databaseName),
-			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_USER", "db.user", databaseName),
-			newSecretEnvVar(asc.Object.GetAnnotations(), "POSTGRESQL_PASSWORD", "db.password", databaseName),
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "postgresdb",
-				MountPath: "/var/lib/pgsql/data",
-			},
-		},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("400Mi"),
-			},
-		},
+		Env:          postgresEnv,
+		VolumeMounts: postgresVolumeMounts,
+		Resources:    postgresResources,
 	}
 
 	if asc.spec.MirrorRegistryRef != nil {
@@ -2397,6 +2402,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 		setAnnotation(meta, mirrorConfigHashAnnotation, mirrorConfigHash)
 		setAnnotation(meta, userConfigHashAnnotation, userConfigHash)
 
+		deployment.Spec.Template.Spec.InitContainers = postgresUpgradeInitContainers(postgresEnv, postgresVolumeMounts, postgresResources)
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{serviceContainer, postgresContainer}
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -2364,6 +2364,25 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 		Expect(found.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort).To(Equal(int32(serviceHTTPPort.IntValue())))
 	})
 
+	It("adds postgres hop init containers for EUS skip-upgrades", func() {
+		asc = newASCDefault()
+		ascr = newTestReconciler(asc, route, assistedCM, assistedTrustedCM)
+		ascc = initASC(ascr, asc)
+		AssertReconcileSuccess(ctx, log, ascc, newAssistedServiceDeployment)
+
+		found := &appsv1.Deployment{}
+		Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
+		Expect(found.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+		Expect(found.Spec.Template.Spec.InitContainers[0].Name).To(Equal("postgres-upgrade-to-13"))
+		Expect(found.Spec.Template.Spec.InitContainers[0].Image).To(Equal(defaultDatabaseImagePG13))
+		Expect(found.Spec.Template.Spec.InitContainers[1].Name).To(Equal("postgres-upgrade-to-15"))
+		Expect(found.Spec.Template.Spec.InitContainers[1].Image).To(Equal(defaultDatabaseImagePG15))
+		Expect(found.Spec.Template.Spec.Containers[1].Image).To(Equal(defaultDatabaseImage))
+		Expect(found.Spec.Template.Spec.InitContainers[0].VolumeMounts).To(
+			ContainElement(corev1.VolumeMount{Name: "postgresdb", MountPath: "/var/lib/pgsql/data"}),
+		)
+	})
+
 	It("deploys the default image when no base image annotation is present", func() {
 		asc = newASCDefault()
 		ascr = newTestReconciler(asc, route, assistedCM, assistedTrustedCM)

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -26,8 +26,9 @@ const (
 	OsImagesEnvVar string = "OS_IMAGES"
 	// leaving this here to ensure it's consistent with the previous implementation if/when it is needed for el9/10
 	serviceImageBaseAnnotation string = "agent-install.openshift.io/service-image-base"
-	defaultDatabaseImage       = "quay.io/sclorg/postgresql-16-c9s:latest"
 )
+
+const defaultDatabaseImage = "quay.io/sclorg/postgresql-16-c9s:latest"
 
 func ServiceImage(asc client.Object) string {
 	return serviceImageDefault()

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -26,6 +26,7 @@ const (
 	OsImagesEnvVar string = "OS_IMAGES"
 	// leaving this here to ensure it's consistent with the previous implementation if/when it is needed for el9/10
 	serviceImageBaseAnnotation string = "agent-install.openshift.io/service-image-base"
+	defaultDatabaseImage       = "quay.io/sclorg/postgresql-16-c9s:latest"
 )
 
 func ServiceImage(asc client.Object) string {
@@ -41,7 +42,7 @@ func ImageServiceImage() string {
 }
 
 func DatabaseImage() string {
-	return getEnvVar("DATABASE_IMAGE", "quay.io/sclorg/postgresql-16-c9s:latest")
+	return getEnvVar("DATABASE_IMAGE", defaultDatabaseImage)
 }
 
 func AgentImage() string {

--- a/internal/controller/controllers/postgres_hop.sh
+++ b/internal/controller/controllers/postgres_hop.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# postgres_hop.sh - One-shot PostgreSQL major-version hop for init containers.
+#
+# sclorg images can only upgrade from POSTGRESQL_PREV_VERSION. ACM/MCE EUS
+# skip-upgrades (for example ACM 2.15 PG12 → ACM 2.17 PG15) therefore need
+# intermediate images. This script runs in an init container: it upgrades
+# exactly one hop if needed, then exits so the next hop or the main postgres
+# container can run.
+#
+# See docs/dev/postgresql-upgrade.md for details.
+
+set -eu
+
+PGDATA="${PGDATA:-/var/lib/pgsql/data/userdata}"
+CONTAINER_SCRIPTS_PATH="${CONTAINER_SCRIPTS_PATH:-/usr/share/container-scripts/postgresql}"
+APP_DATA="${APP_DATA:-/opt/app-root}"
+
+echo "=== PostgreSQL hop (${POSTGRESQL_VERSION:-unknown}, prev=${POSTGRESQL_PREV_VERSION:-unknown}) ==="
+
+if [ ! -f "$PGDATA/PG_VERSION" ]; then
+    echo "No existing data directory - skipping hop"
+    exit 0
+fi
+
+DATA_VERSION="$(tr -d '[:space:]' < "$PGDATA/PG_VERSION")"
+echo "Data directory version: $DATA_VERSION"
+echo "Hop image version: ${POSTGRESQL_VERSION:-}"
+
+if [ -z "${POSTGRESQL_VERSION:-}" ]; then
+    echo "ERROR: POSTGRESQL_VERSION is not set in this image" >&2
+    exit 1
+fi
+
+# Skip if data is already at or past this hop. Only read PG_VERSION — do not
+# start postgres, because a newer data directory cannot be opened by an older hop image.
+if [ "$DATA_VERSION" -ge "$POSTGRESQL_VERSION" ] 2>/dev/null; then
+    echo "Data is already at version $DATA_VERSION - skipping this hop"
+    exit 0
+fi
+
+if [ -z "${POSTGRESQL_PREV_VERSION:-}" ]; then
+    echo "ERROR: POSTGRESQL_PREV_VERSION is not set in this image" >&2
+    exit 1
+fi
+
+if [ "$DATA_VERSION" != "$POSTGRESQL_PREV_VERSION" ]; then
+    echo "ERROR: this hop image can only upgrade from ${POSTGRESQL_PREV_VERSION}, not ${DATA_VERSION}." >&2
+    echo "An earlier hop init container is missing from the upgrade path." >&2
+    exit 1
+fi
+
+echo "Upgrading PostgreSQL data from ${DATA_VERSION} to ${POSTGRESQL_VERSION} (hardlink mode)"
+export POSTGRESQL_UPGRADE=hardlink
+export ENABLE_REPLICATION="${ENABLE_REPLICATION:-false}"
+
+export_vars="$(cgroup-limits)"
+# shellcheck disable=SC2086
+export $export_vars
+
+# shellcheck disable=SC1091
+source "${CONTAINER_SCRIPTS_PATH}/common.sh"
+
+set_pgdata
+process_extending_files \
+    "${APP_DATA}/src/postgresql-pre-start" \
+    "${CONTAINER_SCRIPTS_PATH}/pre-start"
+check_env_vars
+generate_passwd_file
+generate_postgresql_config
+
+try_pgupgrade
+
+echo "Hop to PostgreSQL ${POSTGRESQL_VERSION} complete"

--- a/internal/controller/controllers/postgres_startup.sh
+++ b/internal/controller/controllers/postgres_startup.sh
@@ -9,16 +9,20 @@
 
 set -e
 
-PGDATA=/var/lib/pgsql/data/userdata
+PGDATA="${PGDATA:-/var/lib/pgsql/data/userdata}"
 
 echo "=== PostgreSQL Startup Check ==="
 
 if [ -f "$PGDATA/PG_VERSION" ]; then
-    DATA_VERSION=$(cat "$PGDATA/PG_VERSION")
+    DATA_VERSION="$(tr -d '[:space:]' < "$PGDATA/PG_VERSION")"
     echo "Data directory version: $DATA_VERSION"
     echo "Container image version: $POSTGRESQL_VERSION"
 
     if [ "$DATA_VERSION" != "$POSTGRESQL_VERSION" ]; then
+        if [ -n "${POSTGRESQL_PREV_VERSION:-}" ] && [ "$DATA_VERSION" != "$POSTGRESQL_PREV_VERSION" ]; then
+            echo "Data is version ${DATA_VERSION}; this image can only upgrade from ${POSTGRESQL_PREV_VERSION}."
+            echo "Intermediate hop init containers should have upgraded first. See docs/dev/postgresql-upgrade.md."
+        fi
         echo "Version mismatch detected - enabling pg_upgrade (hardlink mode)"
         export POSTGRESQL_UPGRADE=hardlink
     else

--- a/internal/controller/controllers/postgres_startup_script.go
+++ b/internal/controller/controllers/postgres_startup_script.go
@@ -11,3 +11,10 @@ import _ "embed"
 //
 //go:embed postgres_startup.sh
 var PostgresStartupScript string
+
+// PostgresHopScript upgrades exactly one PostgreSQL major version in an init
+// container and then exits. Used for EUS skip-upgrades that sclorg cannot do
+// in a single image (for example PG12 → PG15).
+//
+//go:embed postgres_hop.sh
+var PostgresHopScript string

--- a/internal/controller/controllers/postgres_upgrade.go
+++ b/internal/controller/controllers/postgres_upgrade.go
@@ -35,10 +35,12 @@ func postgresUpgradePath() []postgresUpgradeHop {
 
 var postgresVersionFromImage = regexp.MustCompile(`postgresql-(\d+)`)
 
+// DatabaseImagePG13 is the PostgreSQL 13 hop image used to upgrade PG12 data.
 func DatabaseImagePG13() string {
 	return getEnvVar(databaseImagePG13Env, defaultDatabaseImagePG13)
 }
 
+// DatabaseImagePG15 is the PostgreSQL 15 hop image used to upgrade PG13 data.
 func DatabaseImagePG15() string {
 	return getEnvVar(databaseImagePG15Env, defaultDatabaseImagePG15)
 }
@@ -47,6 +49,7 @@ func (h postgresUpgradeHop) image() string {
 	return getEnvVar(h.envVar, h.defaultImage)
 }
 
+// parsePostgresMajorVersion extracts N from a postgresql-N image reference.
 func parsePostgresMajorVersion(image string) (int, bool) {
 	m := postgresVersionFromImage.FindStringSubmatch(image)
 	if len(m) < 2 {
@@ -75,6 +78,8 @@ func databaseImageMajorVersion() (int, bool) {
 	return 0, false
 }
 
+// postgresHopsBeforeTarget returns sclorg hop images older than DATABASE_IMAGE
+// so EUS skip-upgrades can walk 12 → 13 → 15 → 16.
 func postgresHopsBeforeTarget() []postgresUpgradeHop {
 	targetVer, ok := databaseImageMajorVersion()
 	if !ok {
@@ -93,6 +98,8 @@ func postgresHopsBeforeTarget() []postgresUpgradeHop {
 	return hops
 }
 
+// postgresUpgradeInitContainers builds one-shot init containers that run each
+// hop in postgresHopsBeforeTarget against the postgres PVC, then exit.
 func postgresUpgradeInitContainers(env []corev1.EnvVar, mounts []corev1.VolumeMount, resources corev1.ResourceRequirements) []corev1.Container {
 	hops := postgresHopsBeforeTarget()
 	init := make([]corev1.Container, 0, len(hops))

--- a/internal/controller/controllers/postgres_upgrade.go
+++ b/internal/controller/controllers/postgres_upgrade.go
@@ -1,0 +1,111 @@
+package controllers
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	databaseImagePG13Env     = "DATABASE_IMAGE_PG13"
+	databaseImagePG15Env     = "DATABASE_IMAGE_PG15"
+	databaseImageVersionEnv  = "DATABASE_IMAGE_VERSION"
+	defaultDatabaseImagePG13 = "quay.io/sclorg/postgresql-13-c9s:latest"
+	defaultDatabaseImagePG15 = "quay.io/sclorg/postgresql-15-c9s:latest"
+)
+
+// postgresUpgradeHop is one sclorg image in the major-version path. Each image
+// can only upgrade from POSTGRESQL_PREV_VERSION baked into that image.
+type postgresUpgradeHop struct {
+	version      string
+	envVar       string
+	defaultImage string
+}
+
+// postgresUpgradePath is the sclorg hop chain excluding the current DATABASE_IMAGE.
+// RHEL 9 skips PG14, so the supported path is 12 → 13 → 15 → 16.
+func postgresUpgradePath() []postgresUpgradeHop {
+	return []postgresUpgradeHop{
+		{version: "13", envVar: databaseImagePG13Env, defaultImage: defaultDatabaseImagePG13},
+		{version: "15", envVar: databaseImagePG15Env, defaultImage: defaultDatabaseImagePG15},
+	}
+}
+
+var postgresVersionFromImage = regexp.MustCompile(`postgresql-(\d+)`)
+
+func DatabaseImagePG13() string {
+	return getEnvVar(databaseImagePG13Env, defaultDatabaseImagePG13)
+}
+
+func DatabaseImagePG15() string {
+	return getEnvVar(databaseImagePG15Env, defaultDatabaseImagePG15)
+}
+
+func (h postgresUpgradeHop) image() string {
+	return getEnvVar(h.envVar, h.defaultImage)
+}
+
+func parsePostgresMajorVersion(image string) (int, bool) {
+	m := postgresVersionFromImage.FindStringSubmatch(image)
+	if len(m) < 2 {
+		return 0, false
+	}
+	v, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// databaseImageMajorVersion is the major version of DATABASE_IMAGE.
+// Prefer a postgresql-N token in the image reference; fall back to
+// DATABASE_IMAGE_VERSION for digest-only mirrors.
+func databaseImageMajorVersion() (int, bool) {
+	if v, ok := parsePostgresMajorVersion(DatabaseImage()); ok {
+		return v, true
+	}
+	if v := getEnvVar(databaseImageVersionEnv, ""); v != "" {
+		n, err := strconv.Atoi(v)
+		if err == nil && n > 0 {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func postgresHopsBeforeTarget() []postgresUpgradeHop {
+	targetVer, ok := databaseImageMajorVersion()
+	if !ok {
+		return nil
+	}
+	var hops []postgresUpgradeHop
+	for _, h := range postgresUpgradePath() {
+		hv, err := strconv.Atoi(h.version)
+		if err != nil {
+			continue
+		}
+		if hv < targetVer {
+			hops = append(hops, h)
+		}
+	}
+	return hops
+}
+
+func postgresUpgradeInitContainers(env []corev1.EnvVar, mounts []corev1.VolumeMount, resources corev1.ResourceRequirements) []corev1.Container {
+	hops := postgresHopsBeforeTarget()
+	init := make([]corev1.Container, 0, len(hops))
+	for _, h := range hops {
+		init = append(init, corev1.Container{
+			Name:         fmt.Sprintf("postgres-upgrade-to-%s", h.version),
+			Image:        h.image(),
+			Command:      []string{"/bin/bash", "-c"},
+			Args:         []string{PostgresHopScript},
+			Env:          env,
+			VolumeMounts: mounts,
+			Resources:    resources,
+		})
+	}
+	return init
+}

--- a/internal/controller/controllers/postgres_upgrade_test.go
+++ b/internal/controller/controllers/postgres_upgrade_test.go
@@ -1,0 +1,143 @@
+package controllers
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ = Describe("parsePostgresMajorVersion", func() {
+	It("parses sclorg image tags", func() {
+		v, ok := parsePostgresMajorVersion("quay.io/sclorg/postgresql-16-c9s:latest")
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(16))
+	})
+
+	It("parses mirrored OLM image names", func() {
+		v, ok := parsePostgresMajorVersion("registry.example/olm/sclorg-postgresql-15-c9s:latest")
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(15))
+	})
+
+	It("parses registry.redhat.io rhel9 images", func() {
+		v, ok := parsePostgresMajorVersion("registry.redhat.io/rhel9/postgresql-13:1-1")
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(13))
+	})
+
+	It("returns false when the image has no postgresql-N token", func() {
+		_, ok := parsePostgresMajorVersion("registry.example/sha256:abc")
+		Expect(ok).To(BeFalse())
+	})
+})
+
+var _ = Describe("postgresHopsBeforeTarget", func() {
+	AfterEach(func() {
+		Expect(os.Unsetenv("DATABASE_IMAGE")).To(Succeed())
+		Expect(os.Unsetenv(databaseImageVersionEnv)).To(Succeed())
+		Expect(os.Unsetenv(databaseImagePG13Env)).To(Succeed())
+		Expect(os.Unsetenv(databaseImagePG15Env)).To(Succeed())
+	})
+
+	It("includes PG13 and PG15 hops when the target is PG16", func() {
+		hops := postgresHopsBeforeTarget()
+		Expect(hops).To(HaveLen(2))
+		Expect(hops[0].version).To(Equal("13"))
+		Expect(hops[1].version).To(Equal("15"))
+	})
+
+	It("includes only the PG13 hop when the target is PG15", func() {
+		Expect(os.Setenv("DATABASE_IMAGE", "quay.io/sclorg/postgresql-15-c9s:latest")).To(Succeed())
+		hops := postgresHopsBeforeTarget()
+		Expect(hops).To(HaveLen(1))
+		Expect(hops[0].version).To(Equal("13"))
+	})
+
+	It("includes no hops when the target is PG13", func() {
+		Expect(os.Setenv("DATABASE_IMAGE", "quay.io/sclorg/postgresql-13-c9s:latest")).To(Succeed())
+		Expect(postgresHopsBeforeTarget()).To(BeEmpty())
+	})
+
+	It("uses DATABASE_IMAGE_VERSION when the image name has no version token", func() {
+		Expect(os.Setenv("DATABASE_IMAGE", "registry.example/postgres@sha256:deadbeef")).To(Succeed())
+		Expect(os.Setenv(databaseImageVersionEnv, "16")).To(Succeed())
+		hops := postgresHopsBeforeTarget()
+		Expect(hops).To(HaveLen(2))
+		Expect(hops[0].version).To(Equal("13"))
+		Expect(hops[1].version).To(Equal("15"))
+	})
+
+	It("prefers the postgresql-N token over DATABASE_IMAGE_VERSION", func() {
+		Expect(os.Setenv("DATABASE_IMAGE", "quay.io/sclorg/postgresql-15-c9s:latest")).To(Succeed())
+		Expect(os.Setenv(databaseImageVersionEnv, "16")).To(Succeed())
+		hops := postgresHopsBeforeTarget()
+		Expect(hops).To(HaveLen(1))
+		Expect(hops[0].version).To(Equal("13"))
+	})
+
+	It("skips hops when the target version cannot be determined", func() {
+		Expect(os.Setenv("DATABASE_IMAGE", "registry.example/postgres@sha256:deadbeef")).To(Succeed())
+		Expect(postgresHopsBeforeTarget()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("postgresUpgradeInitContainers", func() {
+	AfterEach(func() {
+		Expect(os.Unsetenv("DATABASE_IMAGE")).To(Succeed())
+		Expect(os.Unsetenv(databaseImagePG13Env)).To(Succeed())
+		Expect(os.Unsetenv(databaseImagePG15Env)).To(Succeed())
+	})
+
+	It("builds init containers that share env, mounts, and the hop script", func() {
+		env := []corev1.EnvVar{{Name: "POSTGRESQL_USER", Value: "admin"}}
+		mounts := []corev1.VolumeMount{{Name: "postgresdb", MountPath: "/var/lib/pgsql/data"}}
+		resources := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("400Mi"),
+			},
+		}
+
+		init := postgresUpgradeInitContainers(env, mounts, resources)
+		Expect(init).To(HaveLen(2))
+		Expect(init[0].Name).To(Equal("postgres-upgrade-to-13"))
+		Expect(init[0].Image).To(Equal(defaultDatabaseImagePG13))
+		Expect(init[1].Name).To(Equal("postgres-upgrade-to-15"))
+		Expect(init[1].Image).To(Equal(defaultDatabaseImagePG15))
+		for _, c := range init {
+			Expect(c.Command).To(Equal([]string{"/bin/bash", "-c"}))
+			Expect(c.Args).To(Equal([]string{PostgresHopScript}))
+			Expect(c.Env).To(Equal(env))
+			Expect(c.VolumeMounts).To(Equal(mounts))
+			Expect(c.Resources).To(Equal(resources))
+		}
+	})
+
+	It("uses operator env overrides for hop images", func() {
+		Expect(os.Setenv(databaseImagePG13Env, "registry.example/postgresql-13:custom")).To(Succeed())
+		init := postgresUpgradeInitContainers(nil, nil, corev1.ResourceRequirements{})
+		Expect(init[0].Image).To(Equal("registry.example/postgresql-13:custom"))
+	})
+})
+
+var _ = Describe("DatabaseImage hop getters", func() {
+	AfterEach(func() {
+		Expect(os.Unsetenv(databaseImagePG13Env)).To(Succeed())
+		Expect(os.Unsetenv(databaseImagePG15Env)).To(Succeed())
+	})
+
+	It("returns default hop images", func() {
+		Expect(DatabaseImagePG13()).To(Equal(defaultDatabaseImagePG13))
+		Expect(DatabaseImagePG15()).To(Equal(defaultDatabaseImagePG15))
+	})
+
+	It("returns configured hop images", func() {
+		Expect(os.Setenv(databaseImagePG13Env, "registry.example/pg13")).To(Succeed())
+		Expect(os.Setenv(databaseImagePG15Env, "registry.example/pg15")).To(Succeed())
+		Expect(DatabaseImagePG13()).To(Equal("registry.example/pg13"))
+		Expect(DatabaseImagePG15()).To(Equal("registry.example/pg15"))
+	})
+})


### PR DESCRIPTION
## List all the issues related to this PR

- [x] Bug fix
- [x] Tests
- [x] Documentation

Fixes https://issues.redhat.com/browse/ACM-39262 (also https://redhat.atlassian.net/browse/ACM-39262)

Direct ACM EUS upgrades (2.15 → 2.17) crash-loop the assisted-service `postgres` container because sclorg images can only `pg_upgrade` from `POSTGRESQL_PREV_VERSION`. ACM 2.15 data is PG12; the 2.17 image is PG15, which only accepts PG13.

## What environments does this code impact?

- [x] Operator Managed Deployments

## How was this code tested?

- [x] Waiting for CI to do a full test run
- [x] Unit tests added for hop selection and init-container wiring

QE should verify:

- ACM 2.15.4 → 2.17.z with existing InfraEnvs (PG12 → PG15)
- ACM 2.16 → 2.17 (PG13 → PG15)
- Fresh ACM 2.17 / current master install (no hops run)

## Summary

Add sequential PostgreSQL hop init containers (`postgres-upgrade-to-13`, `postgres-upgrade-to-15`) that run `postgres_hop.sh` against the existing PVC, then start the main postgres container. Fresh installs and same-version restarts no-op the hops. Intermediate images are added to operator env and CSV `relatedImages` so disconnected payloads can include them.

A follow-up is required in `stolostron/backplane-operator` so MCE sets `DATABASE_IMAGE_PG13` / `DATABASE_IMAGE_PG15` from image overrides. Cherry-pick to `release-ocm-2.17` for the ACM 2.17.z fix (PG15 target emits only the PG13 hop).

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc) <!-- docs updated -->
- [x] Does this change include unit-tests (note that code changes require unit-tests)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sequential PostgreSQL major-version upgrades, including multi-hop EUS upgrade paths.
  - Added configurable PostgreSQL 13 and 15 upgrade images, including support for digest-based deployments.
  - PostgreSQL upgrades now use intermediate versions when required, including skipped-version scenarios.

- **Documentation**
  - Expanded upgrade guidance for multi-hop migrations, image configuration, and unsupported source versions.
  - Updated operator configuration examples with the new database image settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->