### PR TITLE
MGMT-25367: consider imageType when selecting OpenShift version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,10 @@ create-ocp-manifests:
 	export HW_REQUIREMENTS="$(subst ",\", $(shell cat $(ROOT_DIR)/data/default_hw_requirements.json | tr -d "\n\t "))" && \
 	$(MAKE) deploy-postgres deploy-ocm-secret deploy-s3-secret deploy-service deploy-ui
 
-ci-deploy-for-subsystem: deploy-test
+ci-deploy-for-subsystem:
+	OS_IMAGES="$$( "$(ROOT_DIR)/hack/ci/prepare_subsystem_os_images.sh" "$(ROOT_DIR)" )" && \
+	export OS_IMAGES && \
+	$(MAKE) deploy-test
 
 deploy-test: _verify_cluster generate-keys
 	-$(KUBECTL) delete deployments.apps assisted-service &> /dev/null

--- a/api/vendor/github.com/openshift/assisted-service/models/os_image.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/os_image.go
@@ -36,6 +36,10 @@ type OsImage struct {
 	// The OS stream of this image (e.g. rhel-9, rhel-10).
 	OsStream *string `json:"os_stream,omitempty"`
 
+	// The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.
+	// Enum: [disconnected-iso]
+	Type string `json:"type,omitempty"`
+
 	// The base OS image used for the discovery iso.
 	// Required: true
 	URL *string `json:"url"`
@@ -54,6 +58,10 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOpenshiftVersion(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -126,6 +134,45 @@ func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 func (m *OsImage) validateOpenshiftVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var osImageTypeTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["disconnected-iso"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeTypePropEnum = append(osImageTypeTypePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageTypeDisconnectedIso captures enum value "disconnected-iso"
+	OsImageTypeDisconnectedIso string = "disconnected-iso"
+)
+
+// prop value enum
+func (m *OsImage) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *OsImage) validateType(formats strfmt.Registry) error {
+	if swag.IsZero(m.Type) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateTypeEnum("type", "body", m.Type); err != nil {
 		return err
 	}
 

--- a/client/vendor/github.com/openshift/assisted-service/models/os_image.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/os_image.go
@@ -36,6 +36,10 @@ type OsImage struct {
 	// The OS stream of this image (e.g. rhel-9, rhel-10).
 	OsStream *string `json:"os_stream,omitempty"`
 
+	// The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.
+	// Enum: [disconnected-iso]
+	Type string `json:"type,omitempty"`
+
 	// The base OS image used for the discovery iso.
 	// Required: true
 	URL *string `json:"url"`
@@ -54,6 +58,10 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOpenshiftVersion(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -126,6 +134,45 @@ func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 func (m *OsImage) validateOpenshiftVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var osImageTypeTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["disconnected-iso"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeTypePropEnum = append(osImageTypeTypePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageTypeDisconnectedIso captures enum value "disconnected-iso"
+	OsImageTypeDisconnectedIso string = "disconnected-iso"
+)
+
+// prop value enum
+func (m *OsImage) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *OsImage) validateType(formats strfmt.Registry) error {
+	if swag.IsZero(m.Type) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateTypeEnum("type", "body", m.Type); err != nil {
 		return err
 	}
 

--- a/hack/ci/prepare_subsystem_os_images.sh
+++ b/hack/ci/prepare_subsystem_os_images.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Prepare OS_IMAGES for subsystem test deploy.
+#
+# Subsystem tests register disconnected-iso InfraEnvs against the default OCP
+# version. That requires a catalog entry with type "disconnected-iso". Production
+# OVE images are not mirrored in CI, so when no disconnected entry exists for the
+# default version we add a stub that reuses the regular public RHCOS mirror URL
+# (same bytes image-service already downloads for online ISOs).
+#
+# Prints compact JSON to stdout for use as OS_IMAGES.
+
+set -euo pipefail
+
+ROOT_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+OS_IMAGES_FILE="${ROOT_DIR}/data/default_os_images.json"
+RELEASE_IMAGES_FILE="${ROOT_DIR}/data/default_release_images.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "error: jq is required" >&2
+	exit 1
+fi
+
+DEFAULT_OCP="$(jq -r '[.[] | select(.default == true)][0].openshift_version // empty' "${RELEASE_IMAGES_FILE}")"
+if [[ -z "${DEFAULT_OCP}" ]]; then
+	echo "error: no default openshift version in ${RELEASE_IMAGES_FILE}" >&2
+	exit 1
+fi
+
+jq -c --arg ver "${DEFAULT_OCP}" '
+  def is_regular:
+    (.type // "") == "";
+  def is_disconnected:
+    .type == "disconnected-iso";
+
+  if any(.[]; is_disconnected and .openshift_version == $ver and .cpu_architecture == "x86_64") then
+    .
+  else
+    ([.[] | select(.openshift_version == $ver and .cpu_architecture == "x86_64" and is_regular)] | first) as $regular |
+    if $regular == null then
+      error("no regular x86_64 OS image for openshift version " + $ver)
+    else
+      . + [$regular + {type: "disconnected-iso"}]
+    end
+  end
+' "${OS_IMAGES_FILE}"

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -616,7 +616,7 @@ func (b *bareMetalInventory) validateOsImageForCluster(openshiftVersion, cpuArch
 	if !b.EnableImageService {
 		return nil
 	}
-	osImage, err := b.osImages.GetOsImage(openshiftVersion, cpuArchitecture, osStream)
+	osImage, err := b.osImages.GetOsImage(openshiftVersion, cpuArchitecture, osStream, "")
 	if err != nil || osImage.URL == nil {
 		return errors.Errorf("No OS images are available for version (%s), CPU architecture (%s) and os stream (%s)", openshiftVersion, cpuArchitecture, osStream)
 	}
@@ -1302,7 +1302,7 @@ func (b *bareMetalInventory) updateExternalImageInfo(ctx context.Context, infraE
 	updates["type"] = imageType
 	infraEnv.Type = common.ImageTypePtr(imageType)
 
-	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream)
+	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, string(common.ImageTypeValue(infraEnv.Type)))
 	if err != nil {
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
@@ -5264,7 +5264,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(ctx context.Context, kubeK
 			osStream = cluster.OsStream
 		}
 
-		openshiftVersion, err = b.getOsImageOpenshiftVersion(openshiftVersion, params.InfraenvCreateParams.CPUArchitecture, osStream)
+		openshiftVersion, err = b.getOsImageOpenshiftVersion(openshiftVersion, params.InfraenvCreateParams.CPUArchitecture, osStream, string(params.InfraenvCreateParams.ImageType))
 		if err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
@@ -5413,11 +5413,11 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(ctx context.Context, kubeK
 	return b.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *infraEnv.ID})
 }
 
-func (b *bareMetalInventory) getOsImageOpenshiftVersion(openshiftVersion, cpuArch, osStream string) (string, error) {
+func (b *bareMetalInventory) getOsImageOpenshiftVersion(openshiftVersion, cpuArch, osStream, imageType string) (string, error) {
 	if !b.EnableImageService {
 		return openshiftVersion, nil
 	}
-	osImage, err := b.osImages.GetOsImageOrLatest(openshiftVersion, cpuArch, osStream)
+	osImage, err := b.osImages.GetOsImageOrLatest(openshiftVersion, cpuArch, osStream, imageType)
 	if err != nil {
 		return "", err
 	}
@@ -5706,7 +5706,7 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 			osStream = *params.InfraEnvUpdateParams.OsStream
 		}
 
-		_, err = b.getOsImageOpenshiftVersion(openshiftVersion, infraEnv.CPUArchitecture, osStream)
+		_, err = b.getOsImageOpenshiftVersion(openshiftVersion, infraEnv.CPUArchitecture, osStream, string(targetImageType))
 		if err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -274,7 +274,7 @@ func mockClusterRegisterSteps(withReleaseImageURL bool) {
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 	}
 
-	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 	mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
@@ -335,8 +335,8 @@ func mockClusterUpdateSuccess(times int, hosts int) {
 
 func mockInfraEnvRegisterSuccess() {
 
-	mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
-	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+	mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 	mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("", nil).Times(1)
 	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(1)
@@ -346,8 +346,8 @@ func mockInfraEnvRegisterSuccess() {
 
 func mockInfraEnvUpdateSuccess() {
 
-	mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
-	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+	mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 	mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(1)
 	mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 		eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
@@ -2225,7 +2225,7 @@ var _ = Describe("cluster", func() {
 
 			It("updates OS stream when the OS image exists for the cluster version and architecture", func() {
 				mockSuccess()
-				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9", "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 				osStream := "rhel-9"
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2241,7 +2241,7 @@ var _ = Describe("cluster", func() {
 			})
 
 			It("rejects OS stream update when no OS image exists", func() {
-				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9").Return(nil, errors.New("not found")).Times(1)
+				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9", "").Return(nil, errors.New("not found")).Times(1)
 				osStream := "rhel-9"
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2255,7 +2255,7 @@ var _ = Describe("cluster", func() {
 			})
 
 			It("rejects OS stream update when the OS image has no URL", func() {
-				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9").Return(&models.OsImage{}, nil).Times(1)
+				mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9", "").Return(&models.OsImage{}, nil).Times(1)
 				osStream := "rhel-9"
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2885,7 +2885,7 @@ var _ = Describe("cluster", func() {
 				It("OLM invalid name", func() {
 					newOperatorName := "invalid-name"
 					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().GetOperatorByName(newOperatorName).Return(nil, errors.Errorf("error")).Times(1)
 
@@ -2901,7 +2901,7 @@ var _ = Describe("cluster", func() {
 
 				It("should return error when both cnv and lvm operator enabled", func() {
 					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
 						DoAndReturn(func(commonCluster *common.Cluster, operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
@@ -9283,10 +9283,10 @@ var _ = Describe("infraEnvs", func() {
 		})
 
 		It("No version specified", func() {
-			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			mockOSImages.EXPECT().GetOsImageOrLatest(
 				*common.TestDefaultConfig.OsImage.OpenshiftVersion,
-				*common.TestDefaultConfig.OsImage.CPUArchitecture, "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+				*common.TestDefaultConfig.OsImage.CPUArchitecture, "", string(models.ImageTypeFullIso)).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("", nil).Times(1)
 			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(1)
@@ -9414,8 +9414,8 @@ var _ = Describe("infraEnvs", func() {
 
 			cluster := createCluster(db, models.ClusterStatusInstallingPendingUserAction)
 
-			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
-			mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+			mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(1)
 			mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
@@ -9450,7 +9450,7 @@ var _ = Describe("infraEnvs", func() {
 			largeDiscoveryIgnition := fmt.Sprintf(`{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,%s"}}]}}`, content)
 			override := `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 
-			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 			mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("", nil).Times(1)
 			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(largeDiscoveryIgnition, nil).AnyTimes()
@@ -10037,7 +10037,6 @@ var _ = Describe("infraEnvs", func() {
 					},
 				})
 				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
-				var err error
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.AdditionalNtpSources).ToNot(Equal(nil))
@@ -10054,7 +10053,6 @@ var _ = Describe("infraEnvs", func() {
 					},
 				})
 				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
-				var err error
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.IgnitionConfigOverride).To(Equal(override))
@@ -10070,7 +10068,6 @@ var _ = Describe("infraEnvs", func() {
 					},
 				})
 				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
-				var err error
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.OpenshiftVersion).To(HaveValue(Equal(updateOCPVersion)))
@@ -10086,13 +10083,11 @@ var _ = Describe("infraEnvs", func() {
 					},
 				})
 				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
-				var err error
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.OsStream).To(HaveValue(Equal(updateOsStream)))
 			})
 			It("Update Image type", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("type", models.ImageTypeMinimalIso).Error
 				Expect(err).ToNot(HaveOccurred())
@@ -10108,9 +10103,8 @@ var _ = Describe("infraEnvs", func() {
 				Expect(common.ImageTypeValue(i.Type)).To(Equal(models.ImageTypeFullIso))
 			})
 			It("Update Image type on s390x architecture", func() {
-				var err error
-				mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
-				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 				mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
 
@@ -10128,9 +10122,8 @@ var _ = Describe("infraEnvs", func() {
 				Expect(common.ImageTypeValue(i.Type)).To(Equal(models.ImageTypeFullIso))
 			})
 			It("Update Image type on s390x architecture to full - fail", func() {
-				var err error
-				mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
-				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 				mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
 
@@ -10164,7 +10157,6 @@ var _ = Describe("infraEnvs", func() {
 				Expect(reply.(*common.ApiErrorResponse).Error()).To(Equal("cannot use Minimal ISO because it's not compatible with the s390x architecture on version 4.12 of OpenShift"))
 			})
 			It("Update Image type on ppc64le architecture", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("type", models.ImageTypeMinimalIso).Error
@@ -10183,7 +10175,6 @@ var _ = Describe("infraEnvs", func() {
 				Expect(common.ImageTypeValue(i.Type)).To(Equal(models.ImageTypeMinimalIso))
 			})
 			It("Update additional trust bundle", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("additional_trust_bundle", testCert).Error
@@ -10201,7 +10192,7 @@ var _ = Describe("infraEnvs", func() {
 				Expect(i.AdditionalTrustBundle).To(Equal(testCert2))
 			})
 			It("Update additional trust bundle - invalid", func() {
-				err := db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("additional_trust_bundle", testCert).Error
+				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("additional_trust_bundle", testCert).Error
 				Expect(err).ToNot(HaveOccurred())
 				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 					InfraEnvID: *i.ID,
@@ -10214,7 +10205,6 @@ var _ = Describe("infraEnvs", func() {
 				Expect(reply.(*common.ApiErrorResponse).StatusCode()).To(Equal(int32(http.StatusBadRequest)))
 			})
 			It("Update additional trust bundle - empty", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("additional_trust_bundle", testCert).Error
@@ -10237,7 +10227,7 @@ var _ = Describe("infraEnvs", func() {
 				params := &models.InfraEnvUpdateParams{
 					AdditionalTrustBundle: swag.String(longString),
 				}
-				err := params.Validate(nil)
+				err = params.Validate(nil)
 				Expect(err.Error()).To(ContainSubstring("should be at most 65535 chars long"))
 			})
 			It("empty mac address is rejected", func() {
@@ -10245,12 +10235,11 @@ var _ = Describe("infraEnvs", func() {
 					LogicalNicName: "eth0",
 					MacAddress:     "",
 				}
-				err := item.Validate(nil)
+				err = item.Validate(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("mac_address"))
 			})
 			It("updates proxy when http and https are the same", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 				proxyURL := "http://[1001:db9::1]:3129"
 				noProxy := ".test-infra-cluster-b0cea5e8.redhat.com,1001:db9::/120,2002:db8::/53,2003:db8::/112"
@@ -10273,7 +10262,6 @@ var _ = Describe("infraEnvs", func() {
 				Expect(swag.StringValue(i.Proxy.NoProxy)).To(Equal(noProxy))
 			})
 			It("doesn't set https proxy when not provided", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 				proxyURL := "http://[1001:db9::1]:3129"
 				noProxy := ".test-infra-cluster-b0cea5e8.redhat.com,1001:db9::/120,2002:db8::/53,2003:db8::/112"
@@ -10296,7 +10284,6 @@ var _ = Describe("infraEnvs", func() {
 			})
 
 			It("updates proxy when http and https are different", func() {
-				var err error
 				mockInfraEnvUpdateSuccess()
 				proxyURL1 := "http://[1001:db9::1]:3129"
 				proxyURL2 := "http://[1001:db9::1]:3130"
@@ -10349,14 +10336,12 @@ var _ = Describe("infraEnvs", func() {
 					},
 				})
 				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
-				var err error
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.StaticNetworkConfig).To(Equal(staticNetworkFormatRes))
 			})
 
 			It("Update StaticNetwork same", func() {
-				var err error
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", *i.ID).Update("static_network_config", "static network format result").Error
 				Expect(err).ToNot(HaveOccurred())
 				staticNetworkFormatRes := "static network format result"
@@ -10392,7 +10377,6 @@ var _ = Describe("infraEnvs", func() {
 			})
 
 			It("static network usage should be added when StaticNetworkConfig is set", func() {
-				var err error
 
 				cluster := createCluster(db, models.ClusterStatusInstallingPendingUserAction)
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", *i.ID).Update("cluster_id", cluster.ID).Error
@@ -10421,7 +10405,6 @@ var _ = Describe("infraEnvs", func() {
 			})
 
 			It("static network usage should be removed when StaticNetworkConfig is unset", func() {
-				var err error
 
 				cluster := createCluster(db, models.ClusterStatusInstallingPendingUserAction)
 				err = db.Model(&common.InfraEnv{}).Where("id = ?", *i.ID).Update("cluster_id", cluster.ID).Error
@@ -10445,6 +10428,61 @@ var _ = Describe("infraEnvs", func() {
 						StaticNetworkConfig: staticNetworkConfig,
 					},
 				})
+			})
+		})
+
+		Context("Update infraEnv disconnected-iso OS image validation", func() {
+			infraEnvName := "some-infra-env"
+			var (
+				i   *common.InfraEnv
+				err error
+			)
+			BeforeEach(func() {
+				mockEvents.EXPECT().SendInfraEnvEvent(ctx, gomock.Any()).AnyTimes()
+				mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("", nil).Times(1)
+				mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ string, _ string, _ string, imageType string) (*models.OsImage, error) {
+						if imageType == string(models.ImageTypeDisconnectedIso) {
+							return nil, errors.New("no disconnected OS image")
+						}
+						return common.TestDefaultConfig.OsImage, nil
+					}).AnyTimes()
+				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
+					eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).AnyTimes()
+
+				reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
+					InfraenvCreateParams: &models.InfraEnvCreateParams{
+						Name:             swag.String(infraEnvName),
+						OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+						PullSecret:       swag.String(fakePullSecret),
+					},
+				})
+				Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterInfraEnvCreated()))
+				actual := reply.(*installer.RegisterInfraEnvCreated)
+				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *actual.Payload.ID})
+				Expect(err).ToNot(HaveOccurred())
+				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("generated_at", strfmt.DateTime(time.Now().AddDate(0, 0, -1))).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("fails when changing to disconnected-iso without matching OS image and does not persist type", func() {
+				err = db.Model(&common.InfraEnv{}).Where("id = ?", i.ID).Update("type", models.ImageTypeMinimalIso).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
+					InfraEnvID: *i.ID,
+					InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+						ImageType: models.ImageTypeDisconnectedIso,
+					},
+				})
+				verifyApiError(reply, http.StatusBadRequest)
+
+				var dbInfraEnv common.InfraEnv
+				Expect(db.First(&dbInfraEnv, "id = ?", i.ID.String()).Error).To(Succeed())
+				Expect(common.ImageTypeValue(dbInfraEnv.Type)).To(Equal(models.ImageTypeMinimalIso))
 			})
 		})
 
@@ -10609,7 +10647,7 @@ var _ = Describe("infraEnvs", func() {
 				i, err := bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
 				Expect(err).ToNot(HaveOccurred())
 
-				mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 				mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil).Times(1)
 				mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -10652,7 +10690,7 @@ var _ = Describe("infraEnvs", func() {
 				err := db.Create(boundedInfraEnv).Error
 				Expect(err).ToNot(HaveOccurred())
 
-				mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+				mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 				mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil).Times(1)
 				mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -10700,7 +10738,7 @@ var _ = Describe("infraEnvs", func() {
 					i, err := bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
 					Expect(err).ToNot(HaveOccurred())
 
-					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil)
 					mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -10727,7 +10765,7 @@ var _ = Describe("infraEnvs", func() {
 					i, err := bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
 					Expect(err).ToNot(HaveOccurred())
 
-					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil)
 					mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -10777,7 +10815,7 @@ var _ = Describe("infraEnvs", func() {
 					i, err := bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
 					Expect(err).ToNot(HaveOccurred())
 
-					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil).Times(1)
 					mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -10794,7 +10832,7 @@ var _ = Describe("infraEnvs", func() {
 					i, err := bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
 					Expect(err).ToNot(HaveOccurred())
 
-					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+					mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "", "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType(), gomock.Any()).Return("ignitionconfigforlogging", nil).Times(7)
 					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, false, bm.authHandler.AuthType(), gomock.Any()).Return(discovery_ignition_3_1, nil).AnyTimes()
 					mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
@@ -10930,7 +10968,7 @@ var _ = Describe("infraEnvs", func() {
 				It("Invalid NTP source", func() {
 					ntpSource := "inject'"
 
-					mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+					mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 					reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
 						InfraEnvID: infraEnvID,
 						InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
@@ -13527,7 +13565,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 	It("returns ipxe-script successfully", func() {
 
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 		content := getResponseData("ipxe-script", false, nil, "", infraEnvID)
 		lines := strings.Split(string(content), "\n")
 
@@ -13580,7 +13618,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 		}
 		initialKernelArguments := `random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8 coreos.inst.persistent-kargs="console=tty1 console=ttyS1,115200n8"`
 
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 		content := getResponseData("ipxe-script", false, nil, "", infraEnvID)
 		lines := strings.Split(string(content), "\n")
 
@@ -13615,7 +13653,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 	It("returns ipxe-script successfully with mac", func() {
 
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 		content := getResponseData("ipxe-script", true, nil, "", infraEnvID)
 		lines := strings.Split(string(content), "\n")
 
@@ -13662,7 +13700,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 	It("fails to return ipxe-script when openshift version is nil", func() {
 
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(&models.OsImage{}, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(&models.OsImage{}, nil).Times(1)
 		params := installer.V2DownloadInfraEnvFilesParams{InfraEnvID: infraEnvID, FileName: "ipxe-script"}
 		response := bm.V2DownloadInfraEnvFiles(ctx, params)
 		verifyApiError(response, http.StatusInternalServerError)
@@ -13670,7 +13708,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 	It("fails to return ipxe-script when openshift version can't be found", func() {
 
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(nil, fmt.Errorf("some error")).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(nil, fmt.Errorf("some error")).Times(1)
 		params := installer.V2DownloadInfraEnvFilesParams{InfraEnvID: infraEnvID, FileName: "ipxe-script"}
 		response := bm.V2DownloadInfraEnvFiles(ctx, params)
 		verifyApiError(response, http.StatusBadRequest)
@@ -13712,7 +13750,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 			}
 			Expect(db.Create(&host).Error).ToNot(HaveOccurred())
 
-			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			content := getResponseData("ipxe-script", true, nil, "", infraEnvID)
 			initrdRegex := regexp.MustCompile(`^initrd --name initrd (.+)`)
 			match := initrdRegex.FindStringSubmatch(strings.Split(string(content), "\n")[1])
@@ -13822,7 +13860,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 		It("signs the initrd ipxe-script url correctly", func() {
 
-			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			content := getResponseData("ipxe-script", false, nil, "", infraEnvID)
 			initrdRegex := regexp.MustCompile(`^initrd --name initrd (.+)`)
 			match := initrdRegex.FindStringSubmatch(strings.Split(string(content), "\n")[1])
@@ -13846,7 +13884,7 @@ var _ = Describe("V2DownloadInfraEnvFiles", func() {
 
 		It("signs the initrd ipxe-script url correctly", func() {
 
-			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			content := getResponseData("ipxe-script", false, nil, "", infraEnvID)
 			initrdRegex := regexp.MustCompile(`^initrd --name initrd (.+)`)
 			match := initrdRegex.FindStringSubmatch(strings.Split(string(content), "\n")[1])
@@ -13931,7 +13969,7 @@ var _ = Describe("UpdateInfraEnv - Ignition", func() {
 		}
 		mockUsageReports()
 
-		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).AnyTimes()
 		mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -14006,7 +14044,7 @@ var _ = Describe("UpdateInfraEnv - Ignition", func() {
 			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{IgnitionConfigOverride: override},
 		}
 
-		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).AnyTimes()
 		mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -14040,7 +14078,7 @@ var _ = Describe("UpdateInfraEnv - Ignition", func() {
 			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{IgnitionConfigOverride: override},
 		}
 
-		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(1)
 		mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName),
@@ -14061,7 +14099,7 @@ var _ = Describe("UpdateInfraEnv - Ignition", func() {
 		largeDiscoveryIgnition := fmt.Sprintf(`{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,%s"}}]}}`, content)
 		override := `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 
-		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest("", gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).AnyTimes()
 		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(largeDiscoveryIgnition, nil).AnyTimes()
 		mockUsage.EXPECT().Add(gomock.Any(), usage.IgnitionConfigOverrideUsage, gomock.Any()).Times(1)
 		mockUsage.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
@@ -14963,7 +15001,7 @@ var _ = Describe("RegisterCluster", func() {
 
 			mockVersions.EXPECT().GetReleaseImage(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil).Times(1)
 
-			mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 
 			reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
@@ -15269,7 +15307,7 @@ var _ = Describe("RegisterCluster", func() {
 				}, nil).Times(1)
 				mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 
-				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+				mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 
 				params := getClusterCreateParams(nil)
 				params.Platform = &models.Platform{
@@ -15699,7 +15737,7 @@ var _ = Describe("RegisterCluster", func() {
 		It("persists OS stream and validates OS image for the selected stream", func() {
 			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-			mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, models.ClusterCPUArchitectureX8664, "rhel-9", "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 			mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockMetric.EXPECT().ClusterRegistered().Times(1)
@@ -16908,7 +16946,7 @@ var _ = Describe("RegisterCluster", func() {
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.PullSecret = swag.String("")
@@ -21991,7 +22029,7 @@ var _ = Describe("GetInfraEnvDownloadURL", func() {
 	})
 
 	getNewURL := func() *models.PresignedURL {
-		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 		params := installer.GetInfraEnvDownloadURLParams{InfraEnvID: infraEnvID}
 		resp := bm.GetInfraEnvDownloadURL(ctx, params)
 		Expect(resp).To(BeAssignableToTypeOf(&installer.GetInfraEnvDownloadURLOK{}))
@@ -22018,7 +22056,7 @@ var _ = Describe("GetInfraEnvDownloadURL", func() {
 
 		It("uses infra-env OS stream when resolving OS image", func() {
 			Expect(db.Model(&common.InfraEnv{}).Where("id = ?", infraEnvID).Update("os_stream", "rhel-9").Error).To(Succeed())
-			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "rhel-9").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, gomock.Any(), "rhel-9", gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 
 			params := installer.GetInfraEnvDownloadURLParams{InfraEnvID: infraEnvID}
 			resp := bm.GetInfraEnvDownloadURL(ctx, params)

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -887,8 +887,7 @@ func (b *bareMetalInventory) GetInfraEnvDownloadURL(ctx context.Context, params 
 	if !b.EnableImageService {
 		return common.GenerateErrorResponder(common.NewApiError(http.StatusBadRequest, errors.New("image service is disabled")))
 	}
-
-	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream)
+	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, string(common.ImageTypeValue(infraEnv.Type)))
 	if err != nil {
 		return common.GenerateErrorResponder(common.NewApiError(http.StatusBadRequest, err))
 	}
@@ -1077,7 +1076,7 @@ func kernelArgsAppendStr(infraEnv *common.InfraEnv) (string, error) {
 }
 
 func (b *bareMetalInventory) bootIPXEScript(ctx context.Context, infraEnv *common.InfraEnv) (string, error) {
-	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream)
+	osImage, err := b.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "")
 	if err != nil {
 		return "", common.NewApiError(http.StatusBadRequest, err)
 	}

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -561,8 +561,8 @@ func (r *InfraEnvReconciler) getOSImageVersion(log logrus.FieldLogger, infraEnv 
 	if osImageVersion == "" || !r.ImageServiceEnabled {
 		return "", nil
 	}
-
-	if _, err := r.OsImages.GetOsImage(osImageVersion, infraEnv.Spec.CpuArchitecture, osStream); err != nil {
+	imageType := infraenv.GetInfraEnvIsoImageType(log, infraEnv.Spec.CpuArchitecture, infraEnv.Spec.ImageType, r.Config.ImageType)
+	if _, err := r.OsImages.GetOsImage(osImageVersion, infraEnv.Spec.CpuArchitecture, osStream, string(imageType)); err != nil {
 		msg := "Specified OSImageVersion is missing from AgentServiceConfig"
 		log.WithError(err).Error(msg)
 		return "", common.NewApiError(http.StatusNotFound, errors.New(msg))
@@ -774,7 +774,7 @@ func (r *InfraEnvReconciler) setBootArtifactURLs(log logrus.FieldLogger, infraEn
 	var bootArtifactURLs *imageservice.BootArtifactURLs
 	var err error
 	var osImage *models.OsImage
-	if osImage, err = r.OsImages.GetOsImageOrLatest(internalInfraEnv.OpenshiftVersion, internalInfraEnv.CPUArchitecture, internalInfraEnv.OsStream); err != nil {
+	if osImage, err = r.OsImages.GetOsImageOrLatest(internalInfraEnv.OpenshiftVersion, internalInfraEnv.CPUArchitecture, internalInfraEnv.OsStream, ""); err != nil {
 		return err
 	}
 	if bootArtifactURLs, err = imageservice.GetBootArtifactURLs(r.ImageServiceBaseURL, internalInfraEnv.ID.String(), osImage, r.InsecureIPXEURLs); err != nil {

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		eventURL = fmt.Sprintf("%s/api/assisted-install/v2/events?infra_env_id=%s", ir.ServiceBaseURL, sId)
 		Expect(c.Create(ctx, pullSecret)).To(BeNil())
 		mockOSImages.EXPECT().GetOpenshiftVersions().Return([]string{"4.8"}).AnyTimes()
-		mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(ocpVersion)}, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(ocpVersion)}, nil).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -1204,7 +1204,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			Do(func(ctx context.Context, kubeKey *types.NamespacedName, mirrorRegistryConfiguration *common.MirrorRegistryConfiguration, params installer.RegisterInfraEnvParams) {
 				Expect(params.InfraenvCreateParams.OpenshiftVersion).To(Equal(osImageVersion))
 			}).Return(backendInfraEnv, nil)
-		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(osImageVersion)}, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(osImageVersion)}, nil).AnyTimes()
 
 		result, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(BeNil())
@@ -1223,7 +1223,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		})
 		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
-		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, gorm.ErrRecordNotFound).AnyTimes()
+		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, gorm.ErrRecordNotFound).AnyTimes()
 
 		result, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(BeNil())
@@ -1364,7 +1364,7 @@ var _ = Describe("infraEnv reconcile", func() {
 				Expect(params.InfraenvCreateParams.OpenshiftVersion).To(Equal(osImageVersion))
 				Expect(params.InfraenvCreateParams.OsStream).To(Equal("rhel-9"))
 			}).Return(backendInfraEnv, nil)
-		mockOSImages.EXPECT().GetOsImage(osImageVersion, gomock.Any(), "rhel-9").Return(&models.OsImage{
+		mockOSImages.EXPECT().GetOsImage(osImageVersion, gomock.Any(), "rhel-9", gomock.Any()).Return(&models.OsImage{
 			CPUArchitecture:  swag.String(infraEnvArch),
 			OpenshiftVersion: swag.String(osImageVersion),
 		}, nil).Times(1)
@@ -1649,7 +1649,7 @@ var _ = Describe("infraEnv reconcile with image service disabled", func() {
 		eventURL = fmt.Sprintf("%s/api/assisted-install/v2/events?infra_env_id=%s", ir.ServiceBaseURL, sId)
 		Expect(c.Create(ctx, pullSecret)).To(BeNil())
 		mockOSImages.EXPECT().GetOpenshiftVersions().Return([]string{"4.8"}).AnyTimes()
-		mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(ocpVersion)}, nil).AnyTimes()
+		mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.OsImage{CPUArchitecture: swag.String(infraEnvArch), OpenshiftVersion: swag.String(ocpVersion)}, nil).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/internal/host/hostcommands/download_boot_artifacts_cmd.go
+++ b/internal/host/hostcommands/download_boot_artifacts_cmd.go
@@ -46,7 +46,7 @@ func (c *downloadBootArtifactsCmd) GetSteps(ctx context.Context, host *models.Ho
 		return nil, err
 	}
 
-	osImage, err := c.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream)
+	osImage, err := c.osImages.GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/host/hostcommands/download_boot_artifacts_cmd_test.go
+++ b/internal/host/hostcommands/download_boot_artifacts_cmd_test.go
@@ -61,7 +61,7 @@ var _ = Describe("downloadBootArtifactsCmd.GetSteps", func() {
 		infraEnv.OpenshiftVersion = *common.TestDefaultConfig.OsImage.OpenshiftVersion
 		Expect(db.Create(infraEnv).Error).To(BeNil())
 		downloadCmd = NewDownloadBootArtifactsCmd(common.GetTestLog(), imgSvcURL, auth.TypeNone, mockOSImages, db, time.Duration(9000), hostFSMountDir)
-		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "").Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 
 		rhcosVersion := *common.TestDefaultConfig.OsImage.Version
 		initrdUrl := fmt.Sprintf("%s/images/%s/pxe-initrd?arch=%s&version=%s", imgSvcURL, infraEnvID, infraEnv.CPUArchitecture, rhcosVersion)
@@ -97,7 +97,7 @@ var _ = Describe("downloadBootArtifactsCmd.GetSteps", func() {
 			OsStream:         swag.String("rhel-9"),
 		}
 		downloadCmd = NewDownloadBootArtifactsCmd(common.GetTestLog(), imgSvcURL, auth.TypeNone, mockOSImages, db, time.Duration(9000), hostFSMountDir)
-		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream).Return(osImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "").Return(osImage, nil).Times(1)
 
 		rhcosVersion := *common.TestDefaultConfig.OsImage.Version
 		initrdUrl := fmt.Sprintf("%s/images/%s/pxe-initrd?arch=%s&version=%s", imgSvcURL, infraEnvID, infraEnv.CPUArchitecture, rhcosVersion)
@@ -128,7 +128,7 @@ var _ = Describe("downloadBootArtifactsCmd.GetSteps", func() {
 		Expect(db.Create(infraEnv).Error).To(BeNil())
 		downloadCmd = NewDownloadBootArtifactsCmd(common.GetTestLog(), imgSvcURL, auth.TypeNone, mockOSImages, db, time.Duration(9000), hostFSMountDir)
 		versionsErr := errors.Errorf("The requested OS image for version (%s) and CPU architecture (%s) isn't specified in OS images list", infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
-		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream).Return(nil, versionsErr).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "").Return(nil, versionsErr).Times(1)
 		_, stepErr := downloadCmd.GetSteps(ctx, &host)
 		Expect(stepErr).ToNot(BeNil())
 	})
@@ -139,7 +139,7 @@ var _ = Describe("downloadBootArtifactsCmd.GetSteps", func() {
 		Expect(db.Create(infraEnv).Error).To(BeNil())
 		downloadCmd = NewDownloadBootArtifactsCmd(common.GetTestLog(), imgSvcURL, auth.TypeNone, mockOSImages, db, time.Duration(9000), hostFSMountDir)
 		versionsErr := errors.Errorf("No OS images are available")
-		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream).Return(nil, versionsErr).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.OsStream, "").Return(nil, versionsErr).Times(1)
 		_, stepErr := downloadCmd.GetSteps(ctx, &host)
 		Expect(stepErr).ToNot(BeNil())
 	})
@@ -149,7 +149,7 @@ var _ = Describe("downloadBootArtifactsCmd.GetSteps", func() {
 		Expect(db.Create(infraEnv).Error).To(BeNil())
 		downloadCmd = NewDownloadBootArtifactsCmd(common.GetTestLog(), imgSvcURL, auth.TypeNone, mockOSImages, db, time.Duration(9000), hostFSMountDir)
 		versionsErr := errors.Errorf("No OS images are available")
-		mockOSImages.EXPECT().GetOsImageOrLatest("", "", "").Return(nil, versionsErr).Times(1)
+		mockOSImages.EXPECT().GetOsImageOrLatest("", "", "", "").Return(nil, versionsErr).Times(1)
 		_, stepErr := downloadCmd.GetSteps(ctx, &host)
 		Expect(stepErr).ToNot(BeNil())
 	})

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -320,7 +320,7 @@ var _ = Describe("instruction_manager", func() {
 			checkStep(models.HostStatusUnbindingPendingUserAction, nil)
 		})
 		It("reclaiming", func() {
-			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
+			mockOSImages.EXPECT().GetOsImageOrLatest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			checkStep(models.HostStatusReclaiming, []models.StepType{
 				models.StepTypeDownloadBootArtifacts,
 			})

--- a/internal/versions/api.go
+++ b/internal/versions/api.go
@@ -257,7 +257,7 @@ func (h *apiHandler) V2ListSupportedOpenshiftVersions(ctx context.Context, param
 
 			// In order to mark a specific version and architecture as supported we do not
 			// only need to have an available release image, but we need RHCOS image as well.
-			if _, err := h.osImages.GetOsImage(displayName, arch, ""); err != nil {
+			if _, err := h.osImages.GetOsImage(displayName, arch, "", ""); err != nil {
 				h.log.Debugf("Marking architecture %s for version %s as not available because no matching OS image found", arch, displayName)
 				continue
 			}

--- a/internal/versions/mock_osimages.go
+++ b/internal/versions/mock_osimages.go
@@ -55,18 +55,18 @@ func (mr *MockOSImagesMockRecorder) GetCPUArchitectures(openshiftVersion any) *g
 }
 
 // GetLatestOsImage mocks base method.
-func (m *MockOSImages) GetLatestOsImage(cpuArchitecture, osStream string) (*models.OsImage, error) {
+func (m *MockOSImages) GetLatestOsImage(cpuArchitecture, osStream, infraImageType string) (*models.OsImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestOsImage", cpuArchitecture, osStream)
+	ret := m.ctrl.Call(m, "GetLatestOsImage", cpuArchitecture, osStream, infraImageType)
 	ret0, _ := ret[0].(*models.OsImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestOsImage indicates an expected call of GetLatestOsImage.
-func (mr *MockOSImagesMockRecorder) GetLatestOsImage(cpuArchitecture, osStream any) *gomock.Call {
+func (mr *MockOSImagesMockRecorder) GetLatestOsImage(cpuArchitecture, osStream, infraImageType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestOsImage", reflect.TypeOf((*MockOSImages)(nil).GetLatestOsImage), cpuArchitecture, osStream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestOsImage", reflect.TypeOf((*MockOSImages)(nil).GetLatestOsImage), cpuArchitecture, osStream, infraImageType)
 }
 
 // GetOpenshiftVersions mocks base method.
@@ -84,31 +84,31 @@ func (mr *MockOSImagesMockRecorder) GetOpenshiftVersions() *gomock.Call {
 }
 
 // GetOsImage mocks base method.
-func (m *MockOSImages) GetOsImage(openshiftVersion, cpuArchitecture, osStream string) (*models.OsImage, error) {
+func (m *MockOSImages) GetOsImage(openshiftVersion, cpuArchitecture, osStream, infraImageType string) (*models.OsImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOsImage", openshiftVersion, cpuArchitecture, osStream)
+	ret := m.ctrl.Call(m, "GetOsImage", openshiftVersion, cpuArchitecture, osStream, infraImageType)
 	ret0, _ := ret[0].(*models.OsImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOsImage indicates an expected call of GetOsImage.
-func (mr *MockOSImagesMockRecorder) GetOsImage(openshiftVersion, cpuArchitecture, osStream any) *gomock.Call {
+func (mr *MockOSImagesMockRecorder) GetOsImage(openshiftVersion, cpuArchitecture, osStream, infraImageType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsImage", reflect.TypeOf((*MockOSImages)(nil).GetOsImage), openshiftVersion, cpuArchitecture, osStream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsImage", reflect.TypeOf((*MockOSImages)(nil).GetOsImage), openshiftVersion, cpuArchitecture, osStream, infraImageType)
 }
 
 // GetOsImageOrLatest mocks base method.
-func (m *MockOSImages) GetOsImageOrLatest(version, cpuArch, osStream string) (*models.OsImage, error) {
+func (m *MockOSImages) GetOsImageOrLatest(version, cpuArch, osStream, infraImageType string) (*models.OsImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOsImageOrLatest", version, cpuArch, osStream)
+	ret := m.ctrl.Call(m, "GetOsImageOrLatest", version, cpuArch, osStream, infraImageType)
 	ret0, _ := ret[0].(*models.OsImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOsImageOrLatest indicates an expected call of GetOsImageOrLatest.
-func (mr *MockOSImagesMockRecorder) GetOsImageOrLatest(version, cpuArch, osStream any) *gomock.Call {
+func (mr *MockOSImagesMockRecorder) GetOsImageOrLatest(version, cpuArch, osStream, infraImageType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsImageOrLatest", reflect.TypeOf((*MockOSImages)(nil).GetOsImageOrLatest), version, cpuArch, osStream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsImageOrLatest", reflect.TypeOf((*MockOSImages)(nil).GetOsImageOrLatest), version, cpuArch, osStream, infraImageType)
 }

--- a/internal/versions/osimages.go
+++ b/internal/versions/osimages.go
@@ -15,9 +15,9 @@ import (
 
 //go:generate mockgen --build_flags=--mod=mod -package versions -destination mock_osimages.go -self_package github.com/openshift/assisted-service/internal/versions . OSImages
 type OSImages interface {
-	GetOsImage(openshiftVersion, cpuArchitecture, osStream string) (*models.OsImage, error)
-	GetLatestOsImage(cpuArchitecture, osStream string) (*models.OsImage, error)
-	GetOsImageOrLatest(version, cpuArch, osStream string) (*models.OsImage, error)
+	GetOsImage(openshiftVersion, cpuArchitecture, osStream, infraImageType string) (*models.OsImage, error)
+	GetLatestOsImage(cpuArchitecture, osStream, infraImageType string) (*models.OsImage, error)
+	GetOsImageOrLatest(version, cpuArch, osStream, infraImageType string) (*models.OsImage, error)
 	GetCPUArchitectures(openshiftVersion string) []string
 	GetOpenshiftVersions() []string
 }
@@ -62,7 +62,7 @@ func validateOSImage(osImage *models.OsImage) error {
 }
 
 // Returns the OsImage entity matching the given OpenShift version, CPU architecture and optional OS stream.
-func (images osImageList) GetOsImage(openshiftVersion, cpuArchitecture, osStream string) (*models.OsImage, error) {
+func (images osImageList) GetOsImage(openshiftVersion, cpuArchitecture, osStream, osImageType string) (*models.OsImage, error) {
 	cpuArchitecture = common.NormalizeCPUArchitecture(cpuArchitecture)
 
 	if cpuArchitecture == "" {
@@ -81,7 +81,8 @@ func (images osImageList) GetOsImage(openshiftVersion, cpuArchitecture, osStream
 		return nil, errors.Errorf("The requested CPU architecture (%s) isn't specified in OS images list", cpuArchitecture)
 	}
 
-	candidates := findVersionCandidates(archImages, openshiftVersion)
+	filteredByImageType := filterByInfraImageType(archImages, osImageType)
+	candidates := findVersionCandidates(filteredByImageType, openshiftVersion)
 	if len(candidates) == 0 {
 		return nil, errors.Errorf(
 			"The requested OS image for version (%s) and CPU architecture (%s) isn't specified in OS images list",
@@ -137,6 +138,21 @@ func findVersionCandidates(archImages []*models.OsImage, openshiftVersion string
 	}).([]*models.OsImage)
 }
 
+func filterByInfraImageType(images []*models.OsImage, infraImageType string) []*models.OsImage {
+	return funk.Filter(images, func(img *models.OsImage) bool {
+		return imageEntryMatchesInfraImageType(img.Type, infraImageType)
+	}).([]*models.OsImage)
+}
+
+func imageEntryMatchesInfraImageType(imageEntryType string, infraImageType string) bool {
+	if infraImageType == string(models.ImageTypeDisconnectedIso) {
+		// Disconnected InfraEnv → only disconnected OS image entries
+		return imageEntryType == string(models.ImageTypeDisconnectedIso)
+	}
+	// Online InfraEnv → OS image entries with empty type only
+	return imageEntryType != string(models.ImageTypeDisconnectedIso)
+}
+
 func selectByOsStream(candidates []*models.OsImage, osStream, openshiftVersion, cpuArchitecture string) (*models.OsImage, error) {
 	if osStream != "" {
 		match := funk.Find(candidates, func(osImage *models.OsImage) bool {
@@ -182,11 +198,11 @@ func selectByOsStream(candidates []*models.OsImage, osStream, openshiftVersion, 
 }
 
 // Returns the latest OSImage entity for a specified CPU architecture and optional OS stream
-func (images osImageList) GetLatestOsImage(cpuArchitecture, osStream string) (*models.OsImage, error) {
+func (images osImageList) GetLatestOsImage(cpuArchitecture, osStream, infraImageType string) (*models.OsImage, error) {
 	var latest *models.OsImage
 	openshiftVersions := images.GetOpenshiftVersions()
 	for _, k := range openshiftVersions {
-		osImage, err := images.GetOsImage(k, cpuArchitecture, osStream)
+		osImage, err := images.GetOsImage(k, cpuArchitecture, osStream, infraImageType)
 		if err != nil {
 			continue
 		}
@@ -206,16 +222,16 @@ func (images osImageList) GetLatestOsImage(cpuArchitecture, osStream string) (*m
 	return latest, nil
 }
 
-func (images osImageList) GetOsImageOrLatest(version, cpuArch, osStream string) (*models.OsImage, error) {
+func (images osImageList) GetOsImageOrLatest(version, cpuArch, osStream, imageType string) (*models.OsImage, error) {
 	var osImage *models.OsImage
 	var err error
 	if version != "" {
-		osImage, err = images.GetOsImage(version, cpuArch, osStream)
+		osImage, err = images.GetOsImage(version, cpuArch, osStream, imageType)
 		if err != nil {
 			return nil, errors.Wrapf(err, "No OS image for Openshift version (%s), CPU architecture (%s) and OS stream (%s)", version, cpuArch, osStream)
 		}
 	} else {
-		osImage, err = images.GetLatestOsImage(cpuArch, osStream)
+		osImage, err = images.GetLatestOsImage(cpuArch, osStream, imageType)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to get latest OS image for CPU architecture (%s) and OS stream (%s)", cpuArch, osStream)
 		}

--- a/internal/versions/osimages_test.go
+++ b/internal/versions/osimages_test.go
@@ -3,6 +3,7 @@ package versions
 import (
 	"github.com/go-openapi/swag"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
@@ -90,39 +91,39 @@ var _ = Describe("GetOsImage", func() {
 		})
 
 		It("fails for an unsupported version", func() {
-			image, err := images.GetOsImage("unsupported", common.TestDefaultConfig.CPUArchitecture, "")
+			image, err := images.GetOsImage("unsupported", common.TestDefaultConfig.CPUArchitecture, "", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).Should(BeNil())
 		})
 
 		It("fails for an unsupported cpuArchitecture", func() {
-			image, err := images.GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported", "")
+			image, err := images.GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported", "", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).Should(BeNil())
 			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
 		})
 
 		It("empty architecture fallback to default", func() {
-			image, err := images.GetOsImage("4.9", "", "")
+			image, err := images.GetOsImage("4.9", "", "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(image.CPUArchitecture).To(HaveValue(Equal(common.DefaultCPUArchitecture)))
 		})
 
 		It("multiarch returns error", func() {
-			image, err := images.GetOsImage("4.11", common.MultiCPUArchitecture, "")
+			image, err := images.GetOsImage("4.11", common.MultiCPUArchitecture, "", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).Should(BeNil())
 			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
 		})
 
 		It("fetch OS image by major.minor", func() {
-			image, err := images.GetOsImage("4.9", common.DefaultCPUArchitecture, "")
+			image, err := images.GetOsImage("4.9", common.DefaultCPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(image.OpenshiftVersion).To(HaveValue(Equal("4.9")))
 		})
 
 		It("With normalizing the CPU architecture", func() {
-			image, err := images.GetOsImage("4.9", common.AARCH64CPUArchitecture, "")
+			image, err := images.GetOsImage("4.9", common.AARCH64CPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(image.Version).To(HaveValue(Equal("version-49.123-0_arm64")))
 			Expect(*image.CPUArchitecture).To(Equal(common.ARM64CPUArchitecture))
@@ -133,7 +134,7 @@ var _ = Describe("GetOsImage", func() {
 				architectures := images.GetCPUArchitectures(version)
 
 				for _, architecture := range architectures {
-					image, err := images.GetOsImage(version, architecture, "")
+					image, err := images.GetOsImage(version, architecture, "", "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, rhcos := range defaultOsImages {
@@ -168,13 +169,13 @@ var _ = Describe("GetOsImage", func() {
 		})
 
 		It("finds latest patch version by X.Y when given X.Y.Z", func() {
-			image, err := images.GetOsImage("4.10.1", common.DefaultCPUArchitecture, "")
+			image, err := images.GetOsImage("4.10.1", common.DefaultCPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(image.OpenshiftVersion).To(HaveValue(Equal("4.10.10")))
 		})
 
 		It("finds latest patch version by X.Y when given X.Y", func() {
-			image, err := images.GetOsImage("4.10", common.DefaultCPUArchitecture, "")
+			image, err := images.GetOsImage("4.10", common.DefaultCPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(image.OpenshiftVersion).To(HaveValue(Equal("4.10.10")))
 		})
@@ -209,21 +210,21 @@ var _ = Describe("GetOsImage", func() {
 		})
 
 		It("returns the default stream when osStream is empty", func() {
-			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "")
+			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(swag.StringValue(image.OsStream)).To(Equal("rhel-9"))
 			Expect(swag.StringValue(image.Version)).To(Equal("9.6.20260101-0"))
 		})
 
 		It("returns the requested stream", func() {
-			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "rhel-10")
+			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "rhel-10", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(swag.StringValue(image.OsStream)).To(Equal("rhel-10"))
 			Expect(swag.StringValue(image.Version)).To(Equal("10.0.20260101-0"))
 		})
 
 		It("fails for an unknown stream", func() {
-			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "rhel-11")
+			image, err := images.GetOsImage("4.22", common.X86CPUArchitecture, "rhel-11", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("OS stream"))
@@ -235,7 +236,7 @@ var _ = Describe("GetOsImage", func() {
 			imgs, err := NewOSImages(noDefault, imageServiceEnabled)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "")
+			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("No default OS stream"))
@@ -247,7 +248,7 @@ var _ = Describe("GetOsImage", func() {
 			imgs, err := NewOSImages(multiDefault, imageServiceEnabled)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "")
+			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "", "")
 			Expect(err).Should(HaveOccurred())
 			Expect(image).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("Multiple default OS streams"))
@@ -271,10 +272,110 @@ var _ = Describe("GetOsImage", func() {
 			imgs, err := NewOSImages(legacy, imageServiceEnabled)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "")
+			image, err := imgs.GetOsImage("4.22", common.X86CPUArchitecture, "", "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(swag.StringValue(image.URL)).To(Equal("rhcos-a"))
 		})
+	})
+
+	Context("with online and disconnected catalog entries", func() {
+		const ocpVersion = "4.21"
+		const regularRHCOSVersion = "9.6.20260616-0"
+		const disconnectedRHCOSVersion = "9.6.20251212-1"
+
+		dualCatalogImages := func() models.OsImages {
+			// Disconnected entry is listed first to catch first-match regressions.
+			return models.OsImages{
+				{
+					OpenshiftVersion: swag.String(ocpVersion),
+					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+					URL:              swag.String("rhcos-disconnected"),
+					Version:          swag.String(disconnectedRHCOSVersion),
+					Type:             string(models.ImageTypeDisconnectedIso),
+				},
+				{
+					OpenshiftVersion: swag.String(ocpVersion),
+					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+					URL:              swag.String("rhcos-regular"),
+					Version:          swag.String(regularRHCOSVersion),
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			var err error
+			images, err = NewOSImages(dualCatalogImages(), imageServiceEnabled)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("selects the regular catalog entry for minimal-iso InfraEnv", func() {
+			image, err := images.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeMinimalIso))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(swag.StringValue(image.Version)).To(Equal(regularRHCOSVersion))
+			Expect(image.Type).To(BeEmpty())
+		})
+
+		It("selects the regular catalog entry for full-iso InfraEnv", func() {
+			image, err := images.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeFullIso))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(swag.StringValue(image.Version)).To(Equal(regularRHCOSVersion))
+		})
+
+		It("selects the regular catalog entry when infra image type is unset", func() {
+			image, err := images.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(swag.StringValue(image.Version)).To(Equal(regularRHCOSVersion))
+		})
+
+		It("selects the disconnected catalog entry for disconnected-iso InfraEnv", func() {
+			image, err := images.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeDisconnectedIso))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(swag.StringValue(image.Version)).To(Equal(disconnectedRHCOSVersion))
+			Expect(image.Type).To(Equal(string(models.ImageTypeDisconnectedIso)))
+		})
+
+		It("fails when only disconnected catalog entry exists and online ISO is requested", func() {
+			disconnectedOnly := models.OsImages{dualCatalogImages()[0]}
+			imgs, err := NewOSImages(disconnectedOnly, imageServiceEnabled)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			image, err := imgs.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeMinimalIso))
+			Expect(err).Should(HaveOccurred())
+			Expect(image).To(BeNil())
+		})
+
+		It("fails when only regular catalog entry exists and disconnected ISO is requested", func() {
+			regularOnly := models.OsImages{dualCatalogImages()[1]}
+			imgs, err := NewOSImages(regularOnly, imageServiceEnabled)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			image, err := imgs.GetOsImage(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeDisconnectedIso))
+			Expect(err).Should(HaveOccurred())
+			Expect(image).To(BeNil())
+		})
+
+		It("GetOsImageOrLatest passes infra image type through to catalog selection", func() {
+			image, err := images.GetOsImageOrLatest(ocpVersion, common.X86CPUArchitecture, "", string(models.ImageTypeDisconnectedIso))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(swag.StringValue(image.Version)).To(Equal(disconnectedRHCOSVersion))
+		})
+	})
+
+	Context("imageEntryMatchesInfraImageType", func() {
+		disconnected := string(models.ImageTypeDisconnectedIso)
+
+		DescribeTable("matches OS image entries by InfraEnv image type",
+			func(imageEntryType, infraImageType string, want bool) {
+				Expect(imageEntryMatchesInfraImageType(imageEntryType, infraImageType)).To(Equal(want),
+					"imageEntryMatchesInfraImageType(%q, %q)", imageEntryType, infraImageType)
+			},
+			Entry("online OS image entry for minimal-iso InfraEnv", "", string(models.ImageTypeMinimalIso), true),
+			Entry("online OS image entry for full-iso InfraEnv", "", string(models.ImageTypeFullIso), true),
+			Entry("online OS image entry for unset InfraEnv image type", "", "", true),
+			Entry("disconnected OS image entry for minimal-iso InfraEnv", disconnected, string(models.ImageTypeMinimalIso), false),
+			Entry("disconnected OS image entry for disconnected-iso InfraEnv", disconnected, disconnected, true),
+			Entry("online OS image entry for disconnected-iso InfraEnv", "", disconnected, false),
+		)
 	})
 })
 
@@ -283,7 +384,7 @@ var _ = Describe("GetLatestOsImage", func() {
 		images, err := NewOSImages(defaultOsImages[0:1], imageServiceEnabled)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		osImage, err := images.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture, "")
+		osImage, err := images.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture, "", "")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
 		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
@@ -293,7 +394,7 @@ var _ = Describe("GetLatestOsImage", func() {
 		images, err := NewOSImages(defaultOsImages, imageServiceEnabled)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		osImage, err := images.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture, "")
+		osImage, err := images.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture, "", "")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
 		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
@@ -303,7 +404,7 @@ var _ = Describe("GetLatestOsImage", func() {
 		images, err := NewOSImages(defaultOsImages, imageServiceEnabled)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		osImage, err := images.GetLatestOsImage(common.MultiCPUArchitecture, "")
+		osImage, err := images.GetLatestOsImage(common.MultiCPUArchitecture, "", "")
 		Expect(err).Should(HaveOccurred())
 		Expect(osImage).Should(BeNil())
 		Expect(err.Error()).To(ContainSubstring("No OS images are available"))
@@ -322,33 +423,33 @@ var _ = Describe("GetOsImageOrLatest", func() {
 	})
 
 	It("successfully gets an OS image with a valid openshift version and cpu architecture", func() {
-		image, err := images.GetOsImageOrLatest("4.9", common.TestDefaultConfig.CPUArchitecture, "")
+		image, err := images.GetOsImageOrLatest("4.9", common.TestDefaultConfig.CPUArchitecture, "", "")
 		Expect(err).To(BeNil())
 		Expect(*image.OpenshiftVersion).Should(Equal("4.9"))
 		Expect(*image.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
 	})
 
 	It("successfully gets the latest OS image with a valid cpu architecture", func() {
-		image, err := images.GetOsImageOrLatest("", common.TestDefaultConfig.CPUArchitecture, "")
+		image, err := images.GetOsImageOrLatest("", common.TestDefaultConfig.CPUArchitecture, "", "")
 		Expect(err).To(BeNil())
 		Expect(*image.OpenshiftVersion).Should(Equal("4.11.1"))
 		Expect(*image.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
 	})
 
 	It("fails to get OS images for invalid cpu architecture and valid openshift version", func() {
-		image, err := images.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866", "")
+		image, err := images.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866", "", "")
 		Expect(err).ToNot(BeNil())
 		Expect(image).Should(BeNil())
 	})
 
 	It("fails to get OS images for invalid cpu architecture and invalid openshift version", func() {
-		image, err := images.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866", "")
+		image, err := images.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866", "", "")
 		Expect(err).ToNot(BeNil())
 		Expect(image).Should(BeNil())
 	})
 
 	It("fails to get OS images for invalid cpu architecture and no openshift version", func() {
-		image, err := images.GetOsImageOrLatest("", "x866", "")
+		image, err := images.GetOsImageOrLatest("", "x866", "", "")
 		Expect(err).ToNot(BeNil())
 		Expect(image).Should(BeNil())
 	})

--- a/models/os_image.go
+++ b/models/os_image.go
@@ -36,6 +36,10 @@ type OsImage struct {
 	// The OS stream of this image (e.g. rhel-9, rhel-10).
 	OsStream *string `json:"os_stream,omitempty"`
 
+	// The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.
+	// Enum: [disconnected-iso]
+	Type string `json:"type,omitempty"`
+
 	// The base OS image used for the discovery iso.
 	// Required: true
 	URL *string `json:"url"`
@@ -54,6 +58,10 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOpenshiftVersion(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -126,6 +134,45 @@ func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 func (m *OsImage) validateOpenshiftVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var osImageTypeTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["disconnected-iso"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeTypePropEnum = append(osImageTypeTypePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageTypeDisconnectedIso captures enum value "disconnected-iso"
+	OsImageTypeDisconnectedIso string = "disconnected-iso"
+)
+
+// prop value enum
+func (m *OsImage) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *OsImage) validateType(formats strfmt.Registry) error {
+	if swag.IsZero(m.Type) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateTypeEnum("type", "body", m.Type); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10646,6 +10646,13 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "type": {
+          "description": "The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.",
+          "type": "string",
+          "enum": [
+            "disconnected-iso"
+          ]
+        },
         "url": {
           "description": "The base OS image used for the discovery iso.",
           "type": "string"
@@ -22436,6 +22443,13 @@ func init() {
           "description": "The OS stream of this image (e.g. rhel-9, rhel-10).",
           "type": "string",
           "x-nullable": true
+        },
+        "type": {
+          "description": "The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.",
+          "type": "string",
+          "enum": [
+            "disconnected-iso"
+          ]
         },
         "url": {
           "description": "The base OS image used for the discovery iso.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7682,6 +7682,10 @@ definitions:
         type: boolean
         description: Whether this OS image is the default stream for its OpenShift version and CPU architecture.
         x-nullable: true
+      type:
+        type: string
+        enum: ['disconnected-iso']
+        description: The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.
 
   os-images:
     type: array

--- a/vendor/github.com/openshift/assisted-service/models/os_image.go
+++ b/vendor/github.com/openshift/assisted-service/models/os_image.go
@@ -36,6 +36,10 @@ type OsImage struct {
 	// The OS stream of this image (e.g. rhel-9, rhel-10).
 	OsStream *string `json:"os_stream,omitempty"`
 
+	// The type of the image. If set to 'disconnected-iso' tags the image as a disconnected ISO image.
+	// Enum: [disconnected-iso]
+	Type string `json:"type,omitempty"`
+
 	// The base OS image used for the discovery iso.
 	// Required: true
 	URL *string `json:"url"`
@@ -54,6 +58,10 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOpenshiftVersion(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -126,6 +134,45 @@ func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 func (m *OsImage) validateOpenshiftVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var osImageTypeTypePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["disconnected-iso"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeTypePropEnum = append(osImageTypeTypePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageTypeDisconnectedIso captures enum value "disconnected-iso"
+	OsImageTypeDisconnectedIso string = "disconnected-iso"
+)
+
+// prop value enum
+func (m *OsImage) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeTypePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *OsImage) validateType(formats strfmt.Registry) error {
+	if swag.IsZero(m.Type) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateTypeEnum("type", "body", m.Type); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When OS_IMAGES contains both a regular and a disconnected-iso entry for the same OpenShift version and CPU architecture (e.g. 4.21 x86_64), the assisted-service can select the disconnected-iso entry when generating download URLs for regular minimal ISOs. This causes a "no such file or directory" error in the image service because no minimal ISO was created for the disconnected-iso entry's RHCOS version.

To fix this the imageType has to be taken into account when filtering the proper image.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying disconnected ISO operating system images.
  * Image selection now respects the requested image type for clusters and infrastructure environments.
  * Added validation for the optional image type field, including `disconnected-iso`.

* **Bug Fixes**
  * Prevented infrastructure environment updates when the requested image type is unavailable.
  * Preserved the existing image type when validation fails.

* **Documentation**
  * Updated the API specification to document the operating system image type field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->