### PR TITLE
OCPBUGS-56946: Fix grammar in AgentServiceConfig mirrorRegistryRef CRD description

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -74,7 +74,7 @@ type AgentServiceConfigSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage for images"
 	ImageStorage *corev1.PersistentVolumeClaimSpec `json:"imageStorage"`
 	// MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-	// In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+	// In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
 	// ca-bundle.crt - hold the contents of mirror registry certificate/s
 	// registries.conf - holds the content of registries.conf file configured with mirror registries
 	// +optional

--- a/config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml
@@ -702,7 +702,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:

--- a/config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
@@ -717,7 +717,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -1926,7 +1926,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:
@@ -2768,7 +2768,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:

--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -80,8 +80,8 @@ spec:
         displayName: Assisted Image Service hostname
         path: ingress.imageServiceHostname
       - description: 'MirrorRegistryRef is the reference to the configmap that contains
-          mirror registry configuration In case no configuration is need, this field
-          will be nil. ConfigMap must contain to entries: ca-bundle.crt - hold the
+          mirror registry configuration In case no configuration is needed, this field
+          will be nil. ConfigMap must contain two entries: ca-bundle.crt - hold the
           contents of mirror registry certificate/s registries.conf - holds the content
           of registries.conf file configured with mirror registries'
         displayName: Mirror Registry and Certificate ConfigMap Name

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agentserviceconfigs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agentserviceconfigs.yaml
@@ -702,7 +702,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml
@@ -717,7 +717,7 @@ spec:
               mirrorRegistryRef:
                 description: |-
                   MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
-                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  In case no configuration is needed, this field will be nil. ConfigMap must contain two entries:
                   ca-bundle.crt - hold the contents of mirror registry certificate/s
                   registries.conf - holds the content of registries.conf file configured with mirror registries
                 properties:

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -364,8 +364,8 @@ spec:
         displayName: Assisted Image Service hostname
         path: ingress.imageServiceHostname
       - description: 'MirrorRegistryRef is the reference to the configmap that contains
-          mirror registry configuration In case no configuration is need, this field
-          will be nil. ConfigMap must contain to entries: ca-bundle.crt - hold the
+          mirror registry configuration In case no configuration is needed, this field
+          will be nil. ConfigMap must contain two entries: ca-bundle.crt - hold the
           contents of mirror registry certificate/s registries.conf - holds the content
           of registries.conf file configured with mirror registries'
         displayName: Mirror Registry and Certificate ConfigMap Name


### PR DESCRIPTION
## Summary

Fixes grammar typos in the OpenAPI description for `AgentServiceConfig.spec.mirrorRegistryRef` and propagates the correction to generated CRD and OLM manifest artifacts.

- Jira: https://issues.redhat.com/browse/OCPBUGS-56946
- OCP version: 4.18.z

## Changes

- `need` → `needed`
- `to` → `two` (in "ConfigMap must contain two entries")

**Source edit:** `api/v1beta1/agentserviceconfig_types.go`

**Generated artifacts updated:**
- `config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml`
- `config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml`
- `config/crd/resources.yaml`
- `config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml`
- `deploy/olm-catalog/manifests/*` (3 files)

Because `HypershiftAgentServiceConfigSpec` embeds `AgentServiceConfigSpec`, both CRDs are corrected from the single source comment change.

## Risk

Low — CRD OpenAPI schema description only. No API contract, controller logic, or runtime behavior change.

## Test plan

### Reproduce (before fix)

- [x] Baseline on `release-4.18` contains typos in source comment
- [ ] *(Optional, cluster)* `oc explain agentserviceconfig.spec.mirrorRegistryRef` shows "is need" / "contain to"

### Verify (after fix)

- [x] Source comment corrected in `api/v1beta1/agentserviceconfig_types.go`
- [x] All CRD/CSV/bundle artifacts updated consistently
- [x] Post-fix typo scan: no matches for old strings in `api/`, `config/`, `deploy/`
- [x] Corrected text present in 8 files (9 occurrences including `resources.yaml` x2)
- [ ] CI: `verify-generated-code` (pending on this PR)
- [ ] *(Optional, cluster)* `oc explain agentserviceconfig.spec.mirrorRegistryRef` shows corrected text

## Test results

| # | Test | Command / check | Expected | Result | Notes |
|---|---|---|---|---|---|
| 1 | Pre-fix baseline | `git show release-4.18:api/v1beta1/agentserviceconfig_types.go \| rg "is need\|contain to"` | Typos present | **PASS** | Confirms bug exists on base branch |
| 2 | Post-fix typo scan | `rg "configuration is need, this field\|contain to entries:" api config deploy` (excl. vendor) | 0 matches | **PASS** | No stale typo strings remain |
| 3 | Correct text propagation | `rg -c "configuration is needed, this field" api config deploy` | 8 files / 9 matches | **PASS** | All CRD + CSV + bundle files updated |
| 4 | Diff scope | `git diff release-4.18..HEAD --stat` | 8 files, word-only changes | **PASS** | 11 insertions, 11 deletions |
| 5 | Functional regression | N/A (description-only change) | No logic change | **PASS** | Existing controller tests unchanged |
| 6 | `make generate` parity | Not run locally (Go/spectral unavailable) | Generated files manually synced with source | **N/A** | Awaiting CI `verify-generated-code` |
| 7 | Prow CI | `verify-generated-code` | Green | **PENDING** | Will update after CI completes |

### Sample output — Test 1 (pre-fix baseline)

```
// In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
```

### Sample output — Test 2 (post-fix)

```
PASS: 0 typo matches
```

### Sample output — Test 3 (post-fix correct text in 8 files)

```
api/v1beta1/agentserviceconfig_types.go:1
config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml:1
config/crd/bases/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml:1
config/crd/resources.yaml:2
config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml:1
deploy/olm-catalog/manifests/agent-install.openshift.io_agentserviceconfigs.yaml:1
deploy/olm-catalog/manifests/agent-install.openshift.io_hypershiftagentserviceconfigs.yaml:1
deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml:1
```

## How this was tested

- [x] Manual verification (grep-based checks above)
- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Waiting for CI to do a full test run (`verify-generated-code`, lint, unit)
- [ ] Reviewer's test appreciated
- [x] No unit tests needed (CRD description string only; no behavior change)


Made with [Cursor](https://cursor.com)