### PR TITLE
ACM-41555: Enable PQC in Dockerfiles

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -46,6 +46,10 @@ RUN git rev-parse --short HEAD > /commit-reference.txt
 # Create final image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
+RUN microdnf install -y --disablerepo="*" --enablerepo="ubi-9-*" crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all
+
 ARG release=main
 ARG version=latest
 

--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -39,6 +39,7 @@ COPY --from=registry.k8s.io/kustomize/kustomize:v5.7.1 /app/kustomize /usr/bin/
 
 RUN dnf install -y --enablerepo=crb \
         openssl openssl-devel postgresql nmstate-devel sqlite gcc genisoimage git libvirt-client libvirt-devel java make && \
+    update-crypto-policies --set DEFAULT:PQ && \
     dnf clean all
 
 # Git checks if the user that owns the files on the filesystem match the

--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -24,6 +24,10 @@ RUN cd ./assisted-service && make build-minimal
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
 
+RUN microdnf install -y --disablerepo="*" --enablerepo="ubi-9-*" crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all
+
 RUN microdnf install -y nmstate nmstate-libs && microdnf clean all
 
 ARG DEBUG_SERVICE_PORT=40000

--- a/Dockerfile.assisted-service-rhel9-mce
+++ b/Dockerfile.assisted-service-rhel9-mce
@@ -25,7 +25,8 @@ RUN CGO_ENABLED=1 GOFLAGS="-p=4" GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGET
 RUN CGO_ENABLED=1 GOFLAGS="-p=4" GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags ${BUILD_TAGS} -o ./build/agent-installer-client cmd/agentbasedinstaller/client/main.go
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:3e009398a8aa8eec621393fbf308c5e622f174900e44e8d5fe224c637920924a
+
 ARG release=main
 ARG version=latest
 

--- a/renovate.json
+++ b/renovate.json
@@ -113,9 +113,10 @@
                 "/^Dockerfile\\.assisted-service.*$/"
             ],
             "matchStrings": [
-                "FROM registry.access.redhat.com/ubi9/ubi-minimal:(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\\n"
+                "FROM registry.redhat.io/ubi9/ubi-minimal-pqc:(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\\n",
+                "FROM --platform=\\$BUILDPLATFORM registry.redhat.io/ubi9/ubi-minimal-pqc:(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\\n"
             ],
-            "depNameTemplate": "registry.access.redhat.com/ubi9/ubi-minimal",
+            "depNameTemplate": "registry.redhat.io/ubi9/ubi-minimal-pqc",
             "datasourceTemplate": "docker"
         }
     ],
@@ -186,7 +187,7 @@
         {
             "matchPackageNames": [
                 "registry.access.redhat.com/ubi9/ubi",
-                "registry.access.redhat.com/ubi9/ubi-minimal"
+                "registry.redhat.io/ubi9/ubi-minimal-pqc"
             ],
             "groupName": "UBI Runtime Images",
             "addLabels": [
@@ -202,7 +203,7 @@
             ],
             "matchPackageNames": [
                 "registry.access.redhat.com/ubi9/ubi",
-                "registry.access.redhat.com/ubi9/ubi-minimal"
+                "registry.redhat.io/ubi9/ubi-minimal-pqc"
             ],
             "enabled": false
         },


### PR DESCRIPTION
## Summary
Enable Post-Quantum Cryptography for ACM 5.0 / MCE 5.0 (part of ACM-40663).

## Changes
### PQC base image
- **Dockerfile.assisted-service** (SaaS): Switch to `registry.redhat.io/ubi9/ubi-minimal-pqc`
- **Dockerfile.assisted-service-rhel9-mce**: Switch to `registry.redhat.io/ubi9/ubi-minimal-pqc`
- **Dockerfile.assisted-service-debug** (dev): Switch to `registry.redhat.io/ubi9/ubi-minimal-pqc`

### Crypto policy
- **Dockerfile.assisted-service-build**: Add `update-crypto-policies --set DEFAULT:PQ` (CentOS)

### Renovate
- **renovate.json**: Track PQC image, removed stale ubi-minimal tracking

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enabled post-quantum cryptography support in service and debug runtime images.
  * Enabled the `DEFAULT:PQ` system crypto policy during image builds.
  * Updated RHEL-based runtime images to use PQC-enabled UBI minimal images.

* **Maintenance**
  * Updated automated image tracking for PQC-enabled base images, including build-platform variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->