### PR TITLE
MGMT-24967: Static-IP iSCSI Boot-from-SAN Support in Assisted Installer

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -351,15 +351,16 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 	hasDay2UnknownMachineNetwork := hasDay2UnknownMachineNetwork(cluster, host, isOciCluster, log)
 	installerArgs, hasIPConfigOverride = appends390xArgs(inventory, installerArgs, log)
 	hasIPConfigOverride = hasIPConfigOverride || hasUserConfiguredIP || hasDay2UnknownMachineNetwork
+	staticNetwork := hasStaticNetwork(cluster, infraEnv)
 
 	// append kargs depending on installation drive type
 	installationDisk := hostutil.GetDiskByInstallationPath(inventory.Disks, hostutil.GetHostInstallationPath(host))
 	if installationDisk != nil {
-		installerArgs, err = appendMultipathArgs(installerArgs, installationDisk, inventory, hasIPConfigOverride)
+		installerArgs, err = appendMultipathArgs(installerArgs, installationDisk, inventory, hasIPConfigOverride, staticNetwork)
 		if err != nil {
 			return "", err
 		}
-		installerArgs, err = appendISCSIArgs(installerArgs, installationDisk, inventory, hasIPConfigOverride)
+		installerArgs, err = appendISCSIArgs(installerArgs, installationDisk, inventory, hasIPConfigOverride, staticNetwork)
 		if err != nil {
 			return "", err
 		}
@@ -442,7 +443,7 @@ func appendCopyNetwork(installerArgs []string) []string {
 	return installerArgs
 }
 
-func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inventory *models.Inventory, hasIPConfigOverride bool) ([]string, error) {
+func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inventory *models.Inventory, hasIPConfigOverride bool, staticNetwork bool) ([]string, error) {
 	if installationDisk.DriveType != models.DriveTypeISCSI {
 		return installerArgs, nil
 	}
@@ -456,7 +457,7 @@ func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inve
 		return installerArgs, nil
 	}
 
-	// configure DHCP on the interface used by the iSCSI boot volume
+	// configure the interface used by the iSCSI boot volume
 	iSCSIHostIP, err := netip.ParseAddr(installationDisk.Iscsi.HostIPAddress)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse iSCSI host IP %s: %w", installationDisk.Iscsi.HostIPAddress, err)
@@ -467,12 +468,15 @@ func appendISCSIArgs(installerArgs []string, installationDisk *models.Disk, inve
 		return nil, fmt.Errorf("Cannot find the interface belonging to iSCSI host IP: %w", err)
 	}
 
