### PR TITLE
NO-ISSUE: Fix agent predicate in clusterdeployments_controller

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -2016,17 +2016,17 @@ func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			var newSyncStatus corev1.ConditionStatus
 
 			for _, condition := range oldAgent.Status.Conditions {
-				if condition.Reason == string(aiv1beta1.SpecSyncedCondition) {
+				if condition.Type == aiv1beta1.SpecSyncedCondition {
 					oldSyncStatus = condition.Status
 				}
 			}
 			for _, condition := range newAgent.Status.Conditions {
-				if condition.Reason == string(aiv1beta1.SpecSyncedCondition) {
+				if condition.Type == aiv1beta1.SpecSyncedCondition {
 					newSyncStatus = condition.Status
 				}
 			}
 
-			return oldSyncStatus != newSyncStatus
+			return oldSyncStatus != newSyncStatus || oldAgent.Spec.Approved != newAgent.Spec.Approved
 		},
 	})
 


### PR DESCRIPTION
The 'agentSpecStatusChangedPredicate' in the 'ClusterDeploymentsReconciler' was incorrectly checking 'condition.Reason' instead of 'condition.Type' when looking for 'SpecSynced' condition changes. This caused the predicate to always miss these updates, relying on fallback mechanisms or lagging event channels to trigger reconciliation.

Additionally, changes to 'agent.Spec.Approved' were not triggering a reconciliation, which also delayed the updates to the 'AgentClusterInstall' conditions (such as 'UnapprovedAgents' or 'UnsyncedAgents').

This fixes the flaky 'subsystem-kubeapi-aws' test where the test timed out waiting for the 'UnsyncedAgents' condition after an invalid ignition config was applied and agents were approved.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ClusterDeployment reconciliation now reliably detects synchronized specifications.
  * Changes to agent approval status now correctly trigger reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->