### PR TITLE
NO-ISSUE: increasing netdev_max_backlog

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11849,12 +11849,12 @@ var _ = Describe("DownloadMinimalInitrd", func() {
 		verifyApiError(response, http.StatusNotFound)
 	})
 
-	It("returns no content without network customizations", func() {
+	It("returns network sysctl tuning without network customizations", func() {
 		infraEnv := createInfraEnv(models.ImageTypeFullIso)
 		Expect(db.Create(&infraEnv).Error).NotTo(HaveOccurred())
 		params := installer.DownloadMinimalInitrdParams{InfraEnvID: id}
 		response := bm.DownloadMinimalInitrd(ctx, params)
-		Expect(response).Should(BeAssignableToTypeOf(&installer.DownloadMinimalInitrdNoContent{}))
+		Expect(response).Should(BeAssignableToTypeOf(&installer.DownloadMinimalInitrdOK{}))
 	})
 
 	It("returns non-empty archive when full ISO is requested", func() {

--- a/internal/constants/network_sysctl.go
+++ b/internal/constants/network_sysctl.go
@@ -1,0 +1,26 @@
+package constants
+
+// NetworkSysctlConfig is applied on discovery hosts to reduce rx_dropped during
+// live rootfs downloads over PXE/virtual media.
+const NetworkSysctlConfig = `# Increase network receive buffers for assisted installation boot
+net.core.netdev_max_backlog = 2000
+net.core.rmem_max = 16777216
+`
+
+const NetworkSysctlTuningScript = `#!/bin/bash
+set -euo pipefail
+sysctl -w net.core.netdev_max_backlog=2000
+sysctl -w net.core.rmem_max=16777216
+`
+
+const NetworkSysctlTuningService = `[Unit]
+Description=Apply network sysctl tuning for assisted installation
+DefaultDependencies=no
+Before=coreos-livepxe-rootfs.service
+After=systemd-sysctl.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/assisted-network-sysctl.sh
+`

--- a/internal/ignition/discovery.go
+++ b/internal/ignition/discovery.go
@@ -337,6 +337,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"SkipCertVerification": strconv.FormatBool(cfg.SkipCertVerification),
 		"AgentTimeoutStartSec": strconv.FormatInt(int64(cfg.AgentTimeoutStart.Seconds()), 10),
 		"SELINUX_POLICY":       base64.StdEncoding.EncodeToString([]byte(selinuxPolicy)),
+		"NetworkSysctlConfig":  base64.StdEncoding.EncodeToString([]byte(constants.NetworkSysctlConfig)),
 		"EnableAgentService":   infraEnv.InternalIgnitionConfigOverride == "",
 		"ProfileProxyExports":  dataurl.EncodeBytes([]byte(GetProfileProxyEntries(httpProxy, httpsProxy, noProxy))),
 		"DesiredNtpSources":    desiredNtpSources,

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -120,6 +120,15 @@
       "contents": { "source": "data:,{{.IPv6_CONF}}" }
     },
     {
+      "overwrite": true,
+      "path": "/etc/sysctl.d/99-assisted-network.conf",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{.NetworkSysctlConfig}}" }
+    },
+    {
         "overwrite": true,
         "path": "/root/.docker/config.json",
         "mode": 420,

--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -32,11 +32,11 @@ func (i *ClusterProxyInfo) Empty() bool {
 }
 
 func RamdiskImageArchive(netFiles []staticnetworkconfig.StaticNetworkConfigData, clusterProxyInfo *ClusterProxyInfo, scriptContent, serviceContent string) ([]byte, error) {
-	if len(netFiles) == 0 && clusterProxyInfo.Empty() {
-		return nil, nil
-	}
 	buffer := new(bytes.Buffer)
 	w := cpio.NewWriter(buffer)
+	if err := addNetworkSysctlTuningToArchive(w); err != nil {
+		return nil, err
+	}
 	if len(netFiles) > 0 {
 		for _, file := range netFiles {
 			err := addFileToArchive(w, filepath.Join("/etc/assisted/network", file.FilePath), file.FileContents, 0o600)
@@ -89,6 +89,21 @@ func RamdiskImageArchive(netFiles []staticnetworkconfig.StaticNetworkConfigData,
 	}
 
 	return compressedBuffer.Bytes(), nil
+}
+
+func addNetworkSysctlTuningToArchive(w *cpio.Writer) error {
+	scriptPath := "/usr/local/bin/assisted-network-sysctl.sh"
+	if err := addFileToArchive(w, scriptPath, constants.NetworkSysctlTuningScript, 0o755); err != nil {
+		return err
+	}
+
+	servicePath := "/etc/systemd/system/assisted-network-sysctl.service"
+	if err := addFileToArchive(w, servicePath, constants.NetworkSysctlTuningService, 0o644); err != nil {
+		return err
+	}
+
+	serviceLink := "/etc/systemd/system/initrd.target.wants/assisted-network-sysctl.service"
+	return addFileToArchive(w, serviceLink, servicePath, cpio.ModeSymlink|0o777)
 }
 
 func formatRootfsServiceConfigFile(clusterProxyInfo *ClusterProxyInfo) (string, error) {

--- a/internal/isoeditor/rhcos_test.go
+++ b/internal/isoeditor/rhcos_test.go
@@ -92,13 +92,13 @@ var _ = Describe("RamdiskImageArchive", func() {
 			clusterProxyInfo.HTTPProxy, clusterProxyInfo.HTTPSProxy, clusterProxyInfo.NoProxy)
 		Expect(rootfsServiceConfigContent).To(Equal(rootfsServiceConfig))
 	})
-	It("returns nothing when given nothing - ocp versions less than MinimalVersionForNmstatectl", func() {
+	It("returns network sysctl tuning when given nothing - ocp versions less than MinimalVersionForNmstatectl", func() {
 		archive, err := RamdiskImageArchive(
 			[]staticnetworkconfig.StaticNetworkConfigData{},
 			&ClusterProxyInfo{},
 			constants.PreNetworkConfigScript, constants.MinimalISONetworkConfigService)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(archive).To(BeNil())
+		expectNetworkSysctlTuningInArchive(archive)
 	})
 
 	It("adds a new archive correctly - ocp versions greater than/ equal to MinimalVersionForNmstatectl", func() {
@@ -205,7 +205,7 @@ var _ = Describe("RamdiskImageArchive", func() {
 		}
 		Fail("pre-network-manager-config.service not found in archive")
 	})
-	It("returns nothing when given nothing - ocp versions greater than/ equal to MinimalVersionForNmstatectl", func() {
+	It("returns network sysctl tuning when given nothing - ocp versions greater than/ equal to MinimalVersionForNmstatectl", func() {
 		serviceContent, err := common.FormatMinimalISONetworkConfigServiceNmstatectl(0)
 		Expect(err).ToNot(HaveOccurred())
 		archive, err := RamdiskImageArchive(
@@ -213,7 +213,7 @@ var _ = Describe("RamdiskImageArchive", func() {
 			&ClusterProxyInfo{},
 			constants.PreNetworkConfigScriptWithNmstatectl, serviceContent)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(archive).To(BeNil())
+		expectNetworkSysctlTuningInArchive(archive)
 	})
 
 	It("handles authenticated proxy with and without urlencoded special characters", func() {
@@ -278,3 +278,35 @@ var _ = Describe("RamdiskImageArchive", func() {
 		}
 	})
 })
+
+func expectNetworkSysctlTuningInArchive(archive []byte) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	Expect(err).ToNot(HaveOccurred())
+
+	var scriptContent, serviceContent, serviceLink string
+	r := cpio.NewReader(gzipReader)
+	for {
+		hdr, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		Expect(err).ToNot(HaveOccurred())
+		switch hdr.Name {
+		case "/usr/local/bin/assisted-network-sysctl.sh":
+			content, err := io.ReadAll(r)
+			Expect(err).ToNot(HaveOccurred())
+			scriptContent = string(content)
+		case "/etc/systemd/system/assisted-network-sysctl.service":
+			content, err := io.ReadAll(r)
+			Expect(err).ToNot(HaveOccurred())
+			serviceContent = string(content)
+		case "/etc/systemd/system/initrd.target.wants/assisted-network-sysctl.service":
+			Expect(hdr.Mode & cpio.ModeSymlink).ToNot(BeZero())
+			serviceLink = hdr.Linkname
+		}
+	}
+
+	Expect(scriptContent).To(Equal(constants.NetworkSysctlTuningScript))
+	Expect(serviceContent).To(Equal(constants.NetworkSysctlTuningService))
+	Expect(serviceLink).To(Equal("/etc/systemd/system/assisted-network-sysctl.service"))
+}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network system tuning is now included in generated discovery images and initramfs archives, even when no custom network or proxy settings are configured.
  * Generated artifacts now consistently include the required tuning script, service, and enabled service link.
  * Minimal initrd downloads now return a successful response containing the expected network tuning configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->