### PR TITLE
MGMT-25131: When getting the release image for a cluster we should always prioritize cluster.OcpReleaseImage if it's set

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1633,7 +1633,7 @@ func (b *bareMetalInventory) validateReleaseImageForDay2HostInstall(ctx context.
 		cpuArch = infraEnv.CPUArchitecture
 	}
 
-	_, err = b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cpuArch, cluster.PullSecret)
+	_, err = b.versionsHandler.GetReleaseImageForCluster(ctx, cluster, cpuArch)
 	if err != nil {
 		// For imported clusters with no ImageSetRef, the release image may not be
 		// available. The install command can use the CoreOS image from the worker
@@ -1999,7 +1999,7 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 		return errors.Wrapf(err, "failed to get install config for cluster %s", cluster.ID)
 	}
 
-	releaseImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
+	releaseImage, err := b.versionsHandler.GetReleaseImageForCluster(ctx, &cluster, cluster.CPUArchitecture)
 	if err != nil {
 		msg := fmt.Sprintf("failed to get OpenshiftVersion for cluster %s with openshift version %s", cluster.ID, cluster.OpenshiftVersion)
 		log.WithError(err).Error(msg)
@@ -2008,6 +2008,8 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 
 	installerReleaseImageOverride := ""
 	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster.CPUArchitecture, cluster.OpenshiftVersion) {
+		// Intentionally look up by version/architecture rather than OcpReleaseImage:
+		// this override needs the default-arch release image, not the cluster's image.
 		defaultArchImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, common.DefaultCPUArchitecture, cluster.PullSecret)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get image for installer image override "+

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -471,7 +471,7 @@ func getDefaultClusterCreateParams() *models.ClusterCreateParams {
 
 func mockGenerateInstallConfigSuccess(mockGenerator *generator.MockInstallConfigGenerator, mockVersions *versions.MockHandler) {
 	if mockGenerator != nil {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockGenerator.EXPECT().GenerateInstallConfig(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
 	}
 }
@@ -5799,7 +5799,7 @@ var _ = Describe("cluster", func() {
 				URL: swag.String("quay.io/openshift-release-dev/ocp-release:4.6.16-aarch64"),
 			}
 			mockGetInstallConfigSuccess(mockInstallConfigBuilder)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture, gomock.Any()).Return(armRelease, nil).Times(1)
+			mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture).Return(armRelease, nil).Times(1)
 			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.DefaultCPUArchitecture, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 			mockGenerator.EXPECT().GenerateInstallConfig(gomock.Any(), gomock.Any(), gomock.Any(), *armRelease.URL, *common.TestDefaultConfig.ReleaseImage.URL, false).Return(nil).Times(1)
 
@@ -5861,7 +5861,7 @@ var _ = Describe("cluster", func() {
 				URL: swag.String("quay.io/openshift-release-dev/ocp-release:4.6.16-aarch64"),
 			}
 			mockGetInstallConfigSuccess(mockInstallConfigBuilder)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture, gomock.Any()).Return(armRelease, nil).Times(1)
+			mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture).Return(armRelease, nil).Times(1)
 			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.DefaultCPUArchitecture, gomock.Any()).Return(nil, errors.Errorf("Dummy")).Times(1)
 
 			mockClusterPrepareForInstallationSuccess(mockClusterApi)
