### PR TITLE
OCPBUGS-120683: Fix NUMAResourcesOperator CR name so it can be applied

### DIFF
--- a/internal/operators/numaresources/numaresources_manifests_test.go
+++ b/internal/operators/numaresources/numaresources_manifests_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("NUMA Resources manifests", func() {
@@ -31,6 +32,17 @@ var _ = Describe("NUMA Resources manifests", func() {
 		Expect(openshiftManifests).To(HaveKey("50_numaresources_subscription.yaml"))
 		Expect(openshiftManifests).To(HaveKey("50_numaresources_prometheus-role.yaml"))
 		Expect(openshiftManifests).To(HaveKey("50_numaresources_prometheus-rolebinding.yaml"))
-		Expect(customManifests).To(ContainSubstring("numaresources"))
+		// The NUMAResourcesOperator is a singleton; its validating webhook requires
+		// the kind/name to be exactly these values or the apply is rejected, so
+		// assert the parsed values rather than substrings.
+		var cr struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		}
+		Expect(yaml.Unmarshal(customManifests, &cr)).To(Succeed())
+		Expect(cr.Kind).To(Equal("NUMAResourcesOperator"))
+		Expect(cr.Metadata.Name).To(Equal("numaresourcesoperator"))
 	})
 })

--- a/internal/operators/numaresources/templates/custom/numaresources.yaml
+++ b/internal/operators/numaresources/templates/custom/numaresources.yaml
@@ -1,7 +1,10 @@
 apiVersion: nodetopology.openshift.io/v1
 kind: NUMAResourcesOperator
 metadata:
-  name: {{ .Operator.Name }}
+  # The NUMAResourcesOperator is a singleton whose validating webhook requires
+  # the name to be exactly "numaresourcesoperator"; any other name (e.g. the
+  # operator's internal name "numaresources") is rejected on apply.
+  name: numaresourcesoperator
 spec:
   nodeGroups:
   - machineConfigPoolSelector:


### PR DESCRIPTION
The NUMAResourcesOperator custom resource is a singleton whose validating webhook requires the name to be exactly "numaresourcesoperator". The custom manifest template rendered metadata.name from the operator's internal name ({{ .Operator.Name }} = "numaresources"), so every apply was rejected with:

  The NUMAResourcesOperator "numaresources" is invalid: <nil>: Invalid value:
  This is a singleton resource and the object name must be 'numaresourcesoperator'.

As a result the CR was never created and the operator was left non-functional, even though its namespace, operator group and subscription applied cleanly.

The fix is to hardcode the required singleton name in the template.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the NUMA resources operator manifest to use the required singleton name, ensuring compatibility with validating webhook checks.
  * Updated manifest validation to verify the exact resource kind and name, improving reliability and preventing incorrectly configured resources from passing validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->