### PR TITLE
APPSRE-14688: remove legacy monitoring.coreos.com/v1 ServiceMonitors

### DIFF
--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -8,42 +8,6 @@ kind: Template
 metadata:
   name: assisted-installer
 objects:
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    labels:
-      prometheus: app-sre
-    name: servicemonitor-assisted-installer-${NAMESPACE}
-  spec:
-    endpoints:
-    - interval: 30s
-      path: /metrics
-      port: assisted-svc
-      scheme: http
-    namespaceSelector:
-      matchNames:
-      - ${NAMESPACE}
-    selector:
-      matchLabels:
-        app: assisted-service
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    labels:
-      prometheus: app-sre
-    name: servicemonitor-assisted-installer-postgres-${NAMESPACE}
-  spec:
-    endpoints:
-    - interval: 30s
-      path: /metrics
-      port: http
-      scheme: http
-    namespaceSelector:
-      matchNames:
-      - ${NAMESPACE}
-    selector:
-      matchLabels:
-        app: assisted-installer-prometheus-postgres-exporter
 - apiVersion: monitoring.rhobs/v1
   kind: ServiceMonitor
   metadata:


### PR DESCRIPTION
## Summary
- Removes the legacy `monitoring.coreos.com/v1` ServiceMonitors from `openshift/template-monitoring.yaml`, keeping only the `monitoring.rhobs/v1` companions added in #10540.
- COO Prometheus scraping of `assisted-service` and the postgres-exporter via the `monitoring.rhobs/v1` ServiceMonitors has been confirmed healthy.

## Test plan
- [ ] Confirm app-interface reconcile deletes the legacy `ServiceMonitor.monitoring.coreos.com` objects from the assisted-installer namespaces after this merges
- [ ] Confirm COO Prometheus continues scraping `up{job="assisted-service"}` and the postgres-exporter targets with no gap

Relates to: https://redhat.atlassian.net/browse/APPSRE-14688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated monitoring integrations to use the supported monitoring API version.
  - Existing monitoring targets, endpoints, selectors, and labels remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->