@@ -14642,7 +14642,28 @@ var _ = Describe("Install Host test", func() {
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, infraEnvId, clusterID, inventory, db)
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(common.TestDefaultConfig.ReleaseImage, nil)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(common.TestDefaultConfig.ReleaseImage, nil)
+		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+
+		res := bm.V2InstallHost(ctx, params)
+		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2InstallHostAccepted()))
+	})
+
+	It("uses the cluster OcpReleaseImage URL when installing to the rootfs", func() {
+		ocpReleaseImage := "registry.mirror.example.com/ocp/release:4.18"
+		Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update("ocp_release_image", ocpReleaseImage).Error).ToNot(HaveOccurred())
+		params := installer.V2InstallHostParams{
+			HTTPRequest: request,
+			InfraEnvID:  infraEnvId,
+			HostID:      hostID,
+		}
+		inventory := `{"boot": {"device_type": "persistent"}}`
+		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, infraEnvId, clusterID, inventory, db)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(common.TestDefaultConfig.ReleaseImage, nil)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
@@ -14661,7 +14682,7 @@ var _ = Describe("Install Host test", func() {
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, infraEnvId, clusterID, inventory, db)
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(nil, fmt.Errorf("failed to find release image"))
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(nil, fmt.Errorf("failed to find release image"))
 
 		res := bm.V2InstallHost(ctx, params)
 		verifyApiError(res, http.StatusInternalServerError)
@@ -14756,7 +14777,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 			eventstest.WithClusterIdMatcher(clusterID.String())))
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(common.TestDefaultConfig.ReleaseImage, nil)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(common.TestDefaultConfig.ReleaseImage, nil)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
@@ -14770,7 +14791,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		addHost(hostId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, infraEnvID, clusterID, inventory, db)
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(nil, fmt.Errorf("failed to find release image"))
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(nil, fmt.Errorf("failed to find release image"))
 
 		Expect(bm.InstallSingleDay2HostInternal(ctx, clusterID, infraEnvID, hostId)).ToNot(Succeed())
 	})
@@ -14791,7 +14812,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 			eventstest.WithClusterIdMatcher(clusterID.String())))
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.TestDefaultConfig.OpenShiftVersion, "x86_64", fakePullSecret).Return(nil, fmt.Errorf("failed to find release image"))
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), "x86_64").Return(nil, fmt.Errorf("failed to find release image"))
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)

--- a/internal/host/hostcommands/container_image_availability_cmd.go
+++ b/internal/host/hostcommands/container_image_availability_cmd.go
@@ -35,12 +35,12 @@ func NewImageAvailabilityCmd(log logrus.FieldLogger, db *gorm.DB, ocRelease oc.R
 
 func (cmd *imageAvailabilityCmd) getImages(ctx context.Context, cluster *common.Cluster) ([]string, error) {
 	images := make([]string, 0)
-	// Use the cluster's OcpReleaseImage field which contains the actual release image URL
+	// Prefer the cluster's OcpReleaseImage field which contains the actual release image URL
 	// (could be from a mirrored registry in disconnected environments via ClusterImageSet)
 	// instead of looking up by version which may return the wrong registry (e.g., upstream quay.io
 	// instead of the configured mirror). This ensures container-image-availability checks use the
 	// correct registry in disconnected environments. See ACM-27906.
-	releaseImage, err := cmd.versionsHandler.GetReleaseImageByURL(ctx, cluster.OcpReleaseImage, cluster.PullSecret)
+	releaseImage, err := cmd.versionsHandler.GetReleaseImageForCluster(ctx, cluster, cluster.CPUArchitecture)
 	if err != nil {
 		return images, err
 	}

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -59,7 +59,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step", func() {
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), cluster.OcpReleaseImage, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 
@@ -79,7 +79,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_release_image_failure", func() {
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), cluster.OcpReleaseImage, gomock.Any()).Return(nil, errors.New("err")).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
 		Expect(err).To(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_mco_failure", func() {
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), cluster.OcpReleaseImage, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
@@ -96,7 +96,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_must_gather_failure", func() {
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), cluster.OcpReleaseImage, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
@@ -133,7 +133,7 @@ var _ = Describe("get images", func() {
 	It("get_step_get_all_images", func() {
 		cluster.OcpReleaseImage = common.TestDefaultConfig.ReleaseImageUrl
 		mco := "image-mco"
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), cluster.OcpReleaseImage, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mco, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		release := common.TestDefaultConfig.ReleaseImageUrl
@@ -161,8 +161,7 @@ var _ = Describe("get images", func() {
 
 		mcoImage := "registry.mirror.example.com:5000/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
 
-		// Expect GetReleaseImageByURL to be called with the cluster's OcpReleaseImage
-		mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), mirroredReleaseImageURL, cluster.PullSecret).Return(mirroredReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), cluster.CPUArchitecture).Return(mirroredReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), mirroredReleaseImageURL, gomock.Any(), cluster.PullSecret).Return(mcoImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret).Return(defaultMustGatherVersion, nil).Times(1)
 

--- a/internal/host/hostcommands/domain_name_resolution_cmd_test.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd_test.go
@@ -52,7 +52,7 @@ var _ = Describe("domainNameResolution", func() {
 	It("happy flow", func() {
 		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, Name: name, BaseDNSDomain: baseDNSDomain}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{URL: swag.String("quay.io/release")}, nil)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{URL: swag.String("quay.io/release")}, nil)
 		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
 		Expect(stepReply).ToNot(BeNil())
 		Expect(stepReply[0].StepType).To(Equal(models.StepTypeDomainResolution))

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -158,7 +158,7 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 	// Get release image for host only if it's either not a day-2 host or it's installing to disk
 	var releaseImage *models.ReleaseImage
 	if installToDisk || !isDay2 {
-		releaseImage, err = i.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cpuArch, cluster.PullSecret)
+		releaseImage, err = i.versionsHandler.GetReleaseImageForCluster(ctx, cluster, cpuArch)
 		if err != nil && !isDay2 {
 			return "", err
 		}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -82,7 +82,7 @@ var _ = Describe("installcmd", func() {
 	})
 
 	mockGetReleaseImage := func(times int) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(times)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(times)
 	}
 
 	mockImages := func(times int) {
@@ -448,7 +448,7 @@ var _ = Describe("installcmd arguments", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).AnyTimes()
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).AnyTimes()
 		mockImages()
 	})
 
