### PR TITLE
MGMT-25406: Add OpenShift-compatible CIDR length validation

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -374,6 +374,7 @@ type Networking struct {
 // MachineNetworkEntry is a single IP address block for node IP blocks.
 type MachineNetworkEntry struct {
 	// CIDR is the IP block address pool for machines within the cluster.
+	// +kubebuilder:validation:MaxLength=43
 	CIDR string `json:"cidr"`
 }
 

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -503,6 +503,7 @@ spec:
                         cidr:
                           description: CIDR is the IP block address pool for machines
                             within the cluster.
+                          maxLength: 43
                           type: string
                       required:
                       - cidr
@@ -708,6 +709,7 @@ spec:
                     cidr:
                       description: CIDR is the IP block address pool for machines
                         within the cluster.
+                      maxLength: 43
                       type: string
                   required:
                   - cidr

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -618,6 +618,7 @@ spec:
                         cidr:
                           description: CIDR is the IP block address pool for machines
                             within the cluster.
+                          maxLength: 43
                           type: string
                       required:
                       - cidr
@@ -823,6 +824,7 @@ spec:
                     cidr:
                       description: CIDR is the IP block address pool for machines
                         within the cluster.
+                      maxLength: 43
                       type: string
                   required:
                   - cidr

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -503,6 +503,7 @@ spec:
                         cidr:
                           description: CIDR is the IP block address pool for machines
                             within the cluster.
+                          maxLength: 43
                           type: string
                       required:
                       - cidr
@@ -708,6 +709,7 @@ spec:
                     cidr:
                       description: CIDR is the IP block address pool for machines
                         within the cluster.
+                      maxLength: 43
                       type: string
                   required:
                   - cidr

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -374,6 +374,7 @@ type Networking struct {
 // MachineNetworkEntry is a single IP address block for node IP blocks.
 type MachineNetworkEntry struct {
 	// CIDR is the IP block address pool for machines within the cluster.
+	// +kubebuilder:validation:MaxLength=43
 	CIDR string `json:"cidr"`
 }
 


### PR DESCRIPTION
Constrain hiveext MachineNetworkEntry CIDR values to 43 characters, matching the maxLength used by OpenShift's config/v1.CIDR type and bounding generated CEL cost.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for machine network CIDR values in AgentClusterInstall resources.
  - CIDR values exceeding 43 characters are now rejected in both configuration and status schemas, helping prevent invalid or malformed network settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->