### PR TITLE
MGMT-25130: assisted-service and assisted-image-service NetworkPolicy ingress has no source restriction (any pod in any namespace can reach them directly)

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -809,12 +809,27 @@ func newAssistedServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger
 			},
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
 			Ingress: []netv1.NetworkPolicyIngressRule{
-				{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}},
 				{
+					From: []netv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{}},
+						{NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"network.openshift.io/policy-group": "ingress"},
+						}},
+					},
 					Ports: []netv1.NetworkPolicyPort{
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &servicePort},
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &serviceHTTPPort},
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 9443}},
+					},
+				},
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"network.openshift.io/policy-group": "monitoring"},
+						}},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &servicePort},
 					},
 				},
 			},
@@ -845,8 +860,13 @@ func newImageServiceNetworkPolicy(ctx context.Context, log logrus.FieldLogger, a
 			},
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
 			Ingress: []netv1.NetworkPolicyIngressRule{
-				{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}},
 				{
+					From: []netv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{}},
+						{NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"network.openshift.io/policy-group": "ingress"},
+						}},
+					},
 					Ports: []netv1.NetworkPolicyPort{
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &imageHandlerPort},
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &imageHandlerHTTPPort},
@@ -880,7 +900,6 @@ func newWebhookNetworkPolicy(ctx context.Context, log logrus.FieldLogger, asc AS
 			},
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
 			Ingress: []netv1.NetworkPolicyIngressRule{
-				{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}},
 				{
 					Ports: []netv1.NetworkPolicyPort{
 						{Protocol: ptr.To(corev1.ProtocolTCP), Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 9443}},

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1375,6 +1375,31 @@ var _ = Describe("newAssistedServiceNetworkPolicy", func() {
 		Expect(np.Spec.PolicyTypes).To(Equal([]netv1.PolicyType{netv1.PolicyTypeIngress}))
 		Expect(np.Spec.Egress).To(BeEmpty())
 	})
+
+	It("should restrict ingress to same-namespace, openshift-ingress, and monitoring", func() {
+		obj, mutateFn, err := newAssistedServiceNetworkPolicy(ctx, log, ascc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mutateFn()).To(Succeed())
+
+		np := obj.(*netv1.NetworkPolicy)
+		Expect(np.Spec.Ingress).To(HaveLen(2))
+
+		rule := np.Spec.Ingress[0]
+		Expect(rule.From).To(HaveLen(2))
+		Expect(rule.From[0].PodSelector).ToNot(BeNil())
+		Expect(rule.From[0].NamespaceSelector).To(BeNil())
+		Expect(rule.From[1].NamespaceSelector).ToNot(BeNil())
+		Expect(rule.From[1].PodSelector).To(BeNil())
+		Expect(rule.From[1].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("network.openshift.io/policy-group", "ingress"))
+		Expect(rule.Ports).To(HaveLen(3))
+
+		monRule := np.Spec.Ingress[1]
+		Expect(monRule.From).To(HaveLen(1))
+		Expect(monRule.From[0].NamespaceSelector).ToNot(BeNil())
+		Expect(monRule.From[0].PodSelector).To(BeNil())
+		Expect(monRule.From[0].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("network.openshift.io/policy-group", "monitoring"))
+		Expect(monRule.Ports).To(HaveLen(1))
+	})
 })
 
 var _ = Describe("newImageServiceNetworkPolicy", func() {
@@ -1400,6 +1425,52 @@ var _ = Describe("newImageServiceNetworkPolicy", func() {
 		np := obj.(*netv1.NetworkPolicy)
 		Expect(np.Spec.PolicyTypes).To(Equal([]netv1.PolicyType{netv1.PolicyTypeIngress}))
 		Expect(np.Spec.Egress).To(BeEmpty())
+	})
+
+	It("should restrict ingress to same-namespace and openshift-ingress only", func() {
+		obj, mutateFn, err := newImageServiceNetworkPolicy(ctx, log, ascc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mutateFn()).To(Succeed())
+
+		np := obj.(*netv1.NetworkPolicy)
+		Expect(np.Spec.Ingress).To(HaveLen(1))
+		rule := np.Spec.Ingress[0]
+		Expect(rule.From).To(HaveLen(2))
+		Expect(rule.From[0].PodSelector).ToNot(BeNil())
+		Expect(rule.From[0].NamespaceSelector).To(BeNil())
+		Expect(rule.From[1].NamespaceSelector).ToNot(BeNil())
+		Expect(rule.From[1].PodSelector).To(BeNil())
+		Expect(rule.From[1].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("network.openshift.io/policy-group", "ingress"))
+		Expect(rule.Ports).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("newWebhookNetworkPolicy", func() {
+	var (
+		asc  *aiv1beta1.AgentServiceConfig
+		ascr *AgentServiceConfigReconciler
+		ascc ASC
+		ctx  = context.Background()
+		log  = logrus.New()
+	)
+
+	BeforeEach(func() {
+		asc = newASCDefault()
+		ascr = newTestReconciler(asc)
+		ascc = initASC(ascr, asc)
+	})
+
+	It("should allow ingress on port 9443 from any source for kube-apiserver webhook calls", func() {
+		obj, mutateFn, err := newWebhookNetworkPolicy(ctx, log, ascc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mutateFn()).To(Succeed())
+
+		np := obj.(*netv1.NetworkPolicy)
+		Expect(np.Spec.Ingress).To(HaveLen(1))
+		rule := np.Spec.Ingress[0]
+		Expect(rule.From).To(BeEmpty())
+		Expect(rule.Ports).To(HaveLen(1))
+		Expect(rule.Ports[0].Port.IntVal).To(Equal(int32(9443)))
 	})
 })
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## Summary
- Fixed NetworkPolicy ingress rules for assisted-service, assisted-image-service,
  and agentinstalladmission webhook that were unintentionally allowing cross-namespace access
- Ingress was split into two rules (From without Ports, Ports without From) — since
  NetworkPolicy rules are OR'd, the port-only rule allowed any namespace to reach the services
- Merged into single rules combining From peers with Ports
- Services now restrict ingress to same-namespace pods + OpenShift ingress controller
  (via `network.openshift.io/policy-group: ingress` namespace label)
- Webhook allows any source on port 9443 only (kube-apiserver uses hostNetwork,
  so namespace/pod selectors cannot match it)
- Added unit tests for all three NetworkPolicy ingress configurations

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Updated network access rules for the assisted service to allow traffic from same-namespace pods, OpenShift ingress namespaces, and monitoring namespaces on port 8090, while retaining existing access and ports.
  - Allowed image-service traffic from OpenShift ingress namespaces in addition to same-namespace pods.
  - Restricted webhook ingress to port 9443.
  - Added validation for approved ingress sources and port-specific access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->