-	dhcp := "dhcp"
-	if iSCSIHostIP.Is6() {
-		dhcp = "dhcp6"
+	ipConfig := "dhcp"
+	switch {
+	case staticNetwork:
+		ipConfig = "ibft"
+	case iSCSIHostIP.Is6():
+		ipConfig = "dhcp6"
 	}
 
-	netArg := formatNetKarg(nic, dhcp)
+	netArg := formatNetKarg(nic, ipConfig)
 	if !lo.Contains(installerArgs, netArg) {
 		installerArgs = append(installerArgs, "--append-karg", netArg)
 	}
@@ -494,7 +498,7 @@ func appendRaidArgs(installerArgs []string, installationDisk *models.Disk) ([]st
 	return installerArgs, nil
 }
 
-func appendMultipathArgs(installerArgs []string, installationDisk *models.Disk, inventory *models.Inventory, hasIPConfigOverride bool) ([]string, error) {
+func appendMultipathArgs(installerArgs []string, installationDisk *models.Disk, inventory *models.Inventory, hasIPConfigOverride bool, staticNetwork bool) ([]string, error) {
 	if installationDisk.DriveType != models.DriveTypeMultipath {
 		return installerArgs, nil
 	}
@@ -506,7 +510,7 @@ func appendMultipathArgs(installerArgs []string, installationDisk *models.Disk, 
 	if len(iSCSIDisks) != 0 {
 		var err error
 		for _, iscsiDisk := range iSCSIDisks {
-			installerArgs, err = appendISCSIArgs(installerArgs, iscsiDisk, inventory, hasIPConfigOverride)
+			installerArgs, err = appendISCSIArgs(installerArgs, iscsiDisk, inventory, hasIPConfigOverride, staticNetwork)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1086,6 +1086,114 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:dhcp6"]`))
 	})
+	It("iSCSI installation disk - static network configuration uses iBFT instead of DHCP", func() {
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}
+		infraEnv.StaticNetworkConfig = "something"
+		cluster.ImageInfo.StaticNetworkConfig = "something"
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.80"
+					}
+				},
+				{
+					"id": "other-id",
+					"drive_type": "%s"
+				}
+			],
+			"interfaces":[
+				{
+					"mac_address": "01:02:03:04:05:06",
+					"ipv4_addresses":["10.56.20.80/25"]
+				},
+				{
+					"mac_address": "07:08:09:0A:0B:0C",
+					"ipv4_addresses":["10.56.21.80/25"]
+				}
+			]
+		}`, models.DriveTypeISCSI, models.DriveTypeSSD)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:ibft","--copy-network"]`))
+	})
+	It("iSCSI installation disk - static network with IPv6 host address uses iBFT (not dhcp6)", func() {
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/25"}}
+		infraEnv.StaticNetworkConfig = "something"
+		cluster.ImageInfo.StaticNetworkConfig = "something"
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "2002:db8::1"
+					}
+				},
+				{
+					"id": "other-id",
+					"drive_type": "%s"
+				}
+			],
+			"interfaces":[
+				{
+					"mac_address": "01:02:03:04:05:06",
+					"ipv6_addresses":["2002:db8::1/64"]
+				}
+			]
+		}`, models.DriveTypeISCSI, models.DriveTypeSSD)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:ibft","--copy-network"]`))
+	})
+	It("multipath iSCSI installation disk - static network configuration uses iBFT instead of DHCP", func() {
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
+		infraEnv.StaticNetworkConfig = "something"
+		cluster.ImageInfo.StaticNetworkConfig = "something"
+		host.Inventory = fmt.Sprintf(`{
+			"disks":[
+				{
+					"id": "install-id",
+					"drive_type": "%s",
+					"name": "dm-0"
+				},
+				{
+					"id": "other-id",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.80"
+					},
+					"holders": "dm-0"
+				},
+				{
+					"id": "other-id-2",
+					"drive_type": "%s",
+					"iscsi": {
+						"host_ip_address": "10.56.20.81"
+					},
+					"holders": "dm-0"
+				}
+			],
+			"interfaces":[
+				{
+					"mac_address": "01:02:03:04:05:06",
+					"ipv4_addresses":["10.56.20.80/25"]
+				},
+				{
+					"mac_address": "07:08:09:0A:0B:0C",
+					"ipv4_addresses":["10.56.20.81/25"]
+				}
+			]
+		}`, models.DriveTypeMultipath, models.DriveTypeISCSI, models.DriveTypeISCSI)
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Debug info: Unmarshalled Inventory: %+v, Host's Inventory: %s", inventory, host.Inventory))
+		Expect(args).To(Equal(`["--append-karg","rw","--append-karg","rd.multipath=default","--append-karg","rd.iscsi.firmware=1","--append-karg","ip=01-02-03-04-05-06:ibft","--append-karg","ip=07-08-09-0A-0B-0C:ibft","--copy-network"]`), fmt.Sprintf("Debug info: Actual args returned: %s", args))
+	})
 	It("iSCSI installation disk - IP configuration is not appended if user already added it", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		kargs := `["--append-karg","ip=dhcp"]`


### PR DESCRIPTION
When installing to an iSCSI boot-from-SAN disk with a static network configuration, use ibft as the network kernel argument instead of dhcp/dhcp6, so the iSCSI NIC config is sourced from iBFT rather than assuming DHCP. Adds unit test coverage for the new static-network iSCSI karg path.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iSCSI installation handling for static network configurations.
  - Uses appropriate boot networking for static IPv4 and IPv6 setups.
  - Ensures multipath iSCSI installations preserve the correct network configuration and copy network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->