@@ -580,7 +580,7 @@ var _ = Describe("installcmd arguments", func() {
 		BeforeEach(func() {
 			noReleaseMock = oc.NewMockRelease(ctrl)
 			noReleaseVersions = versions.NewMockHandler(ctrl)
-			noReleaseVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("release image not found")).AnyTimes()
+			noReleaseVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("release image not found")).AnyTimes()
 
 			var inventory models.Inventory
 			Expect(json.Unmarshal([]byte(host.Inventory), &inventory)).ToNot(HaveOccurred())

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -536,7 +536,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	ExpectWithOffset(1, swag.StringValue(h.Status)).Should(Equal(state))
 	if funk.Contains(expectedStepTypes, models.StepTypeInstall) {
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/disk/by-id/wwn-sda").Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
@@ -553,7 +553,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 
 	if !funk.IsEmpty(funk.Join(expectedStepTypes, []models.StepType{models.StepTypeContainerImageAvailability, models.StepTypeDomainResolution}, funk.InnerJoin)) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImageForCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		if funk.Contains(expectedStepTypes, models.StepTypeContainerImageAvailability) {
 			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		}

--- a/internal/versions/common.go
+++ b/internal/versions/common.go
@@ -24,6 +24,7 @@ import (
 type Handler interface {
 	GetReleaseImage(ctx context.Context, openshiftVersion, cpuArchitecture, pullSecret string) (*models.ReleaseImage, error)
 	GetReleaseImageByURL(ctx context.Context, url, pullSecret string) (*models.ReleaseImage, error)
+	GetReleaseImageForCluster(ctx context.Context, cluster *common.Cluster, cpuArchitecture string) (*models.ReleaseImage, error)
 	GetMustGatherImages(openshiftVersion, cpuArchitecture, pullSecret string) (MustGatherVersion, error)
 	ValidateReleaseImageForRHCOS(rhcosVersion, cpuArch string) error
 }
@@ -197,6 +198,21 @@ func ParseReleaseImages(
 			releaseImage.CPUArchitectures = []string{*releaseImage.CPUArchitecture}
 		}
 	})
+}
+
+// getReleaseImageForCluster returns the release image associated with a cluster.
+// If cluster.OcpReleaseImage is set, the image is resolved by URL so that custom
+// or mirrored release images are used instead of a version/architecture lookup.
+// cpuArchitecture is used only when OcpReleaseImage is empty; if it is also
+// empty, cluster.CPUArchitecture is used.
+func getReleaseImageForCluster(ctx context.Context, h Handler, cluster *common.Cluster, cpuArchitecture string) (*models.ReleaseImage, error) {
+	if cluster.OcpReleaseImage != "" {
+		return h.GetReleaseImageByURL(ctx, cluster.OcpReleaseImage, cluster.PullSecret)
+	}
+	if cpuArchitecture == "" {
+		cpuArchitecture = cluster.CPUArchitecture
+	}
+	return h.GetReleaseImage(ctx, cluster.OpenshiftVersion, cpuArchitecture, cluster.PullSecret)
 }
 
 func normalizeReleaseImageCPUArchitecture(releaseImage *models.ReleaseImage) {

--- a/internal/versions/common_test.go
+++ b/internal/versions/common_test.go
@@ -1,6 +1,7 @@
 package versions
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+	"go.uber.org/mock/gomock"
 )
 
 var _ = Describe("NewHandler", func() {
@@ -192,5 +195,66 @@ var _ = Describe("validateReleaseImageForRHCOS", func() {
 		err := validateReleaseImageForRHCOS(log, "9.9.9-chocobomb", common.PowerCPUArchitecture, releaseImages)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("There are no OCP versions available in release images for arch %s", common.PowerCPUArchitecture)))
+	})
+})
+
+var _ = Describe("getReleaseImageForCluster", func() {
+	var (
+		ctrl         *gomock.Controller
+		mockHandler  *MockHandler
+		ctx          = context.Background()
+		releaseImage *models.ReleaseImage
+		cluster      *common.Cluster
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockHandler = NewMockHandler(ctrl)
+		releaseImage = common.TestDefaultConfig.ReleaseImage
+		cluster = &common.Cluster{
+			PullSecret: "fake-pull-secret",
+			Cluster: models.Cluster{
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+				CPUArchitecture:  common.TestDefaultConfig.CPUArchitecture,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("looks up by URL when OcpReleaseImage is set", func() {
+		cluster.OcpReleaseImage = "registry.mirror.example.com/ocp/release:4.18"
+		mockHandler.EXPECT().GetReleaseImageByURL(ctx, cluster.OcpReleaseImage, cluster.PullSecret).Return(releaseImage, nil).Times(1)
+
+		got, err := getReleaseImageForCluster(ctx, mockHandler, cluster, common.ARM64CPUArchitecture)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(releaseImage))
+	})
+
+	It("looks up by version and architecture when OcpReleaseImage is empty", func() {
+		mockHandler.EXPECT().GetReleaseImage(ctx, cluster.OpenshiftVersion, common.ARM64CPUArchitecture, cluster.PullSecret).Return(releaseImage, nil).Times(1)
+
+		got, err := getReleaseImageForCluster(ctx, mockHandler, cluster, common.ARM64CPUArchitecture)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(releaseImage))
+	})
+
+	It("uses the cluster CPU architecture when none is provided", func() {
+		mockHandler.EXPECT().GetReleaseImage(ctx, cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret).Return(releaseImage, nil).Times(1)
+
+		got, err := getReleaseImageForCluster(ctx, mockHandler, cluster, "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(releaseImage))
+	})
+
+	It("propagates lookup errors", func() {
+		expected := errors.New("release image not found")
+		mockHandler.EXPECT().GetReleaseImage(ctx, cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret).Return(nil, expected).Times(1)
+
+		got, err := getReleaseImageForCluster(ctx, mockHandler, cluster, "")
+		Expect(err).To(MatchError(expected))
+		Expect(got).To(BeNil())
 	})
 })

--- a/internal/versions/kube_api_versions.go
+++ b/internal/versions/kube_api_versions.go
@@ -110,6 +110,10 @@ func (h *kubeAPIVersionsHandler) GetReleaseImageByURL(ctx context.Context, url, 
 	return h.addReleaseImage(url, pullSecret)
 }
 
+func (h *kubeAPIVersionsHandler) GetReleaseImageForCluster(ctx context.Context, cluster *common.Cluster, cpuArchitecture string) (*models.ReleaseImage, error) {
+	return getReleaseImageForCluster(ctx, h, cluster, cpuArchitecture)
+}
+
 // Finds a release image from the cache that matches the specified version and architecture in the following
 // priority:
 // 1. Exact CPU Architecture & OpenShift x.y.z version match
@@ -278,7 +282,7 @@ func extractHost(destination string) string {
 }
 
 func GetReleaseImageHost(cluster *common.Cluster, versionHandler Handler) (string, error) {
-	releaseImage, err := versionHandler.GetReleaseImage(context.Background(), cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
+	releaseImage, err := versionHandler.GetReleaseImageForCluster(context.Background(), cluster, cluster.CPUArchitecture)
 	if err != nil {
 		return "", err
 	}

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -84,6 +85,21 @@ func (m *MockHandler) GetReleaseImageByURL(ctx context.Context, url, pullSecret 
 func (mr *MockHandlerMockRecorder) GetReleaseImageByURL(ctx, url, pullSecret any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImageByURL", reflect.TypeOf((*MockHandler)(nil).GetReleaseImageByURL), ctx, url, pullSecret)
+}
+
+// GetReleaseImageForCluster mocks base method.
+func (m *MockHandler) GetReleaseImageForCluster(ctx context.Context, cluster *common.Cluster, cpuArchitecture string) (*models.ReleaseImage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReleaseImageForCluster", ctx, cluster, cpuArchitecture)
+	ret0, _ := ret[0].(*models.ReleaseImage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReleaseImageForCluster indicates an expected call of GetReleaseImageForCluster.
+func (mr *MockHandlerMockRecorder) GetReleaseImageForCluster(ctx, cluster, cpuArchitecture any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImageForCluster", reflect.TypeOf((*MockHandler)(nil).GetReleaseImageForCluster), ctx, cluster, cpuArchitecture)
 }
 
 // ValidateReleaseImageForRHCOS mocks base method.

--- a/internal/versions/rest_api_versions.go
+++ b/internal/versions/rest_api_versions.go
@@ -101,6 +101,10 @@ func (h *restAPIVersionsHandler) GetReleaseImageByURL(_ context.Context, url, _ 
 	return &releaseImage, nil
 }
 
+func (h *restAPIVersionsHandler) GetReleaseImageForCluster(ctx context.Context, cluster *common.Cluster, cpuArchitecture string) (*models.ReleaseImage, error) {
+	return getReleaseImageForCluster(ctx, h, cluster, cpuArchitecture)
+}
+
 // GetMustGatherImages retrieves the must-gather images for a specified OpenShift version and CPU architecture.
 // If the configuration does not include a must-gather image for the given version and architecture,
 // the function attempts to locate a matching release image. It then uses the 'oc' CLI tool to find and add the corresponding


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

There are currently still a few places that don't check for if OcpReleaseImage is set when getting the release image, instead looking it up via the cluster's openshift version and cpu architecture.
This is an issue if the release image returned from the lookup is different from the one explicitly set in the OcpReleaseImage field.

## List all the issues related to this PR

Closes [MGMT-25131](https://redhat.atlassian.net/browse/MGMT-25131)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release image resolution now supports cluster-specific configuration, including custom release image URLs.
  * When no custom image is configured, release images are selected using the cluster’s OpenShift version and CPU architecture.
  * Host installation and image availability checks now use the resolved cluster release image consistently.
* **Documentation**
  * Clarified that installer image overrides intentionally use the default architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->