### PR TITLE
OCPBUGS-120675: added missing subscription name for lvms-operator

### DIFF
--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -30,7 +30,7 @@ var Operator = models.MonitoredOperator{
 	Name:             "lvm",
 	OperatorType:     models.OperatorTypeOlm,
 	Namespace:        "openshift-storage",
-	SubscriptionName: "",
+	SubscriptionName: "lvms-operator",
 	TimeoutSeconds:   30 * 60,
 }
 


### PR DESCRIPTION
The lack of subscription name for the LVMS operator prevents the OVE ISO to successfully install the all the selected OLM operators (a side effect is that the Virtualization tab is not automatically shown once the cluster has been installed).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the monitored LVM operator subscription configuration to use the `lvms-operator` subscription name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->